### PR TITLE
Data source layer, Redfish enum spaces, RL fixes, and offline test expansion

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,6 +18,12 @@ backups/
 logs/
 *.log
 checkpoints/
+datasets/*.tar.gz
+datasets/dataset.json
+datasets/tokenizer/tokenizer.json
+test_datasets/
+tests/datasets/
+imgs/
 # submodule (not needed for the offline gate image)
 idrac_ctl/
 # local agent/coordination docs (gitignored already)
@@ -25,5 +31,6 @@ COORDINATION.md
 CLAUDE.md
 AGENTS.md
 FLASH_BRAIN.md
+NV72_MODELS.md
 GPU_ACCESS.md
 .codex/

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ datasets/modules/*
 
 # Local data/model artifacts — never commit.
 datasets/*.tar.gz
+datasets/*.tar.gz.md5
 datasets/dataset.json
 datasets/tokenizer/tokenizer.json
 test_datasets/

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,14 @@ datasets/orig/*
 datasets/raw/*
 datasets/original/*
 datasets/modules/*
+
+# Local data/model artifacts — never commit.
+datasets/*.tar.gz
+datasets/dataset.json
+datasets/tokenizer/tokenizer.json
+test_datasets/
+tests/datasets/
+imgs/
 # C extensions
 *.so
 .idea
@@ -171,6 +179,7 @@ CODEX_*.md
 TEAM_GUIDE.md
 COORDINATION.md
 FLASH_BRAIN.md
+NV72_MODELS.md
 GPU_ACCESS.md
 IMPROVEMENT_PLAN.md
 ROADMAP*.md

--- a/accelerate_train.sh
+++ b/accelerate_train.sh
@@ -8,6 +8,5 @@ CUDA_VISIBLE_DEVICES=0,1 accelerate launch --config_file ./config.yaml igc_main.
 #
 #python -m torch.distributed.launch --help
 
-
 accelerate launch --config_file ./configs/config.yaml trainer_state_encoder_only.py --train llm --num_train_epochs 1000 --use_accelerator \
 	--llm latent --llm_log_level info --log_level info --device_map auto

--- a/docs/MATH_CHECKS.md
+++ b/docs/MATH_CHECKS.md
@@ -1,0 +1,181 @@
+# Math checks and optimization gate
+
+This document is the math gate for `igc`. It records the equations, tensor contracts, and numerical
+checks that must be true before a training curve, RL metric, or optimization result is treated as
+evidence. It is deliberately smaller than the full architecture: the job here is to reject bad minima
+and invalid objectives early.
+
+## Status
+
+Current status: **REVISE**.
+
+The direction is sound: move from raw JSON text embeddings and one-hot URL/method actions toward a
+structured Redfish state, legal `ToolAction` candidates, evaluator rewards, and replay-ready
+transitions. The current DQN/HER path is not yet a trustworthy learning baseline.
+
+Do not report the legacy RL trainer as solving a workload until the checks below are green.
+
+## Current blockers
+
+| Area | Current issue | Required checkout |
+| --- | --- | --- |
+| Replay tuple | `igc/modules/igc_experience_buffer.py` stores `(state, action, reward, next_state)` only. | Replay must carry `terminated`, `truncated`, desired goal, achieved goal, and enough action metadata to recompute targets. |
+| Bellman target | `igc/modules/igc_train_agent.py` bootstraps from every sampled next state and clips targets with an upper bound of `0`. | Terminal transitions must not bootstrap; success targets must remain positive when reward is positive. |
+| HER relabeling | Relabeling uses the final pre-action state, not a future achieved next state. | Relabeled goals must come from future achieved observations or an evaluator-produced `achieved_goal`. |
+| Done semantics | Success, timeout, 4xx, and 5xx currently mix `done`, `terminated`, and `truncated`. | Define a single terminal/truncated table and test every branch. |
+| Goal reward | Current checks use tensor equality or `allclose` over embeddings. | `Evaluator.verify(goal, obs)` must compute success and dense reward over structured state. |
+| Legal actions | Current envs expose continuous one-hot `Box(num_urls + methods)`. | `ToolCatalog.available_actions(obs)` must mask illegal actions before selection. |
+| Argument values | `igc/core/action_render.py` intentionally renders action templates without concrete values. | A second-stage argument/effect path must distinguish value choices before mutating actions are trusted. |
+
+## Math contract
+
+### Transition and replay record
+
+The replay record used for RL and HER should contain at least:
+
+```text
+(obs_t, action_t, reward_t, obs_tp1, terminated_t, truncated_t,
+ desired_goal_t, achieved_goal_tp1, info_t)
+```
+
+The env step result may be a smaller runtime object, but replay cannot lose the fields needed to
+recompute targets and relabel rewards.
+
+### Bellman target
+
+For a DQN-style update, the target must be:
+
+```text
+y_t = r_t + gamma * (1 - terminal_t) * max_a' Q_target(s_{t+1}, a')
+```
+
+where:
+
+- `terminal_t` is true for task completion or unrecoverable failure.
+- `truncated_t` is a time/resource cutoff and should be handled explicitly, not silently treated as
+  either success or failure.
+- The clipping range, if any, must not remove positive success rewards.
+
+Minimum checkout: a one-state terminal success fixture must produce target `+1` when `reward_t = 1`
+and `terminal_t = true`.
+
+### HER relabeling
+
+For hindsight experience replay, the relabeled goal must be a future achieved goal:
+
+```text
+g' in {achieved_goal_{t+1}, ..., achieved_goal_T}
+r'_t = Evaluator.reward(obs_{t+1}, g')
+```
+
+Invalid checkout: using `obs_t` or the final pre-action state as `g'` without proving it is an
+achieved goal.
+
+### Candidate-action scoring
+
+The pointer policy scores only legal candidates:
+
+```text
+q = f_state(obs, goal)
+k_i = f_action(candidate_i)
+Q(obs, candidate_i) = q dot k_i
+```
+
+The candidate list must come from `ToolCatalog.available_actions(obs)`. Padding is masked to
+`-inf`. The score chooses an action template; concrete argument values require a separate checked
+stage before execution.
+
+### State compression
+
+The first compact state target is `RedfishStateV0`, a JSON-serializable structured payload under
+`Observation.structured`. Learned graph pooling, bottlenecks, or latent compression wait until
+these invariants are fixture-tested:
+
+- two observations that differ only in pending settings or task phase must not collapse;
+- collection order changes must not change the state;
+- one unhealthy or missing component must change the state;
+- failed, stale, unknown, and fresh observations must be distinguishable;
+- legal action masks must be reproducible from the state.
+
+## Optimization checks
+
+Every trainable objective gets this checkout before longer runs:
+
+1. **Shape proof:** list input/output tensor shapes and assert them in a small test.
+2. **Boundary cases:** empty candidates, one candidate, terminal transition, timeout transition,
+   invalid method, missing telemetry, and NaN/Inf inputs.
+3. **Finite loss:** loss is finite for a tiny deterministic batch.
+4. **Finite gradients:** all trainable parameters have finite gradients after one backward pass.
+5. **Overfit smoke:** a tiny fixture can overfit or reduce loss in a bounded number of steps.
+6. **Metric meaning:** the metric must correspond to the objective being optimized.
+
+```mermaid
+flowchart LR
+    Contract["Math contract\nsymbols + shapes + domains"]
+    Counter["Counterexamples\nterminal, timeout, missing data"]
+    Unit["Offline unit tests\nfixture-level invariants"]
+    Numeric["Numerical smoke\nfinite loss + finite gradients"]
+    Claim["Training claim\nallowed only with exact command + metric"]
+
+    Contract --> Counter --> Unit --> Numeric --> Claim
+```
+
+## Model-specific checkout table
+
+| Stage | Objective | Required math checkout |
+| --- | --- | --- |
+| M1 backbone | language-model loss over Redfish text | tokenization mask, loss finite, small batch overfit, no hidden-size assumptions. |
+| M2 state pooler | pooled state reconstruction or auxiliary prediction | shape contract, no `seq_len * hidden_size` decoder blowup, finite gradients. |
+| M3 planner | instruction to sub-goal plan | plan validity metric, topological order, precondition satisfaction. |
+| M4 evaluator/reward | structured success and dense reward | reward table for success/failure/progress/no-op; no embedding equality as final verifier. |
+| M5 world model | next state/status/task phase | one-step prediction target, terminal-state handling, rollout drift metric. |
+| M6 RL policy | candidate-action Q-learning with HER | terminal mask, legal-action mask, HER achieved-goal relabel, target sanity. |
+
+## Local tool policy
+
+Default math checks must run offline in the CPU `igc-dev` environment from `environment-dev.yaml`.
+Use:
+
+```bash
+KMP_DUPLICATE_LIB_OK=TRUE \
+OMP_NUM_THREADS=1 \
+TRANSFORMERS_OFFLINE=1 \
+HF_DATASETS_OFFLINE=1 \
+conda run -n igc-dev python -m pytest -q <math/test node ids>
+```
+
+Allowed local tools:
+
+- Python standard library for exact fixtures and shape checks.
+- NumPy, SciPy, SymPy, scikit-learn, and PyTorch in `igc-dev`.
+- MATLAB, Octave, or Wolfram tools only when installed and activated locally; they are optional and
+  must not be required by the default gate.
+
+Network, GPU, live Redfish hosts, private endpoints, and captured payloads are not required for this
+math gate.
+
+## Next math tests to queue
+
+1. Replay stores and samples `terminated`/`truncated` masks.
+2. Bellman terminal-success target remains positive and does not bootstrap.
+3. HER relabeling uses future `achieved_goal` and recomputes evaluator reward.
+4. Vector env keeps per-env terminal/truncated state without shrinking batch observations.
+5. `ToolCatalog.available_actions(obs)` masks illegal methods before selection.
+6. `RedfishStateV0` extractor distinguishes pending settings/task phase from already-applied state.
+7. Candidate scoring handles empty, one, and padded candidate sets.
+8. One-step optimizer smoke verifies finite loss and gradients on the smallest deterministic batch.
+
+## Claim rule
+
+A math or optimization claim is acceptable only when it includes one of:
+
+- a proof sketch that states assumptions and boundary cases;
+- a deterministic counterexample showing what fails;
+- exact offline command output from a small numerical check;
+- an explicit blocker explaining the missing tool, fixture, or decision.
+
+If none of those exist, the correct status is:
+
+```text
+BLOCKED: missing math evidence
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,8 @@ Reinforce Learner).
 
 - [ENVIRONMENT.md](ENVIRONMENT.md) — the local CPU setup, current offline smoke gate, Docker test
   image, and GB300 NVL72 training surface.
+- [TRAINING.md](TRAINING.md) — the reproducible GPU training runbook: secret handling, data staging,
+  launch, experiment tracking, checkpoints, and reporting evidence.
 - [ARCHITECTURE.md](ARCHITECTURE.md) — the generic goal-conditioned tool-use framework design,
   simulator plugin plan, hierarchical workload model, model curriculum, backbone modernization, and
   Phase 0 stabilization notes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,10 @@ Reinforce Learner).
 - [ARCHITECTURE.md](ARCHITECTURE.md) — the generic goal-conditioned tool-use framework design,
   simulator plugin plan, hierarchical workload model, model curriculum, backbone modernization, and
   Phase 0 stabilization notes.
+- [MATH_CHECKS.md](MATH_CHECKS.md) — the math and optimization gate for Bellman targets, HER,
+  replay masks, tensor shapes, finite-gradient checks, and trustworthy training claims.
+- [TRAINING_OPTIMIZATION_PLAN.md](TRAINING_OPTIMIZATION_PLAN.md) — the large-model training,
+  optimization, and GPU-efficiency roadmap for 3B/7B state-encoder work.
 
 The repository [README](../README.md) stays short and tutorial-oriented. Put deeper design and runtime
 material in this directory so setup instructions and architecture details do not drift apart.

--- a/docs/REDFISH_ENUM_SPACES.md
+++ b/docs/REDFISH_ENUM_SPACES.md
@@ -1,0 +1,103 @@
+# Redfish Enum Spaces — Offline Ingestion of BIOS / Boot / ActionInfo Value Spaces
+
+Design note for `igc/ds/sources/redfish_enum_space.py`, the extraction layer that turns
+the richer resource types captured by `redfish_ctl` discovery (the data-collection tool
+that writes per-resource JSON under `~/.json_responses/<host>/`) into the per-slot
+argument value spaces consumed by the stage-2 argument decoder
+(`igc/modules/policy/argument_decoder.py`).
+
+## Motivation
+
+Stage 1 of the policy (the pointer policy) selects a value-independent action template;
+stage 2 fills argument values. For a categorical argument, the decoder scores the slot's
+OWN allowable values, read from `ToolSpec.arg_schema[op][slot]["enum"]` — so the head
+width tracks one slot's choice count and never a global vocabulary. Until now those enum
+spaces existed only as hand-written schemas in tests. The captured corpora already
+contain the real value spaces; this layer extracts them offline.
+
+## What discovery captures vs. what was ingested
+
+`redfish_ctl` (>= 1.1.3) discovery preserves the `idrac_ctl` output contract — one JSON
+file per resource plus `rest_api_map.npy` holding `url_file_mapping` and
+`allowed_methods_mapping` (the binding `.npy` contract loaded by
+`igc/ds/ds_rest_trajectories.py`, unchanged by this work). The generic adapter
+`RedfishFixtureSource` (in `igc/ds/sources/redfish_fixture_source.py`) already streams
+every captured body as a provenance-tagged `SourceRecord`; what was missing is semantic
+extraction of the value spaces inside these resource types:
+
+| Resource type (`@odata.type`) | Where captured | Value space it carries |
+| --- | --- | --- |
+| `#AttributeRegistry` (e.g. Dell `Bios/BiosRegistry`, the `BiosAttributeRegistry` under `/redfish/v1/Registries`) | Dell + Supermicro corpora | Per-BIOS-attribute type, `ReadOnly` flag, and — for `Enumeration` attributes — the `Value[].ValueName` choice list (e.g. 360 attributes / 78 enumerations on the Supermicro GB300 target) |
+| `#Bios` (`Attributes` dict + `@Redfish.Settings` pointer) | all vendors | Current attribute values; the `.../Bios/Settings` child is the pending-settings resource (`bios-pending` in `redfish_ctl` terms) |
+| `#ActionInfo` (`Parameters[].AllowableValues`) | referenced via `@Redfish.ActionInfo` from `Actions` blocks | Authoritative per-action parameter names, `Required`, `DataType`, allowable values |
+| Inline `<prop>@Redfish.AllowableValues` annotations | `Boot` and `Actions` blocks of `#ComputerSystem`, all vendors | Lightweight vendor alternative to ActionInfo (e.g. `BootSourceOverrideTarget`, `ResetType`) |
+| `#BootOption` / `#BootOptionCollection` | Dell, Supermicro, HPE (iLO) | `BootOptionReference` ids — the value space bounding a `Boot.BootOrder` write |
+| `#MessageRegistryFile` | HPE (iLO) | A registry *pointer*: `Location[].Uri` names an external payload; carries no entries itself |
+
+## Ingestion path (offline, fixture-driven)
+
+Reuse over duplication: the layer does **not** walk the filesystem. It consumes the
+existing `SourceRecord` stream, so the trust tagging, URL canonicalization
+(`@odata.id`-first), and skip accounting of `RedfishFixtureSource` apply unchanged, and
+any future adapter (DMTF mockup replay, emulator) feeds it for free.
+
+```
+RedfishFixtureSource(capture dir)          # existing generic adapter
+        │  SourceRecord stream (trust-ordered: real first)
+        ▼
+EnumSpaceIndex.from_records(...)           # igc/ds/sources/redfish_enum_space.py
+        │  classify_resource() by @odata.type, URL fallback
+        ├── #AttributeRegistry  → slots_from_attribute_registry()  → registry_slots
+        ├── #ActionInfo         → slots_from_action_info()          → action_slots
+        ├── #BootOption         → BootOptionReference               → boot_references
+        ├── #MessageRegistryFile→ counted (payload is external)
+        └── every body          → slots_from_inline_annotations()   → inline action / settings slots
+        ▼
+index.patch_arg_schema()  →  {"PATCH": {attr:  {"type", "enum", "required"}}}
+index.post_arg_schema()   →  {"POST":  {param: {"type", "enum", "required"}}}
+index.boot_reference_space()  →  ordered BootOptionReference ids
+```
+
+The exported fragments are exactly what `arg_slots_for` in the argument decoder reads
+(pinned by a round-trip test through a real `ToolSpec`). For the dataset side,
+`normalize_enriched()` wraps the existing `normalize_record()` (in
+`igc/ds/sources/training_object.py`) and stamps
+`expected_semantics["resource_kind"]`, so BIOS/boot/registry observations become
+distinguishable `TrainingExample` records without re-parsing bodies.
+
+## Precedence and dedup rules
+
+* **First-seen wins** per slot name inside each bucket — same convention as `SourceMix`
+  dedup, so callers feed higher-trust records first.
+* **ActionInfo beats inline annotations** on a parameter name clash regardless of stream
+  order: DMTF makes `#ActionInfo` the authoritative parameter description; inline
+  `Actions` annotations are the fallback tier.
+* **Read-only registry attributes never enter the PATCH schema** — a settings write
+  cannot carry them.
+* Registry pointers (`#MessageRegistryFile`) contribute no slots; they are counted in
+  `num_registry_pointers` so a corpus report can say how many registries live outside
+  the capture.
+
+## Validation on real corpora
+
+Running the index over the three vendor fixture corpora
+(`idrac_ctl/tests/{idrac,supermicro,hpe}_fixtures`) plus one live HPE capture tree
+(2,030 records, zero parse skips) yields 380 patchable slots — 97 of them categorical
+with real enum spaces (e.g. `ProcCStates`, `BootMode`) — 9 action parameters
+(`ResetType` with the full DMTF reset set, Dell OEM job parameters, SecureBoot /
+storage-initialize parameters), 24 boot references across vendor naming styles, and 17
+external registry pointers.
+
+## Deliberately out of scope / follow-ups
+
+* **No live crawl.** Everything here reads captured JSON. Live capture of missing
+  pieces (below) stays gated on an approved non-production host.
+* **ActionInfo bodies are not yet in the captures**: discovery does not follow
+  `@Redfish.ActionInfo` references, so no `#ActionInfo` body exists in any current tree
+  (only its JSON Schema). The extractor is built and tested against the DMTF shape; a
+  `redfish_ctl`-side enhancement to follow those references would light it up on real
+  data.
+* **HPE registry payloads are external** (`Location[].Uri` under a registry store);
+  ingesting them needs either a targeted capture of those URIs or the vendor tree they
+  ship in.
+* The `.npy` contract and the `idrac_ctl` submodule are untouched.

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -1,8 +1,9 @@
 # Training & reproducibility
 
 How to reproduce an igc training run end to end: environment, data, launch, experiment
-tracking (Weights & Biases), checkpoints, and weight sharing. Cluster topology and the
-hard cautions live in `GPU_ACCESS.md`; environment setup in [ENVIRONMENT.md](ENVIRONMENT.md).
+tracking (Weights & Biases), checkpoints, and weight sharing. Cluster topology and hard
+cautions live in the private cluster runbook; environment setup is in
+[ENVIRONMENT.md](ENVIRONMENT.md).
 
 ## 0. Secrets (read first)
 
@@ -38,7 +39,7 @@ cluster login node alongside the checkout — it is not in git). If a key has be
 Training reads captured Redfish JSON from `~/.json_responses` (collected by `idrac_ctl`; the
 `.npy` map is the binding contract). There is **no shared filesystem** on the cluster, so stage the
 data (and the igc checkout) onto the target node's local NVMe, and pin the job to that node with
-`-w gb300-poc1-slotN`.
+the scheduler's node-selection flag.
 
 ## 3. Experiment tracking (Weights & Biases)
 
@@ -68,10 +69,14 @@ squeue --me ; tail -f igc-m1-*.out                              # watch
 ```
 
 [scripts/train_m1.sbatch](../scripts/train_m1.sbatch) runs `igc_main.py --train llm --llm latent`
-on 1 GPU with `NCCL_NVLS_ENABLE=0` and slots 2/15/16 excluded. **Start with the `gpt2` smoke** before
-spending a large model's time — it surfaces any remaining launch issues cheaply. A *large* model on
-one GPU needs LoRA — set `IGC_USE_PEFT=1` (LoRA via HF PEFT); full fine-tune is for the small
-validation model only.
+on 1 GPU with conservative fabric settings and unavailable nodes excluded by the launcher. **Start
+with the `gpt2` smoke** before spending a large model's time — it surfaces any remaining launch
+issues cheaply. A *large* model on one GPU needs LoRA — set `IGC_USE_PEFT=1` (LoRA via HF PEFT);
+full fine-tune is for the small validation model only.
+
+The code-improvement and GPU-efficiency roadmap for 3B/7B state-encoder training lives in
+[TRAINING_OPTIMIZATION_PLAN.md](TRAINING_OPTIMIZATION_PLAN.md). Keep this page as the runnable launch
+guide; put deeper optimization decisions in that roadmap.
 
 Knobs (env): `IGC_MODEL`, `EPOCHS`, `SEED`, `IGC_USE_PEFT` (+`LORA_R`/`LORA_ALPHA`), `IGC_DIR`, `DATA_DIR`, `NGC_IMAGE`, `IGC_REPORT`,
 `WANDB_PROJECT`, `WANDB_NAME`.

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -55,9 +55,49 @@ You will see the usual training-loop curves in the wandb run: training/val **los
 token **accuracy**, **grad-norm**, **learning rate**, tokens/sec, and GPU memory. For the RL agent
 (later phases) the same logger reports reward, success-rate, and episode length.
 
-To use TensorBoard instead: `IGC_REPORT=tensorboard sbatch scripts/train_m1.sbatch`.
+To use TensorBoard instead, choose the variable for the launcher you are using:
+`IGC_METRIC_REPORT=tensorboard bash scripts/run_profile.sh` for the profile wrapper, or
+`IGC_REPORT=tensorboard sbatch scripts/train_m1.sbatch` for the sbatch smoke path.
 
 ## 4. Launch (first GPU loop — M1 state encoder)
+
+There are two launch routes today:
+
+- `scripts/train_m1.sbatch`, the Slurm smoke launcher, is the normal scheduled GPU path.
+- `scripts/run_profile.sh`, the profile-backed wrapper, is for direct named-profile execution.
+
+The profile registry, defined in `igc/modules/train/profiles.py`, is the committed source of truth
+for named M1 state-encoder runs. Inspect a profile locally before spending GPU time:
+
+```bash
+python -m igc.modules.train.launch --profile m1_gpt2_smoke
+python -m igc.modules.train.launch --profile m1_7b_rslora_r32 --print-argv
+```
+
+The smoke argv should include `--model_type gpt2` and `--max_train_steps 50`; the rsLoRA argv should
+include `--adapter_method rslora`, `--lora_r 32`, and `--lora_alpha 64`.
+
+The `scripts/run_profile.sh` wrapper, committed as the profile-name launcher, resolves `IGC_PROFILE`
+through `igc.modules.train.launch`, then supplies `--json_data_dir`, `--output_dir`, and
+`--metric_report` from `IGC_DATA_DIR`, `IGC_OUTPUT_DIR`, and `IGC_METRIC_REPORT`:
+
+```bash
+IGC_PROFILE=m1_gpt2_smoke \
+IGC_DATA_DIR=$HOME/.json_responses \
+IGC_OUTPUT_DIR=experiments/m1_gpt2_smoke \
+bash scripts/run_profile.sh
+```
+
+Use `IGC_SET`, read by `scripts/run_profile.sh` as profile-field overrides, for small controlled
+changes such as a shorter smoke or batch-size check:
+
+```bash
+IGC_PROFILE=m1_3b_lora IGC_SET="batch_size=16 lr=2e-4" bash scripts/run_profile.sh
+```
+
+`scripts/run_profile.sh` is the profile-backed local launcher. `scripts/train_m1.sbatch`, the older
+Slurm smoke launcher, does not read `IGC_PROFILE`; it still uses `IGC_MODEL`, `EPOCHS`, and
+`IGC_USE_PEFT`.
 
 ```bash
 # on a GB300 login node, with $HOME/igc and $HOME/.json_responses staged on the node
@@ -73,8 +113,8 @@ spending a large model's time — it surfaces any remaining launch issues cheapl
 one GPU needs LoRA — set `IGC_USE_PEFT=1` (LoRA via HF PEFT); full fine-tune is for the small
 validation model only.
 
-Knobs (env): `IGC_MODEL`, `EPOCHS`, `SEED`, `IGC_USE_PEFT` (+`LORA_R`/`LORA_ALPHA`), `IGC_DIR`, `DATA_DIR`, `NGC_IMAGE`, `IGC_REPORT`,
-`WANDB_PROJECT`, `WANDB_NAME`.
+Knobs (env): `IGC_MODEL`, `EPOCHS`, `SEED`, `IGC_USE_PEFT` (+`LORA_R`/`LORA_ALPHA`), `IGC_DIR`,
+`DATA_DIR`, `NGC_IMAGE`, `IGC_REPORT`, `WANDB_PROJECT`, `WANDB_NAME`.
 
 ## 5. Checkpoints & weight sharing
 
@@ -97,6 +137,11 @@ other supported distribution path for published artifacts.
 
 - The exact parameters of every run are dumped to `parameters.json` (via `save_spec`) alongside the
   checkpoints — keep it with the weights.
+- `RunManifest`, `ResultBundle`, and `compare`, defined in `igc/modules/train/report.py`, are the
+  library contract for adapter comparisons, not automatic launcher output. Until a reporting command
+  exists, the eval/reporting caller creates each `ResultBundle` after metrics are computed, writes
+  `report.json` next to the checkpoint artifacts, and compares bundles across LoRA, rsLoRA, and
+  full-fine-tune arms.
 - `--seed` (default 42) is recorded; set it explicitly for a reproducible run.
 - Report results with evidence: the exact command, the logged metric (wandb run URL), and where the
   checkpoint landed — never paste secrets or raw auth responses.

--- a/docs/TRAINING_OPTIMIZATION_PLAN.md
+++ b/docs/TRAINING_OPTIMIZATION_PLAN.md
@@ -1,0 +1,400 @@
+# Training Optimization Plan
+
+This plan keeps the large-model training path from inheriting old GPT-2 and
+small-GPU assumptions. It is a code-improvement roadmap for M1 state-encoder
+training, GPU efficiency, Redfish data variation, simulator-backed data
+generation, and the evaluation gates needed before claiming that a 3B or 7B
+backbone is better.
+
+The plan is public-safe by design. Operational secrets, live endpoints, raw
+captures, credentials, private node details, and local runbooks stay outside the
+repository.
+
+## Purpose
+
+The M1 state encoder is the first large-model training loop in `igc`. Its job is
+to learn a compact representation of Redfish resource state, action availability,
+and transition-relevant fields. That goal needs a modern large-model path, not
+defaults carried over from a GPT-2 smoke test.
+
+The intended progression is:
+
+1. prove the training and data path with a tiny model on CPU or one GPU;
+2. run a GPT-2 smoke job to catch launch and logging failures cheaply;
+3. compare 3B LoRA and 7B LoRA on the same fixture/eval split;
+4. try full fine-tuning only when LoRA underfits trusted metrics;
+5. scale out across NVL72 for controlled ablations, not one large fragile run.
+
+## Current Limitations
+
+These are the current improvement targets. Some are already configurable, but
+the defaults and launchers do not yet make a safe large-model profile obvious.
+
+| Area | Limitation | Risk |
+| --- | --- | --- |
+| Accelerator path | `--use_accelerator` is opt-in while large-model sharding and mixed precision need it. | A 7B run may silently use the plain one-device path. |
+| Launch scripts | Older scripts still encode stale trainer names, fixed epoch counts, or local assumptions. | Operators may run an obsolete path and misread the result. |
+| Scheduler | The parser exposes warmup-like knobs, but selected PyTorch scheduler constructors only consume matching argument names. | A run can appear to use warmup or max-step control while the scheduler ignores it. |
+| Precision | fp16 is still the legacy default in parts of the parser surface. | GB300 large-model training should start with bf16 unless a measured reason says otherwise. |
+| Gradient accumulation | Accumulation is configured, but the trainer loop should enforce it explicitly around backward/step. | Effective batch size and learning-rate schedule can differ from the run spec. |
+| Gradient clipping | The current logging path can compute grad norm without applying the parsed clipping limit. | Large-model runs lose a basic stability guardrail. |
+| Cache handling | Clearing the CUDA cache inside the hot loop hurts throughput. | Step time is inflated and memory behavior becomes harder to interpret. |
+| Profiles | There is no single profile table for smoke, 3B LoRA, 7B LoRA, and full fine-tune controls. | Old small-model defaults become the practical ceiling. |
+
+## Target Training Profiles
+
+The following profile names are planned training-profile concepts. They should
+become explicit config or launcher presets before routine 3B/7B training.
+
+| Profile | Purpose | Backbone | Adaptation | First-use gate |
+| --- | --- | --- | --- | --- |
+| `m1_gpt2_smoke` | Validate launch, labels, logging, checkpoint write, and data loading cheaply. | GPT-2 class | Full fine-tune is acceptable. | One short run with finite loss and checkpoint output. |
+| `m1_3b_lora` | Fast serious baseline for Redfish representation. | 3B dense decoder | LoRA, bf16 | Held-out loss and structural metrics better than smoke baseline. |
+| `m1_7b_lora` | Default target for the state encoder. | 7B/8B dense decoder | LoRA, bf16 | Beats 3B on held-out structure/action/state metrics within a reasonable cost budget. |
+| `m1_3b_full` | Controlled full fine-tune comparison. | 3B dense decoder | Full fine-tune, bf16 | Runs only after LoRA metrics and data splits are stable. |
+| `m1_7b_full_zero3` | Higher-ceiling experiment when LoRA underfits. | 7B/8B dense decoder | Full fine-tune with ZeRO-3/FSDP | Requires measured LoRA underfit and a successful smaller full-FT control. |
+
+Planned profile knobs:
+
+| Knob | Meaning |
+| --- | --- |
+| `IGC_PROFILE` | Named training profile selected by the launcher. |
+| `IGC_MODEL` | Hugging Face model id or local model path. |
+| `IGC_USE_PEFT` | Enables PEFT/LoRA for large-backbone adaptation. |
+| `IGC_PRECISION` | Compute precision such as `bf16`; fp8 remains opt-in after bf16 is green. |
+| `IGC_TORCH_DTYPE` | Model load dtype, expected to be `bfloat16` for large models. |
+| `BATCH_SIZE` | Per-device train batch size. |
+| `GRAD_ACCUM` | Gradient accumulation steps. |
+| `LR` | Optimizer learning rate. |
+| `SCHEDULER` | Scheduler family, preferably one with explicit warmup semantics. |
+| `WARMUP_RATIO` | Warmup fraction derived into warmup steps after dataloader sizing. |
+| `MAX_STEPS` | Hard step cap for smoke and comparison runs. |
+| `SHARDING` | `none`, `zero3`, or `fsdp` style model/optimizer sharding. |
+| `LORA_R` | LoRA rank. |
+| `LORA_ALPHA` | LoRA scaling. |
+| `ADAPTER_METHOD` | Planned adapter family, for example `lora`, `rslora`, `dora`, `pissa`, `eva`, or `corda`. |
+| `LORA_INIT` | Planned LoRA-family initialization, for example default, PiSSA, EVA, or CorDA. |
+
+## Adapter Strategy
+
+Plain LoRA is the baseline control, not the end of the search. The first 7B
+run should use the simplest stable adapter so the data path, labels, metrics,
+and launcher are debuggable. After that, adapter variants are a high-value
+NVL72 ablation axis.
+
+| Method | Planned role | Why it matters | Gate before adoption |
+| --- | --- | --- | --- |
+| LoRA | Baseline adapter for 3B/7B. | Simple, widely supported, cheap, and easy to compare. | Must beat GPT-2 smoke and produce stable held-out metrics. |
+| rsLoRA | Default candidate for higher-rank sweeps. | Rank-stabilized scaling can make larger ranks less fragile. | Compare rank 16/32/64 against plain LoRA at equal data and steps. |
+| DoRA | Higher-quality adapter candidate. | Decomposes magnitude and direction, often improving adaptation at extra memory/runtime cost. | Use after LoRA/rsLoRA baseline; require memory and tokens/sec report. |
+| PiSSA | Weight-SVD initialization experiment. | Can start adapters closer to useful subspaces than random/default LoRA init. | Run as an initializer ablation, not a new training objective. |
+| EVA | Activation/data-driven initialization experiment. | Uses representative activations, so it may fit Redfish structure sooner. | Requires a fixed calibration dataloader and manifest. |
+| CorDA | Context-oriented initialization experiment. | Useful when preserving base knowledge while adapting to a target context matters. | Requires clear mode/config choice and a held-out generalization check. |
+
+The recommended ablation order is:
+
+```text
+LoRA rank 16 -> rsLoRA rank 32/64 -> DoRA -> PiSSA/EVA/CorDA initializers
+```
+
+Keep the comparison fair: same backbone, same tokenizer, same train/eval split,
+same max optimizer steps, same sequence length, and the same metrics. Do not
+promote an adapter from training loss alone.
+
+The first serious 7B adapter candidate should be rsLoRA over all major decoder
+linear projections:
+
+```python
+from peft import LoraConfig, TaskType
+
+lora_config = LoraConfig(
+    task_type=TaskType.CAUSAL_LM,
+    r=32,
+    lora_alpha=64,
+    lora_dropout=0.05,
+    target_modules=[
+        "q_proj", "k_proj", "v_proj", "o_proj",
+        "gate_proj", "up_proj", "down_proj",
+    ],
+    bias="none",
+    use_rslora=True,
+    init_lora_weights=True,
+)
+```
+
+Use this as the `m1_7b_rslora_r32` candidate after the plain LoRA control is
+green. For a PiSSA run, keep the same rank/targets and change only the
+initializer, for example `init_lora_weights="pissa_niter_16"` if the installed
+PEFT version supports that initializer.
+
+The concrete state-encoder ablation should be:
+
+| Arm | Configuration | Purpose |
+| --- | --- | --- |
+| A | Frozen base + projection/pooling head only | Measures how much structure the pretrained backbone already exposes without adapting transformer weights. |
+| B | LoRA, `r=16` and `r=32`, all linear decoder layers | Baseline PEFT adaptation across attention and MLP projections. |
+| C | rsLoRA, `r=32` and `r=64` | Tests whether rank-stabilized scaling improves higher-rank adapters. |
+| D | DoRA, `r=16` and `r=32` | Tests quality gain from magnitude/direction decomposition against extra memory/runtime cost. |
+| E | PiSSA-LoRA or EVA-LoRA, `r=16` and `r=32` | Tests whether weight-SVD or activation-driven initialization improves sample efficiency. |
+| F | QLoRA + PiSSA/LoftQ | Only for memory-constrained runs; do not make this the default when bf16 LoRA fits. |
+
+Each arm must produce the same result bundle: resolved profile, model id, adapter
+method, adapter rank, initialization method, data manifest, eval split, max
+optimizer steps, sequence length, tokens/sec, peak memory, and metric table.
+
+## Code Improvement Roadmap
+
+1. **Make profiles explicit.**
+   Add one source of truth for training profiles and make launchers print the
+   resolved profile before training starts. Profile resolution should record the
+   final model id, dtype, batch size, accumulation, scheduler, max steps, LoRA
+   settings, and sharding mode.
+
+2. **Clean up parser and config semantics.**
+   Make large-model defaults conservative: bf16 first, accelerator explicit,
+   LoRA opt-in for large backbones, and full fine-tune treated as an experiment.
+   Rename or document any scheduler knob that is not consumed by the selected
+   scheduler.
+
+3. **Fix trainer-loop mechanics.**
+   Enforce gradient accumulation, clip with `max_grad_norm`, step the scheduler
+   only when the optimizer steps, honor `max_train_steps`, and avoid per-step
+   CUDA cache clearing. Keep the corrected causal-LM label path as the only
+   state-encoder training path.
+
+4. **Modernize scheduler and optimizer setup.**
+   Prefer explicit warmup plus cosine or constant-with-warmup schedules for 3B
+   and 7B runs. Compute total optimizer steps from dataloader size, epochs,
+   accumulation, and max-step caps, then pass exact scheduler arguments.
+
+5. **Make precision and sharding visible.**
+   Load large backbones with bf16 dtype, report accelerator mixed precision,
+   and require ZeRO/FSDP only for full fine-tune or memory pressure. LoRA 7B
+   should first prove itself on one GPU.
+
+6. **Unify launchers.**
+   Make the main training launcher the blessed path and move stale shell scripts
+   into a clearly marked legacy area or remove them after review. Every launch
+   should emit the resolved profile and the exact command-equivalent settings.
+
+7. **Improve checkpoint and resume hygiene.**
+   Store the resolved profile, source data manifest, git commit, dependency
+   versions, and evaluation split id beside each checkpoint. Resume should
+   restore model, optimizer, scheduler, scaler/accelerator state, and step count.
+
+## GPU Performance Plan
+
+Performance work should optimize measured bottlenecks, not just occupy hardware.
+
+| Area | Plan |
+| --- | --- |
+| Precision | Start with bf16. Treat fp8/NVFP4 as a later opt-in after bf16 correctness and metrics are stable. |
+| Memory | Use LoRA, gradient checkpointing, smaller per-device batches, and accumulation before sharding. |
+| Sequence efficiency | Add packed/chunked sequence training so padding does not dominate Redfish JSON batches. |
+| Tokenization | Cache tokenized fixtures by dataset manifest, tokenizer hash, max length, and masking strategy. |
+| Data loading | Tune workers, pinned memory, persistent workers, and local storage only after measuring tokens/sec. |
+| Logging | Report tokens/sec, samples/sec, step time, optimizer steps, allocated/reserved memory, LR, loss, and grad norm. |
+| Multi-GPU | Use NVL72 first for parallel ablations. Use ZeRO-3/FSDP for full fine-tune or larger batches only after one-GPU profiles are green. |
+
+The default 7B sequence should be:
+
+```text
+GPT-2 smoke -> 3B LoRA -> 7B LoRA -> multi-GPU smoke -> full fine-tune experiments
+```
+
+## Profiling and Custom Kernel Policy
+
+Optimization starts with measurement. Do not write custom CUDA or Triton kernels
+until profiling proves that a stable, repeated hot operation remains after the
+standard PyTorch/Transformers/PEFT path is configured correctly.
+
+The profiling pass should start on one GPU, then scale to multiple GPUs only
+after single-GPU bottlenecks are understood. It must use offline data and must
+not require a live Redfish endpoint.
+
+| Profiling area | Required signal |
+| --- | --- |
+| Step-time breakdown | Dataloader, tokenization/collation, host-to-device copy, forward, backward, optimizer, scheduler, logging, checkpointing. |
+| Throughput | Tokens/sec, samples/sec, optimizer steps/sec, and p50/p95 step time. |
+| GPU utilization | SM activity, memory allocated/reserved/peak, HBM bandwidth where available, and kernel-vs-Python time. |
+| Data path | Tokenization cache hit rate, padding waste, sequence-length distribution, dataloader worker utilization. |
+| Distributed path | Per-rank step time, communication time, all-reduce/sharding overhead, and straggler rank. |
+
+Recommended tools:
+
+```text
+torch.profiler with NVTX ranges
+Nsight Systems for timeline and CPU/GPU overlap
+Nsight Compute only after a specific hot CUDA kernel is identified
+nvidia-smi dmon or DCGM-style telemetry for coarse utilization
+W&B or TensorBoard plots for tokens/sec, memory, and step time
+```
+
+Fix high-level bottlenecks before kernel work:
+
+1. remove step-loop cache clearing;
+2. cache tokenization;
+3. reduce padding with packing/chunking;
+4. tune dataloader workers, pinned memory, and local storage;
+5. enforce true gradient accumulation;
+6. use bf16 model load and compute for large backbones;
+7. verify optimized attention backends such as SDPA or FlashAttention where supported;
+8. avoid logging/checkpointing syncs in the hot path.
+
+Custom kernels are justified only when the profiler identifies a stable hot op
+that is not already covered by fused PyTorch, SDPA/FlashAttention, `torch.compile`,
+or a PEFT/optimizer configuration change. Any custom kernel must include:
+
+```text
+correctness tests against a PyTorch reference
+dtype coverage for bf16/fp16/fp32 as needed
+shape coverage for expected sequence and batch sizes
+benchmark against the baseline implementation
+fallback path when the kernel is unavailable
+```
+
+## Data and Simulator Plan
+
+Better state representation depends more on diverse transition data than raw
+token volume. Data must be provenance-tagged so training and evaluation can
+separate real, replayed, simulated, and public fixture sources.
+
+| Source | Use | Trust boundary |
+| --- | --- | --- |
+| Real captured Redfish snapshots | Grounding and final held-out evaluation. | Approval-gated collection; scrubbed before any shared use. |
+| Replay/cassette traces | Deterministic offline parity tests and transition examples. | Default safe mode after capture. |
+| DMTF mockups and emulators | Schema variety, legal actions, error cases, and synthetic transitions. | Schema-valid but not vendor truth. |
+| Vendor-flavored simulators | OEM behavior and schema extensions. | Validate against real/replay traces before treating as ground truth. |
+| Synthetic resource graphs | Topology/action/state variation and rare edge cases. | Training augmentation, not final truth. |
+| Public unit-test fixtures | Expected edge behavior and negative cases. | Convert fixtures to structured transitions; do not train on random source text. |
+
+Normalized training examples should eventually look like:
+
+```text
+source_domain
+trust_level
+schema_version
+resource_graph_before
+request_or_action
+response
+resource_graph_after
+allowed_methods
+expected_semantics
+```
+
+The Redfish recorder should capture ordered traces:
+
+```text
+timestamp
+request method/path/body
+response status/body/headers
+state_before_hash
+state_after_hash
+resource graph delta
+job/task ids
+goal or actor label
+provenance tag
+```
+
+Live recording remains an approval-gated operation. Replay, scrub, diff, and
+export should be offline defaults.
+
+## Evaluation Gates
+
+Training loss is not enough. A profile can only be promoted when it improves
+held-out, source-separated metrics.
+
+| Gate | Required signal |
+| --- | --- |
+| Held-out language loss | Lower validation loss/perplexity on unseen Redfish snapshots. |
+| JSON validity | Decoded or reconstructed structures remain parseable and schema-like. |
+| Resource reconstruction | Important identity, health, status, link, and action fields are preserved. |
+| Action availability | The representation predicts legal actions and allowed methods. |
+| Transition prediction | Before/action/after pairs preserve causality and job/task semantics. |
+| Embedding retrieval | Similar semantic states cluster while different operational states separate. |
+| Downstream policy value | Action ranking or RL evaluation improves on offline traces. |
+| Performance budget | Tokens/sec, memory, and wall-clock cost are acceptable for the target profile. |
+
+The adapter experiment should report these metrics, not just training loss:
+
+| Metric | What it answers |
+| --- | --- |
+| State retrieval accuracy | Does the embedding retrieve the same semantic state across renamed ids, topology variation, and source domains? |
+| Next-state prediction / transition consistency | Does the representation preserve action-conditioned state changes, including async job/task phases? |
+| Action prediction accuracy | Can a small head recover legal actions, allowed methods, and action targets from the state representation? |
+| Linear probe labels | Are useful labels linearly accessible, such as health, power state, pending/applied config, task phase, and resource class? |
+| Downstream RL return / planning success | Does the adapter improve offline planning or policy success on held-out traces? |
+| Embedding collapse / nearest-neighbor sanity | Do embeddings avoid collapsing to one cluster, and do nearest neighbors make operational sense? |
+
+Promotion rule: an adapter can replace plain LoRA only if it improves at least
+one semantic metric without regressing public safety, held-out generalization,
+throughput, or memory beyond the target profile budget.
+
+## Report and Plot Suite
+
+Every adapter arm must produce the same tight report. A run without these plots
+is a smoke result, not a promotion candidate.
+
+| Case | Required metrics | Required plots | Status |
+| --- | --- | --- | --- |
+| State retrieval accuracy | recall@1, recall@5, MRR, source-domain split. | retrieval@k bars by source, nearest-neighbor table, embedding UMAP/t-SNE colored by resource class and source. | Planned harness. |
+| Next-state prediction / transition consistency | delta-field F1, task/job phase accuracy, one-step error, rollout drift. | transition confusion matrix, error-by-field bars, rollout drift over step horizon. | Planned harness. |
+| Action prediction accuracy | top-1/top-3 action accuracy, method accuracy, illegal-action false-positive rate. | top-k accuracy bars, action-class confusion matrix, precision/recall by action family. | Planned harness. |
+| Linear probe labels | accuracy/F1 per label, macro-F1, AUROC for binary labels. | per-label F1 bars, probe learning curves, label-support table. | Planned harness. |
+| Downstream RL return / planning success | success rate, return, episode length, action invalid-rate. | success-vs-step curves, return curves, episode-length distribution, invalid-action trend. | Blocked on trustworthy offline RL eval. |
+| Embedding collapse / nearest-neighbor sanity | cosine distribution, effective rank, cluster purity, duplicate-collapse rate. | pairwise cosine histogram, singular-value spectrum, nearest-neighbor audit table. | Planned harness. |
+
+Each report should include:
+
+```text
+run id
+profile and adapter arm
+model and tokenizer
+data manifest
+eval split
+metric table
+plots directory
+five best examples
+five worst examples
+known blockers
+```
+
+Plots should be generated from offline artifacts only. Do not require a live
+Redfish endpoint, a private host, or raw captured secrets to render a report.
+
+Results must report:
+
+```text
+profile
+model
+data manifest
+eval split
+command or launcher settings
+checkpoint path
+metric table
+known blockers
+```
+
+## Execution Order
+
+1. Add docs and profile definitions.
+2. Add offline tests for profile resolution and scheduler argument construction.
+3. Fix trainer-loop semantics under tiny CPU/GPT-2 tests.
+4. Add throughput and memory telemetry.
+5. Add a one-GPU profiling report for the GPT-2 smoke and one adapter smoke.
+6. Modernize the blessed launcher around explicit profiles.
+7. Run the CPU/offline gate.
+8. Run one-GPU GPT-2 smoke.
+9. Run 3B LoRA and 7B LoRA on the same data split.
+10. Use NVL72 for parallel ablations across LoRA rank, sequence length, learning rate, and data mix.
+11. Try full fine-tune only if LoRA underfits trusted metrics and the full-FT control is stable.
+12. Consider custom kernels only after profiler evidence survives all higher-level fixes.
+
+## Non-Goals
+
+- Do not make public claims that 7B, full fine-tune, fp8, or NVL72 scaling is
+  validated without metric evidence.
+- Do not commit raw captures, checkpoints, tokenizers, tarballs, private
+  endpoints, or secrets.
+- Do not run live Redfish collection as part of a training or test default.
+- Do not use simulator-only metrics as proof of real infrastructure behavior.

--- a/igc/ds/redfish_dataset.py
+++ b/igc/ds/redfish_dataset.py
@@ -1848,8 +1848,8 @@ class JSONDataset(
     def build_special_tok_table() -> List[str]:
         """
         This method called to build a table for all tokens.
-        This token added to a tokenizer,  we also store in dataset
-        on client when we download dataset we need make
+        Token added to a tokenizer,  note we also store in dataset
+        on client side when we download dataset we need make
         sure we use same token ids.
 
         Again it important since during masking if we make

--- a/igc/ds/sources/__init__.py
+++ b/igc/ds/sources/__init__.py
@@ -17,6 +17,7 @@ from igc.ds.sources.base import (
     TrustLevel,
 )
 from igc.ds.sources.redfish_fixture_source import RedfishFixtureSource
+from igc.ds.sources.mixer import DataManifest, SourceMix, unit_hash
 
 __all__ = [
     "READ_METHODS",
@@ -24,6 +25,9 @@ __all__ = [
     "SourceRecord",
     "TrustLevel",
     "RedfishFixtureSource",
+    "SourceMix",
+    "DataManifest",
+    "unit_hash",
 ]
 
 # Author: Mus mbayramo@stanford.edu

--- a/igc/ds/sources/__init__.py
+++ b/igc/ds/sources/__init__.py
@@ -18,6 +18,12 @@ from igc.ds.sources.base import (
 )
 from igc.ds.sources.redfish_fixture_source import RedfishFixtureSource
 from igc.ds.sources.mixer import DataManifest, SourceMix, unit_hash
+from igc.ds.sources.training_object import (
+    TrainingExample,
+    compact_resource,
+    normalize,
+    normalize_record,
+)
 
 __all__ = [
     "READ_METHODS",
@@ -28,6 +34,10 @@ __all__ = [
     "SourceMix",
     "DataManifest",
     "unit_hash",
+    "TrainingExample",
+    "compact_resource",
+    "normalize",
+    "normalize_record",
 ]
 
 # Author: Mus mbayramo@stanford.edu

--- a/igc/ds/sources/__init__.py
+++ b/igc/ds/sources/__init__.py
@@ -5,7 +5,10 @@ Exposes the source contract (:class:`SourceAdapter`, :class:`SourceRecord`,
 :class:`TrustLevel`) and the offline filesystem adapter
 (:class:`RedfishFixtureSource`) that reads captured Redfish JSON corpora — real
 vendor captures, the DMTF mockup replay tree, or ``~/.json_responses`` — into a
-single trust-tagged record stream.
+single trust-tagged record stream, plus the enum-space extraction layer
+(:class:`EnumSpaceIndex` and friends) that turns captured BIOS registries,
+ActionInfo bodies, and inline allowable-value annotations into the per-slot
+``arg_schema`` enum spaces the stage-2 argument decoder scores over.
 
 Author:
 Mus mbayramo@stanford.edu
@@ -18,6 +21,17 @@ from igc.ds.sources.base import (
 )
 from igc.ds.sources.redfish_fixture_source import RedfishFixtureSource
 from igc.ds.sources.mixer import DataManifest, SourceMix, unit_hash
+from igc.ds.sources.redfish_enum_space import (
+    EnumSlot,
+    EnumSpaceIndex,
+    ResourceKind,
+    classify_resource,
+    normalize_enriched,
+    slots_from_action_info,
+    slots_from_attribute_registry,
+    slots_from_inline_annotations,
+    to_arg_schema,
+)
 from igc.ds.sources.training_object import (
     TrainingExample,
     compact_resource,
@@ -39,6 +53,15 @@ __all__ = [
     "SourceRecord",
     "TrustLevel",
     "RedfishFixtureSource",
+    "EnumSlot",
+    "EnumSpaceIndex",
+    "ResourceKind",
+    "classify_resource",
+    "normalize_enriched",
+    "slots_from_action_info",
+    "slots_from_attribute_registry",
+    "slots_from_inline_annotations",
+    "to_arg_schema",
     "SourceMix",
     "DataManifest",
     "unit_hash",

--- a/igc/ds/sources/__init__.py
+++ b/igc/ds/sources/__init__.py
@@ -24,6 +24,14 @@ from igc.ds.sources.training_object import (
     normalize,
     normalize_record,
 )
+from igc.ds.sources.corpus_io import (
+    iter_examples,
+    read_examples,
+    read_manifest,
+    write_corpus,
+    write_examples,
+    write_manifest,
+)
 
 __all__ = [
     "READ_METHODS",
@@ -38,6 +46,12 @@ __all__ = [
     "compact_resource",
     "normalize",
     "normalize_record",
+    "write_examples",
+    "iter_examples",
+    "read_examples",
+    "write_manifest",
+    "read_manifest",
+    "write_corpus",
 ]
 
 # Author: Mus mbayramo@stanford.edu

--- a/igc/ds/sources/corpus_io.py
+++ b/igc/ds/sources/corpus_io.py
@@ -1,0 +1,110 @@
+"""
+Persist a normalized training corpus to disk and read it back.
+
+Writes :class:`TrainingExample` objects as JSONL (one ``to_dict()`` per line) with a
+:class:`DataManifest` sidecar, and reads them back as dicts. Offline only — this is the seam
+between the source/mixer/normalizer pipeline and a training run that consumes a fixed corpus.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+from typing import Any, Dict, Iterable, Iterator, List
+
+from igc.ds.sources.mixer import DataManifest
+from igc.ds.sources.training_object import TrainingExample
+
+
+def _ensure_parent(path: str) -> None:
+    """Create the parent directory of ``path`` when it is non-empty and missing.
+
+    :param path: a file path whose parent directory should exist.
+    :return: ``None``.
+    """
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+
+
+def write_examples(examples: Iterable[TrainingExample], path: str) -> int:
+    """Write training examples as JSONL (one ``to_dict()`` per line).
+
+    :param examples: the examples to serialize.
+    :param path: destination ``.jsonl`` path (parent dirs are created).
+    :return: the number of examples written.
+    """
+    _ensure_parent(path)
+    count = 0
+    with open(path, "w") as handle:
+        for example in examples:
+            handle.write(json.dumps(example.to_dict()))
+            handle.write("\n")
+            count += 1
+    return count
+
+
+def iter_examples(path: str) -> Iterator[Dict[str, Any]]:
+    """Yield one example dict per non-blank JSONL line (streams the file).
+
+    :param path: a ``.jsonl`` file written by :func:`write_examples`.
+    :return: an iterator of example dicts.
+    """
+    with open(path, "r") as handle:
+        for line in handle:
+            if line.strip():
+                yield json.loads(line)
+
+
+def read_examples(path: str) -> List[Dict[str, Any]]:
+    """Read a JSONL corpus fully into memory.
+
+    :param path: a ``.jsonl`` file written by :func:`write_examples`.
+    :return: the list of example dicts.
+    """
+    return list(iter_examples(path))
+
+
+def write_manifest(manifest: DataManifest, path: str) -> None:
+    """Write a :class:`DataManifest` as pretty, sorted JSON.
+
+    :param manifest: the manifest to serialize.
+    :param path: destination ``.json`` path (parent dirs are created).
+    :return: ``None``.
+    """
+    _ensure_parent(path)
+    with open(path, "w") as handle:
+        json.dump(dataclasses.asdict(manifest), handle, indent=2, sort_keys=True)
+
+
+def read_manifest(path: str) -> Dict[str, Any]:
+    """Load a manifest JSON file written by :func:`write_manifest`.
+
+    :param path: the manifest path.
+    :return: the manifest as a dict.
+    """
+    with open(path, "r") as handle:
+        return json.load(handle)
+
+
+def write_corpus(examples: Iterable[TrainingExample], manifest: DataManifest,
+                 out_dir: str) -> Dict[str, str]:
+    """Write a corpus (``examples.jsonl`` + ``manifest.json``) into ``out_dir``.
+
+    :param examples: the examples to serialize.
+    :param manifest: the corpus manifest.
+    :param out_dir: destination directory (created if missing).
+    :return: mapping with ``examples`` / ``manifest`` paths and ``count`` (as a string).
+    """
+    os.makedirs(out_dir, exist_ok=True)
+    examples_path = os.path.join(out_dir, "examples.jsonl")
+    manifest_path = os.path.join(out_dir, "manifest.json")
+    count = write_examples(examples, examples_path)
+    write_manifest(manifest, manifest_path)
+    return {"examples": examples_path, "manifest": manifest_path, "count": str(count)}
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/igc/ds/sources/mixer.py
+++ b/igc/ds/sources/mixer.py
@@ -1,0 +1,178 @@
+"""
+Multi-source mixer with a deterministic, trust-tier-aware train/eval split.
+
+Composes several provenance-tagged Redfish data sources (real vendor captures, the DMTF
+mockup replay tree, vendor/synthetic emulators) into a single training corpus. The eval split
+is drawn ONLY from the highest-trust tier, so real captures serve as held-out ground truth
+while the more synthetic tiers always feed training for coverage. The split is deterministic —
+a stable hash of each resource URL rather than an RNG — so it reproduces across runs and stays
+stable as the corpus grows, and a serializable :class:`DataManifest` records the mix (for the
+training run manifest and as a fair-comparison key).
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+from igc.ds.sources.base import SourceAdapter, SourceRecord, TrustLevel
+
+
+def unit_hash(key: str, seed: int) -> float:
+    """Map ``(seed, key)`` to a stable float in ``[0.0, 1.0)``.
+
+    Uses blake2b so the value is identical across processes and runs (unlike the builtin
+    ``hash()``); the first 8 digest bytes are read big-endian and divided by ``2 ** 64``.
+
+    :param key: the string to hash (a resource URL).
+    :param seed: split seed, mixed into the digest.
+    :return: a deterministic float in ``[0.0, 1.0)``.
+    """
+    digest = hashlib.blake2b(f"{seed}:{key}".encode("utf-8"), digest_size=8).digest()
+    return int.from_bytes(digest, "big") / 2 ** 64
+
+
+@dataclass
+class DataManifest:
+    """A serializable summary of a composed corpus and its train/eval split.
+
+    :param total: total records after dedup.
+    :param train_count: records assigned to training.
+    :param eval_count: records held out for evaluation.
+    :param by_source: record count per source label.
+    :param by_trust: record count per :class:`TrustLevel` name.
+    :param by_vendor: record count per vendor (``"unknown"`` when unset).
+    :param eval_trust_floor: name of the lowest trust tier eligible for eval.
+    :param eval_fraction: fraction of eligible records held out for eval.
+    :param seed: the split seed.
+    :param sources: sorted unique source labels.
+    """
+    total: int
+    train_count: int
+    eval_count: int
+    by_source: Dict[str, int]
+    by_trust: Dict[str, int]
+    by_vendor: Dict[str, int]
+    eval_trust_floor: str
+    eval_fraction: float
+    seed: int
+    sources: List[str]
+
+    def content_hash(self) -> str:
+        """Return a stable 16-hex-char hash over the manifest fields.
+
+        Two manifests with equal contents hash equal, so this can key reproducibility and
+        fair-comparison checks. Field (and nested-dict) order is canonicalized via sorted-key
+        JSON before hashing.
+
+        :return: a 16-character hex digest.
+        """
+        payload = json.dumps(self.__dict__, sort_keys=True, default=str)
+        return hashlib.blake2b(payload.encode("utf-8"), digest_size=8).hexdigest()
+
+
+class SourceMix:
+    """Compose sources into one corpus with a deterministic trust-tier train/eval split.
+
+    :param adapters: source adapters to combine, in priority order (earlier wins a dedup tie).
+    :param eval_fraction: fraction of eval-eligible records held out (``0.0``-``1.0``).
+    :param eval_trust_floor: only records at or above this tier are eval-eligible.
+    :param seed: seed for the deterministic split hash.
+    :param dedup: when true, keep one record per URL (highest trust; first-seen on a tie).
+    :raises ValueError: if ``eval_fraction`` is outside ``[0.0, 1.0]``.
+    """
+
+    def __init__(self, adapters: List[SourceAdapter], *, eval_fraction: float = 0.15,
+                 eval_trust_floor: TrustLevel = TrustLevel.REAL, seed: int = 0,
+                 dedup: bool = True):
+        if not 0.0 <= eval_fraction <= 1.0:
+            raise ValueError(f"eval_fraction must be in [0.0, 1.0], got {eval_fraction}")
+        self._adapters = list(adapters)
+        self.eval_fraction = eval_fraction
+        self.eval_trust_floor = eval_trust_floor
+        self.seed = seed
+        self.dedup = dedup
+        self._records_cache: List[SourceRecord] = None
+
+    def records(self) -> List[SourceRecord]:
+        """Collect all records from every adapter, optionally deduped by URL.
+
+        With dedup on, a URL seen in several sources collapses to its highest-trust copy
+        (first-seen wins a trust tie, so adapter order is the tie-break); the record keeps its
+        first-appearance position. The result is cached for repeated calls.
+
+        :return: the composed list of records.
+        """
+        if self._records_cache is not None:
+            return self._records_cache
+
+        if not self.dedup:
+            self._records_cache = [rec for adapter in self._adapters for rec in adapter.iter_records()]
+            return self._records_cache
+
+        best: Dict[str, SourceRecord] = {}
+        order: List[str] = []
+        for adapter in self._adapters:
+            for rec in adapter.iter_records():
+                current = best.get(rec.url)
+                if current is None:
+                    best[rec.url] = rec
+                    order.append(rec.url)
+                elif rec.trust_level > current.trust_level:
+                    best[rec.url] = rec
+        self._records_cache = [best[url] for url in order]
+        return self._records_cache
+
+    def split(self) -> Tuple[List[SourceRecord], List[SourceRecord]]:
+        """Partition the corpus into ``(train, eval)`` deterministically.
+
+        A record is held out for eval iff it is at or above ``eval_trust_floor`` AND
+        ``unit_hash(url, seed) < eval_fraction``; everything else trains. Input order is
+        preserved within each list.
+
+        :return: ``(train_records, eval_records)``.
+        """
+        train: List[SourceRecord] = []
+        held_out: List[SourceRecord] = []
+        for rec in self.records():
+            eligible = rec.trust_level >= self.eval_trust_floor
+            if eligible and unit_hash(rec.url, self.seed) < self.eval_fraction:
+                held_out.append(rec)
+            else:
+                train.append(rec)
+        return train, held_out
+
+    def manifest(self) -> DataManifest:
+        """Summarize the composed corpus and split into a :class:`DataManifest`.
+
+        :return: the manifest — counts by source / trust / vendor and train/eval sizes.
+        """
+        records = self.records()
+        train, held_out = self.split()
+        by_source: Dict[str, int] = {}
+        by_trust: Dict[str, int] = {}
+        by_vendor: Dict[str, int] = {}
+        for rec in records:
+            by_source[rec.source] = by_source.get(rec.source, 0) + 1
+            by_trust[rec.trust_level.name] = by_trust.get(rec.trust_level.name, 0) + 1
+            vendor = rec.vendor or "unknown"
+            by_vendor[vendor] = by_vendor.get(vendor, 0) + 1
+        return DataManifest(
+            total=len(records),
+            train_count=len(train),
+            eval_count=len(held_out),
+            by_source=by_source,
+            by_trust=by_trust,
+            by_vendor=by_vendor,
+            eval_trust_floor=self.eval_trust_floor.name,
+            eval_fraction=self.eval_fraction,
+            seed=self.seed,
+            sources=sorted(by_source.keys()),
+        )
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/igc/ds/sources/mixer.py
+++ b/igc/ds/sources/mixer.py
@@ -74,6 +74,28 @@ class DataManifest:
         payload = json.dumps(self.__dict__, sort_keys=True, default=str)
         return hashlib.blake2b(payload.encode("utf-8"), digest_size=8).hexdigest()
 
+    def eval_split_id(self) -> str:
+        """Return a stable id of the eval-split policy (floor / fraction / seed).
+
+        Distinct from :meth:`content_hash` (which identifies the exact record mix): this
+        identifies HOW the split was drawn, so two runs over the same corpus with the same
+        policy share an ``eval_split`` id.
+
+        :return: e.g. ``"floor=REAL:frac=0.15:seed=0"``.
+        """
+        return f"floor={self.eval_trust_floor}:frac={self.eval_fraction}:seed={self.seed}"
+
+    def to_run_manifest_fields(self) -> Dict[str, str]:
+        """Fields to populate a training ``RunManifest`` from this mix.
+
+        A run records its exact data mix by constructing
+        ``RunManifest(..., **manifest.to_run_manifest_fields())`` so the report bundle's
+        fair-comparison check can tell whether two runs trained on the same data + split.
+
+        :return: ``{"data_manifest": content_hash, "eval_split": eval_split_id}``.
+        """
+        return {"data_manifest": self.content_hash(), "eval_split": self.eval_split_id()}
+
 
 class SourceMix:
     """Compose sources into one corpus with a deterministic trust-tier train/eval split.

--- a/igc/ds/sources/redfish_enum_space.py
+++ b/igc/ds/sources/redfish_enum_space.py
@@ -1,0 +1,440 @@
+"""
+Extract per-slot argument value spaces from captured Redfish resources.
+
+The stage-2 argument decoder (:mod:`igc.modules.policy.argument_decoder`) scores a
+categorical argument over its OWN allowable values, read from
+``ToolSpec.arg_schema[op][slot]["enum"]``. This module builds those enum spaces
+offline from the resource types ``redfish_ctl`` discovery captures under
+``~/.json_responses/<host>/`` (and the vendor fixture corpora): BIOS attribute
+registries (``#AttributeRegistry`` bodies with ``RegistryEntries.Attributes``),
+``#ActionInfo`` bodies (``Parameters[].AllowableValues``), inline
+``<prop>@Redfish.AllowableValues`` annotations (e.g. ``Boot`` and ``Actions``
+blocks of a ``#ComputerSystem``), and ``#BootOption`` entries (the
+``BootOptionReference`` id space that bounds ``Boot.BootOrder``).
+
+Everything here is pure stdlib and consumes already-captured
+:class:`~igc.ds.sources.base.SourceRecord` streams (typically from
+:class:`~igc.ds.sources.redfish_fixture_source.RedfishFixtureSource`); it never
+touches a live controller. HPE-style registry *pointers*
+(``#MessageRegistryFile`` bodies whose ``Location[].Uri`` names an external
+registry) are counted but yield no slots — the pointed-to payload is a separate
+capture.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from igc.ds.sources.base import SourceRecord
+from igc.ds.sources.training_object import TrainingExample, normalize_record
+
+# suffix of the standard Redfish annotation carrying a property's allowable values.
+ALLOWABLE_SUFFIX = "@Redfish.AllowableValues"
+
+# Redfish registry / ActionInfo type names -> JSON-schema-style type names used
+# in ``arg_schema`` fragments (see igc.modules.policy.argument_decoder.arg_slots_for).
+_TYPE_MAP = {
+    "enumeration": "string",
+    "string": "string",
+    "password": "string",
+    "integer": "integer",
+    "number": "number",
+    "boolean": "boolean",
+}
+
+
+class ResourceKind(enum.Enum):
+    """Semantic type of a captured Redfish resource, keyed off ``@odata.type``.
+
+    ``classify_resource`` falls back to URL heuristics when a capture carries no
+    ``@odata.type`` (older iLO firmware omits it on some resources).
+    """
+    BIOS = "bios"
+    BIOS_PENDING = "bios_pending"
+    ATTRIBUTE_REGISTRY = "attribute_registry"
+    REGISTRY_FILE = "registry_file"
+    BOOT_OPTION_COLLECTION = "boot_option_collection"
+    BOOT_OPTION = "boot_option"
+    ACTION_INFO = "action_info"
+    COMPUTER_SYSTEM = "computer_system"
+    OTHER = "other"
+
+
+# (odata.type prefix, kind) in match order; BIOS is refined to BIOS_PENDING by URL.
+_ODATA_PREFIXES: Tuple[Tuple[str, ResourceKind], ...] = (
+    ("#AttributeRegistry.", ResourceKind.ATTRIBUTE_REGISTRY),
+    ("#MessageRegistryFile.", ResourceKind.REGISTRY_FILE),
+    ("#BootOptionCollection.", ResourceKind.BOOT_OPTION_COLLECTION),
+    ("#BootOption.", ResourceKind.BOOT_OPTION),
+    ("#ActionInfo.", ResourceKind.ACTION_INFO),
+    ("#Bios.", ResourceKind.BIOS),
+    ("#ComputerSystem.", ResourceKind.COMPUTER_SYSTEM),
+)
+
+
+def _is_pending_settings_url(url: str) -> bool:
+    """True when *url* names the pending-settings child of a BIOS resource.
+
+    Matches the standard ``.../Bios/Settings`` (Dell) and lowercase
+    ``.../bios/settings`` (iLO) forms.
+
+    :param url: canonical resource URL.
+    :return: whether the URL is a BIOS pending-settings resource.
+    """
+    parts = url.rstrip("/").lower().rsplit("/", 2)
+    return len(parts) == 3 and parts[1] == "bios" and parts[2] == "settings"
+
+
+def classify_resource(url: str, body: Dict[str, Any]) -> ResourceKind:
+    """Classify a captured resource by ``@odata.type``, with URL fallbacks.
+
+    :param url: canonical resource URL (``@odata.id`` or filename-derived).
+    :param body: decoded JSON resource body.
+    :return: the :class:`ResourceKind`; ``OTHER`` when nothing matches.
+    """
+    odata_type = body.get("@odata.type", "") if isinstance(body, dict) else ""
+    for prefix, kind in _ODATA_PREFIXES:
+        if isinstance(odata_type, str) and odata_type.startswith(prefix):
+            if kind is ResourceKind.BIOS and _is_pending_settings_url(url):
+                return ResourceKind.BIOS_PENDING
+            return kind
+    # URL fallbacks for captures without @odata.type.
+    lowered = url.rstrip("/").lower()
+    if _is_pending_settings_url(url):
+        return ResourceKind.BIOS_PENDING
+    if lowered.endswith("/bios"):
+        return ResourceKind.BIOS
+    if "/bootoptions/" in lowered:
+        return ResourceKind.BOOT_OPTION
+    if lowered.endswith("/bootoptions"):
+        return ResourceKind.BOOT_OPTION_COLLECTION
+    return ResourceKind.OTHER
+
+
+@dataclass(frozen=True)
+class EnumSlot:
+    """One argument slot extracted from a captured resource.
+
+    Mirrors what :func:`igc.modules.policy.argument_decoder.arg_slots_for` needs:
+    a slot with ``choices`` is categorical (finite enum space); without, it is a
+    typed free-form slot for the generative head.
+
+    :param name: slot key (attribute / parameter / property name).
+    :param type: JSON-schema-style type name (``string``/``integer``/...).
+    :param choices: allowable values, or ``None`` for a free-form slot.
+    :param required: whether the op is invalid without this slot.
+    :param read_only: registry ``ReadOnly`` flag (read-only slots are excluded
+        from PATCH schemas).
+    :param current_value: value observed at capture time, when the source carries one.
+    :param source_url: URL of the resource the slot was extracted from.
+    :param extracted_from: which extractor produced it (``registry`` /
+        ``action_info`` / ``inline``).
+    :param path: dotted location inside the body for inline annotations
+        (e.g. ``Boot.BootSourceOverrideTarget``), else ``""``.
+    """
+    name: str
+    type: str = "string"
+    choices: Optional[Tuple] = None
+    required: bool = False
+    read_only: bool = False
+    current_value: Any = None
+    source_url: str = ""
+    extracted_from: str = ""
+    path: str = ""
+
+    def to_schema_fragment(self) -> Dict[str, Any]:
+        """Return the ``arg_schema[op][slot]`` fragment for this slot.
+
+        The fragment shape (``type`` / ``enum`` / ``required``) is exactly what
+        ``arg_slots_for`` reads when sizing the stage-2 decoder head.
+
+        :return: dict with ``type``, ``required``, and ``enum`` when categorical.
+        """
+        fragment: Dict[str, Any] = {"type": self.type, "required": self.required}
+        if self.choices:
+            fragment["enum"] = list(self.choices)
+        return fragment
+
+
+def _map_type(type_name: Any) -> str:
+    """Map a Redfish registry/ActionInfo type name to a JSON-schema-style name.
+
+    :param type_name: e.g. ``"Enumeration"`` / ``"Integer"`` / ``"String"``.
+    :return: mapped name; unknown or missing types default to ``"string"``.
+    """
+    if not isinstance(type_name, str):
+        return "string"
+    return _TYPE_MAP.get(type_name.lower(), "string")
+
+
+def slots_from_attribute_registry(url: str, body: Dict[str, Any]) -> List[EnumSlot]:
+    """Extract per-attribute slots from an ``#AttributeRegistry`` body.
+
+    Walks ``RegistryEntries.Attributes``: an ``Enumeration`` attribute yields a
+    categorical slot whose choices come from ``Value[].ValueName``; other types
+    yield typed free-form slots. Entries without an ``AttributeName`` are
+    skipped. A registry *pointer* (no ``RegistryEntries``, HPE style) yields [].
+
+    :param url: URL of the registry resource.
+    :param body: decoded registry body.
+    :return: extracted slots in registry order.
+    """
+    entries = body.get("RegistryEntries")
+    if not isinstance(entries, dict):
+        return []
+    slots: List[EnumSlot] = []
+    for attr in entries.get("Attributes", []) or []:
+        if not isinstance(attr, dict):
+            continue
+        name = attr.get("AttributeName")
+        if not isinstance(name, str) or not name:
+            continue
+        choices: Optional[Tuple] = None
+        if attr.get("Type") == "Enumeration":
+            names = [
+                v.get("ValueName") for v in attr.get("Value", []) or []
+                if isinstance(v, dict) and v.get("ValueName") is not None
+            ]
+            choices = tuple(names) if names else None
+        slots.append(EnumSlot(
+            name=name,
+            type=_map_type(attr.get("Type")),
+            choices=choices,
+            read_only=bool(attr.get("ReadOnly", False)),
+            current_value=attr.get("CurrentValue"),
+            source_url=url,
+            extracted_from="registry",
+        ))
+    return slots
+
+
+def slots_from_action_info(url: str, body: Dict[str, Any]) -> List[EnumSlot]:
+    """Extract parameter slots from an ``#ActionInfo`` body.
+
+    Follows the DMTF ActionInfo shape: ``Parameters[]`` entries with ``Name``,
+    ``Required``, ``DataType``, and ``AllowableValues``. Discovery does not yet
+    follow ``@Redfish.ActionInfo`` references, so bodies come from targeted
+    captures; the shape is pinned by the fixture tests either way.
+
+    :param url: URL of the ActionInfo resource.
+    :param body: decoded ActionInfo body.
+    :return: extracted slots in parameter order.
+    """
+    slots: List[EnumSlot] = []
+    for param in body.get("Parameters", []) or []:
+        if not isinstance(param, dict):
+            continue
+        name = param.get("Name")
+        if not isinstance(name, str) or not name:
+            continue
+        values = param.get("AllowableValues")
+        choices = tuple(values) if isinstance(values, list) and values else None
+        slots.append(EnumSlot(
+            name=name,
+            type=_map_type(param.get("DataType")),
+            choices=choices,
+            required=bool(param.get("Required", False)),
+            source_url=url,
+            extracted_from="action_info",
+        ))
+    return slots
+
+
+def slots_from_inline_annotations(url: str, body: Dict[str, Any]) -> List[EnumSlot]:
+    """Extract slots from ``<prop>@Redfish.AllowableValues`` annotations anywhere in a body.
+
+    Vendors annotate writable properties inline instead of (or besides)
+    publishing ActionInfo — e.g. ``Boot.BootSourceOverrideTarget`` and the
+    ``ResetType`` of an ``Actions`` block. The dotted ``path`` records where the
+    annotation sat, so callers can split action parameters (path under
+    ``Actions``) from patchable properties.
+
+    :param url: URL of the annotated resource.
+    :param body: decoded resource body.
+    :return: extracted slots in depth-first key order.
+    """
+    slots: List[EnumSlot] = []
+
+    def _walk(node: Any, path: str) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key.endswith(ALLOWABLE_SUFFIX) and isinstance(value, list) and value:
+                    prop = key[: -len(ALLOWABLE_SUFFIX)]
+                    slots.append(EnumSlot(
+                        name=prop,
+                        type="string",
+                        choices=tuple(value),
+                        current_value=node.get(prop),
+                        source_url=url,
+                        extracted_from="inline",
+                        path=f"{path}.{prop}" if path else prop,
+                    ))
+                else:
+                    _walk(value, f"{path}.{key}" if path else key)
+        elif isinstance(node, list):
+            for item in node:
+                _walk(item, path)
+
+    _walk(body, "")
+    return slots
+
+
+def to_arg_schema(op: str, slots: Iterable[EnumSlot]) -> Dict[str, Dict[str, Any]]:
+    """Assemble slots into the ``{op: {slot: fragment}}`` shape ``ToolSpec.arg_schema`` takes.
+
+    First-seen wins on a duplicate slot name (mirrors the adapter-order
+    convention in :class:`~igc.ds.sources.mixer.SourceMix` dedup), so feed
+    higher-trust records first.
+
+    :param op: the operation the slots belong to (e.g. ``"PATCH"`` / ``"POST"``).
+    :param slots: slots to assemble.
+    :return: an ``arg_schema``-shaped dict for one op.
+    """
+    fragments: Dict[str, Any] = {}
+    for slot in slots:
+        if slot.name not in fragments:
+            fragments[slot.name] = slot.to_schema_fragment()
+    return {op: fragments}
+
+
+class EnumSpaceIndex:
+    """Accumulate per-slot value spaces from a provenance-tagged record stream.
+
+    Routes each :class:`SourceRecord` by :func:`classify_resource`: attribute
+    registries and ActionInfo bodies feed their dedicated extractors, every body
+    is scanned for inline annotations, and ``#BootOption`` entries contribute
+    their ``BootOptionReference`` to the boot-order id space. Feed records in
+    trust order (real first) — schema exports keep the first-seen fragment per
+    slot name.
+    """
+
+    def __init__(self) -> None:
+        #: slots from registry bodies, keyed by registry URL.
+        self.registry_slots: Dict[str, List[EnumSlot]] = {}
+        #: action-parameter slots from ``#ActionInfo`` bodies (authoritative per DMTF).
+        self.action_slots: Dict[str, List[EnumSlot]] = {}
+        #: action-parameter slots from inline ``Actions`` annotations (fallback tier).
+        self.inline_action_slots: Dict[str, List[EnumSlot]] = {}
+        #: patchable-property slots (inline annotations outside ``Actions``).
+        self.settings_slots: Dict[str, List[EnumSlot]] = {}
+        #: ordered unique ``BootOptionReference`` ids seen across boot options.
+        self.boot_references: List[str] = []
+        #: record count per :class:`ResourceKind` name (all records, not just slot-bearing).
+        self.by_kind: Dict[str, int] = {}
+        #: registry pointers seen (kind ``REGISTRY_FILE``) — their payload is external.
+        self.num_registry_pointers = 0
+
+    @classmethod
+    def from_records(cls, records: Iterable[SourceRecord]) -> "EnumSpaceIndex":
+        """Build an index from a record stream.
+
+        :param records: provenance-tagged records, highest trust first.
+        :return: the populated index.
+        """
+        index = cls()
+        for record in records:
+            index.add_record(record)
+        return index
+
+    def add_record(self, record: SourceRecord) -> ResourceKind:
+        """Classify one record and fold its value spaces into the index.
+
+        :param record: a captured GET observation.
+        :return: the kind the record classified as.
+        """
+        kind = classify_resource(record.url, record.response)
+        self.by_kind[kind.name] = self.by_kind.get(kind.name, 0) + 1
+
+        if kind is ResourceKind.ATTRIBUTE_REGISTRY:
+            slots = slots_from_attribute_registry(record.url, record.response)
+            if slots:
+                self.registry_slots.setdefault(record.url, []).extend(slots)
+        elif kind is ResourceKind.REGISTRY_FILE:
+            self.num_registry_pointers += 1
+        elif kind is ResourceKind.ACTION_INFO:
+            slots = slots_from_action_info(record.url, record.response)
+            if slots:
+                self.action_slots.setdefault(record.url, []).extend(slots)
+        elif kind is ResourceKind.BOOT_OPTION:
+            reference = record.response.get("BootOptionReference") or record.response.get("Id")
+            if isinstance(reference, str) and reference and reference not in self.boot_references:
+                self.boot_references.append(reference)
+
+        # any body may carry inline annotations; split them by location.
+        for slot in slots_from_inline_annotations(record.url, record.response):
+            top_segment = slot.path.split(".", 1)[0]
+            bucket = self.inline_action_slots if top_segment == "Actions" else self.settings_slots
+            bucket.setdefault(record.url, []).append(slot)
+        return kind
+
+    def _merged(self, buckets: Iterable[Dict[str, List[EnumSlot]]],
+                writeable_only: bool = False) -> List[EnumSlot]:
+        """Flatten slot buckets in insertion order, optionally dropping read-only slots.
+
+        :param buckets: bucket dicts to merge.
+        :param writeable_only: when true, exclude ``read_only`` slots.
+        :return: the flattened slot list.
+        """
+        merged: List[EnumSlot] = []
+        for bucket in buckets:
+            for slots in bucket.values():
+                merged.extend(s for s in slots if not (writeable_only and s.read_only))
+        return merged
+
+    def patch_arg_schema(self, op: str = "PATCH") -> Dict[str, Dict[str, Any]]:
+        """The ``arg_schema`` for settings writes: registry attributes + patchable properties.
+
+        Read-only registry attributes are excluded — a PATCH can never carry
+        them. First-seen wins per slot name across registries and hosts.
+
+        :param op: schema key to emit under (default ``"PATCH"``).
+        :return: ``{op: {attribute: fragment}}``.
+        """
+        return to_arg_schema(op, self._merged(
+            (self.registry_slots, self.settings_slots), writeable_only=True))
+
+    def post_arg_schema(self, op: str = "POST") -> Dict[str, Dict[str, Any]]:
+        """The ``arg_schema`` for action invocations.
+
+        ``#ActionInfo`` parameters take precedence over inline ``Actions``
+        annotations on a name clash, whatever order the records streamed in —
+        DMTF makes ActionInfo the authoritative parameter description.
+
+        :param op: schema key to emit under (default ``"POST"``).
+        :return: ``{op: {parameter: fragment}}``.
+        """
+        return to_arg_schema(op, self._merged((self.action_slots, self.inline_action_slots)))
+
+    def boot_reference_space(self) -> Tuple[str, ...]:
+        """The ordered ``BootOptionReference`` id space bounding ``Boot.BootOrder``.
+
+        :return: unique references in first-seen order.
+        """
+        return tuple(self.boot_references)
+
+
+def normalize_enriched(records: Iterable[SourceRecord]) -> List[TrainingExample]:
+    """Normalize records into TrainingExamples stamped with their resource kind.
+
+    Delegates to :func:`~igc.ds.sources.training_object.normalize_record` and adds
+    ``expected_semantics["resource_kind"]`` so the enriched resource types (BIOS
+    attributes, boot options, registries) are distinguishable downstream without
+    re-parsing bodies.
+
+    :param records: iterable of GET-observation records.
+    :return: one enriched :class:`TrainingExample` per record.
+    """
+    examples: List[TrainingExample] = []
+    for record in records:
+        kind = classify_resource(record.url, record.response)
+        example = normalize_record(record)
+        example.expected_semantics["resource_kind"] = kind.value
+        examples.append(example)
+    return examples
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/igc/ds/sources/training_object.py
+++ b/igc/ds/sources/training_object.py
@@ -1,0 +1,134 @@
+"""
+Normalize provenance-tagged Redfish SourceRecords (GET observations) into uniform
+TrainingExample tuples consumed by the state-encoder and RL agent.
+
+Each SourceRecord carries a full Redfish response body, provenance metadata, and a trust level.
+This module compacts the resource representation for the state graph, constructs the
+(state, action, next_state, semantics) tuple, and preserves provenance end-to-end.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional
+
+from igc.ds.sources.base import SourceRecord, TrustLevel
+
+
+def compact_resource(body: Dict[str, Any]) -> Dict[str, Any]:
+    """Build a small faithful summary of a Redfish resource body.
+
+    The full body remains in ``response``; this summary keeps the state graph light.
+
+    :param body: Full Redfish response body (a JSON-like dict).
+    :return: Dict with keys ``@odata.id``, ``@odata.type``, and ``keys`` (sorted
+        top-level keys that do not start with ``@``).  If *body* is not a dict or is
+        empty, ``@odata.id`` and ``@odata.type`` default to ``""`` and ``keys`` to ``[]``.
+    """
+    if not isinstance(body, dict) or not body:
+        return {"@odata.id": "", "@odata.type": "", "keys": []}
+
+    return {
+        "@odata.id": body.get("@odata.id", ""),
+        "@odata.type": body.get("@odata.type", ""),
+        "keys": sorted(k for k in body if not k.startswith("@")),
+    }
+
+
+@dataclass
+class TrainingExample:
+    """Uniform (state, action, next_state, semantics) tuple with provenance.
+
+    For a GET observation the resource graph is unchanged by the read, so
+    ``resource_graph_after`` is a separate-but-equal copy of ``resource_graph_before``.
+    """
+
+    source: str
+    trust_level: TrustLevel
+    schema_version: str
+    resource_graph_before: Dict[str, Dict[str, Any]]
+    request_or_action: Dict[str, Any]
+    response: Dict[str, Any]
+    resource_graph_after: Dict[str, Dict[str, Any]]
+    allowed_methods: List[str]
+    expected_semantics: Dict[str, Any]
+    vendor: Optional[str]
+    provenance: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a JSON-serializable dict representation of the training example.
+
+        ``trust_level`` is emitted as its ``.name`` string (e.g. ``"REAL"``); all other
+        fields are returned as-is.
+
+        :return: Dict suitable for JSON serialization.
+        """
+        return {
+            "source": self.source,
+            "trust_level": self.trust_level.name,
+            "schema_version": self.schema_version,
+            "resource_graph_before": self.resource_graph_before,
+            "request_or_action": self.request_or_action,
+            "response": self.response,
+            "resource_graph_after": self.resource_graph_after,
+            "allowed_methods": self.allowed_methods,
+            "expected_semantics": self.expected_semantics,
+            "vendor": self.vendor,
+            "provenance": self.provenance,
+        }
+
+
+def normalize_record(record: SourceRecord) -> TrainingExample:
+    """Convert a single GET-observation SourceRecord into a TrainingExample.
+
+    :param record: SourceRecord carrying a Redfish GET response and provenance.
+    :return: TrainingExample with compacted resource graph, request metadata, and
+        derived semantics.
+    """
+    graph: Dict[str, Dict[str, Any]] = {record.url: compact_resource(record.response)}
+
+    method_upper = record.method.upper()
+    mutating = method_upper not in ("GET", "HEAD")
+    allowed = record.allowed_methods or []
+
+    expected_semantics: Dict[str, Any] = {
+        "method": method_upper,
+        "mutating": mutating,
+        "read_only": not mutating,
+        "idempotent": method_upper in ("GET", "HEAD", "PUT", "DELETE"),
+        "expected_status": 200,
+        "mutable_endpoint": any(
+            m.upper() in ("POST", "PATCH", "PUT", "DELETE") for m in allowed
+        ),
+    }
+
+    return TrainingExample(
+        source=record.source,
+        trust_level=record.trust_level,
+        schema_version=record.schema_version,
+        resource_graph_before=graph,
+        request_or_action={
+            "method": record.method,
+            "url": record.url,
+            "body": None,
+        },
+        response=record.response,
+        resource_graph_after=dict(graph),  # separate-but-equal copy
+        allowed_methods=allowed,
+        expected_semantics=expected_semantics,
+        vendor=record.vendor,
+        provenance=record.provenance,
+    )
+
+
+def normalize(records: Iterable[SourceRecord]) -> List[TrainingExample]:
+    """Normalize an iterable of SourceRecords into a list of TrainingExamples.
+
+    :param records: Iterable of SourceRecord objects (typically GET observations).
+    :return: List of TrainingExample instances, one per input record.
+    """
+    return [normalize_record(r) for r in records]
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/igc/modules/base/igc_base_module.py
+++ b/igc/modules/base/igc_base_module.py
@@ -663,7 +663,7 @@ class IgcModule(IgcBaseState):
         """
 
         if self._module_checkpoint_dir is None:
-            return CheckpointState(0, None, 0, -float('-inf'), 0)
+            return CheckpointState(0, None, 0, float('-inf'), 0)
 
         scheduler = None
         map_to = {'cuda:1': 'cuda:0'} if map_location is None else map_location
@@ -671,7 +671,7 @@ class IgcModule(IgcBaseState):
         checkpoint_file = self.checkpoint_file(checkpoint_dir, resuming)
         if not checkpoint_file:
             self.logger.info(f"No checkpoint files found checkpoint dir {checkpoint_dir}")
-            return CheckpointState(0, None, 0, -float('-inf'), 0)
+            return CheckpointState(0, None, 0, float('-inf'), 0)
 
         self.logger.info(f"Found latest checkpoint, loading {checkpoint_file}.")
         checkpoint = torch.load(checkpoint_file)
@@ -693,7 +693,7 @@ class IgcModule(IgcBaseState):
 
         if not hasattr(self.model, 'load_state_dict'):
             warnings.warn("Model does not have load_state_dict method. ")
-            return CheckpointState(0, None, 0, -float('-inf'), 0)
+            return CheckpointState(0, None, 0, float('-inf'), 0)
 
         self.model.load_state_dict(checkpoint['model_state_dict'])
 
@@ -702,7 +702,7 @@ class IgcModule(IgcBaseState):
             if 'optimizer_state_dict' in checkpoint:
                 if not hasattr(self.optimizer, 'load_state_dict'):
                     warnings.warn("Optimizer does not have load_state_dict method. ")
-                    return CheckpointState(0, None, 0, -float('-inf'), 0)
+                    return CheckpointState(0, None, 0, float('-inf'), 0)
                 self.optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
 
                 if lr is not None:
@@ -719,7 +719,7 @@ class IgcModule(IgcBaseState):
                     if self.scheduler is not None:
                         if not hasattr(self.scheduler, 'load_state_dict'):
                             warnings.warn("Scheduler does not have load_state_dict method. ")
-                            return CheckpointState(0, None, 0, -float('-inf'), 0)
+                            return CheckpointState(0, None, 0, float('-inf'), 0)
                         self.scheduler.load_state_dict(checkpoint['scheduler_state_dict'])
 
                 elif 'scheduler_state_dicts' in checkpoint:
@@ -730,7 +730,7 @@ class IgcModule(IgcBaseState):
                                 checkpoint['scheduler_state_dicts']):
                             if not hasattr(self.scheduler[idx], 'load_state_dict'):
                                 warnings.warn("Scheduler does not have load_state_dict method. ")
-                                return CheckpointState(0, None, 0, -float('-inf'), 0)
+                                return CheckpointState(0, None, 0, float('-inf'), 0)
                             self.scheduler[idx].load_state_dict(scheduler_state_dict)
 
         last_accuracy = checkpoint['last_accuracy'] if "last_accuracy" in checkpoint else float('-inf')

--- a/igc/modules/base/igc_base_module.py
+++ b/igc/modules/base/igc_base_module.py
@@ -674,7 +674,7 @@ class IgcModule(IgcBaseState):
             return CheckpointState(0, None, 0, float('-inf'), 0)
 
         self.logger.info(f"Found latest checkpoint, loading {checkpoint_file}.")
-        checkpoint = torch.load(checkpoint_file)
+        checkpoint = torch.load(checkpoint_file, map_location=map_to)
 
         required_keys = ['model_state_dict', 'epoch']
         if resuming:
@@ -783,7 +783,7 @@ class IgcModule(IgcBaseState):
                 last_file = last_checkpoint_file
 
         if last_file is None:
-            print(f"No checkpoint or module file found")
+            print("No checkpoint or module file found")
             return 0, False
 
         print(f"Found model file {last_file} loading mapping to {map_to}")
@@ -865,7 +865,7 @@ class IgcModule(IgcBaseState):
             self.logger.debug("Memory allocated:", mem_get_info["allocated_bytes.all.current"] / 1024 ** 3, "GB")
             # additional CUDA statistics if available
             if hasattr(torch.cuda, 'utilization'):
-                self.logger.debug(f"CUDA utilization:", torch.cuda.utilization())
+                self.logger.debug("CUDA utilization:", torch.cuda.utilization())
             if hasattr(torch.cuda, 'memory_summary'):
                 torch.cuda.memory_summary()
 

--- a/igc/modules/igc_experience_buffer.py
+++ b/igc/modules/igc_experience_buffer.py
@@ -77,12 +77,22 @@ class Buffer:
 
         Tolerates plain ``bool``/scalar done values (the ``add`` default) by
         broadcasting them to each sample's reward shape, so a terminal mask is
-        always available even for experiences added without one.
+        always available even for experiences added without one. Tensor done
+        flags whose shape differs from the reward (e.g. a scalar ``[]`` mixed
+        with a ``[1]``) are coerced to the reward shape so ``torch.stack`` never
+        fails on ragged entries.
         """
         done_items = []
         for sample, reward in zip(samples, reward_batch):
             done = sample[4] if len(sample) > 4 else False
             if not torch.is_tensor(done):
                 done = torch.full_like(reward, float(bool(done)))
+            elif done.shape != reward.shape:
+                done = done.to(reward.dtype)
+                done = (
+                    done.reshape(reward.shape)
+                    if done.numel() == reward.numel()
+                    else torch.full_like(reward, float(done.reshape(-1)[0]))
+                )
             done_items.append(done)
         return torch.stack(done_items, dim=0)

--- a/igc/modules/igc_train_agent.py
+++ b/igc/modules/igc_train_agent.py
@@ -1,8 +1,9 @@
 """
+Train the legacy Redfish DQN agent with HER relabeling.
 
-This class is used to train a RL agent.
-It consists two trainer, auto encoder used to
-reduce state encoder dimensionality , and RL trainer.
+This module owns rollout collection, replay-buffer updates, DQN targets, and
+target-network synchronization for ``IgcAgentTrainer``. Autoencoder setup is
+orchestrated outside this file by the RL module wiring.
 
 Author:Mus mbayramo@stanford.edu
 """
@@ -28,8 +29,12 @@ from igc.modules.rl.q_targets import q_learning_target, relabel_future
 
 def env_reward_function(state, goal):
     """
-    Reward function for the goal_all_4_trajectory_reward_state_goal_single_trajectory method.
-    Rewards +1 when at least one state matches the goal state, and -1 otherwise.
+    Return a binary reward for states that match the goal tensor.
+
+    :param state: Batched environment state tensor.
+    :param goal: Goal state tensor to compare against each row in ``state``.
+    :return: Reward vector with ``1.0`` when any state row matches the goal,
+        otherwise ``0.0``.
     """
     # print(f"state {state.shape} {goal.shape}")
     is_goal_reached = torch.any(torch.all(state == goal, dim=1), dim=0)
@@ -41,24 +46,10 @@ def env_reward_function(state, goal):
 
 class IgcAgentTrainer(RlBaseModule):
     """
-    A class representing the IGC Agent Trainer.
+    Collect goal-conditioned REST rollouts and train the legacy DQN policy.
 
-    :param module_name: The name of the module.
-    :type module_name: str
-    :param spec: The specifications for the trainer.
-    :type spec: argparse.Namespace
-    :param llm_model: The LLM model for training.
-    :type llm_model: torch.nn.Module
-    :param llm_tokenizer: The LLM tokenizer for training.
-    :type llm_tokenizer: PreTrainedTokenizer
-    :param env: The vectorized REST API environment.
-    :type env: VectorizedRestApiEnv
-    :param ds: The JSONDataset for training, if available.
-    :type ds: Optional[JSONDataset]
-    :param metric_logger: The metric logger for tracking training metrics, if available.
-    :type metric_logger: Optional[MetricLogger]
-    :param is_inference: Flag indicating whether the trainer is for inference.
-    :type is_inference: Optional[bool]
+    The trainer owns replay insertion, HER relabeling, target-network sync, and
+    epoch-level metric logging for the current one-hot action path.
     """
 
     def __init__(self,
@@ -72,13 +63,17 @@ class IgcAgentTrainer(RlBaseModule):
                  is_inference: Optional[bool] = False,
                  device=None):
         """
-        :param module_name:
-        :param spec:
-        :param llm_model:
-        :param llm_tokenizer:
-        :param ds:
-        :param metric_logger:
-        :param is_inference:
+        Initialize the DQN trainer, target network, and replay buffer.
+
+        :param module_name: Stable module name used for logging and checkpoint paths.
+        :param spec: Training configuration namespace parsed by the shared CLI.
+        :param llm_model: LLM module used by the base trainer contract.
+        :param llm_tokenizer: Tokenizer paired with ``llm_model``.
+        :param env: Vectorized REST environment used for rollout collection.
+        :param ds: Optional Redfish JSON dataset used for sampled REST actions.
+        :param metric_logger: Optional metric sink for training metrics.
+        :param is_inference: Whether the trainer is being built for inference.
+        :param device: Torch device for networks and sampled batches.
         """
         super().__init__(
             module_name,
@@ -184,7 +179,8 @@ class IgcAgentTrainer(RlBaseModule):
         """
         Create rest api action, that consists of one hot vector for rest api
         and one hot vector for http method.
-        :return:
+
+        :return: Tuple of encoded action tensor, REST API path, and supported methods.
         """
         rest_api, http_supported_method, one_hot_action = self.dataset.sample_rest_api()
         action = RestApiEnv.concat_rest_api_method(
@@ -194,9 +190,11 @@ class IgcAgentTrainer(RlBaseModule):
 
     def _create_goal(self, http_method: Optional[str] = "GET") -> dict:
         """
-        Sample a goal from the dataset.
+        Sample a goal from the vectorized REST environment.
 
-        :return:
+        :param http_method: HTTP method associated with the sampled goal.
+        :return: Goal dictionary with state, REST APIs, action vector, method,
+            and parameters fields consumed by the rollout loop.
         """
         goal_state, action_vector, rest_apis, supported_methods = self.env.sample_same_goal()
         goal = {
@@ -211,7 +209,10 @@ class IgcAgentTrainer(RlBaseModule):
 
     def train_goal(self, epsilon=0.0):
         """
-        :return:
+        Roll out one goal-conditioned episode with epsilon-greedy actions.
+
+        :param epsilon: Probability of sampling a random action instead of the policy action.
+        :return: Episode transitions, cumulative reward, and reached-goal count.
         """
         _state, info = self.env.reset(
             goal=self.current_goal["state"],
@@ -268,8 +269,6 @@ class IgcAgentTrainer(RlBaseModule):
                     num_classes=num_rest_api_methods
                 ).float().float().detach().cpu()
 
-                at_most_one_1_rest_api = torch.sum(rest_api_one_hot == 1) <= 1
-                at_most_one_1_rest_api_method = torch.sum(rest_api_method_one_hot == 1) <= 1
                 concatenated_vector = torch.cat([rest_api_one_hot, rest_api_method_one_hot], dim=1)
 
             next_state, rewards, done, truncated, info = self.env.step(concatenated_vector)
@@ -292,9 +291,9 @@ class IgcAgentTrainer(RlBaseModule):
 
     def update_replay_buffer(self, episode_experience):
         """
+        Insert episode transitions and HER relabeled transitions into replay.
 
-        :param episode_experience:
-        :return:
+        :param episode_experience: Sequence of rollout tuples from ``train_goal``.
         """
         num_experiences_added = 0
         for timestep in range(len(episode_experience)):
@@ -329,8 +328,7 @@ class IgcAgentTrainer(RlBaseModule):
 
     def train(self):
         """
-
-        :return:
+        Train the DQN policy with rollout collection, HER relabeling, and target updates.
         """
         # epsilon = 0
         epsilon = 0.98

--- a/igc/modules/igc_train_agent.py
+++ b/igc/modules/igc_train_agent.py
@@ -232,10 +232,13 @@ class IgcAgentTrainer(RlBaseModule):
         rewards_per_trajectory = []
 
         i = 0
-        terminated = [False] * self.env.num_envs
-        truncated = [False] * self.env.num_envs
+        # VectorizedRestApiEnv.step returns ``done`` (goal reached or horizon truncation)
+        # as its third value. Stop the rollout as soon as any env reports the episode is
+        # over; previously ``terminated`` was never updated and the loop always ran to
+        # ``max_episode_len``, replaying past-terminal transitions under the same goal.
+        done = [False] * self.env.num_envs
 
-        while (not any(terminated) or not any(truncated)) and i < self.max_episode_len:
+        while not any(done) and i < self.max_episode_len:
 
             goal_state = self.current_goal["state"]
             state_flat = _state.view(_state.size(0), -1)
@@ -271,8 +274,7 @@ class IgcAgentTrainer(RlBaseModule):
 
                 concatenated_vector = torch.cat([rest_api_one_hot, rest_api_method_one_hot], dim=1)
 
-            next_state, rewards, done, truncated, info = self.env.step(concatenated_vector)
-            print(rewards)
+            next_state, rewards, done, terminated, info = self.env.step(concatenated_vector)
             next_state_flat = next_state.view(next_state.size(0), -1).detach().cpu()
             episode_experience.append(
                 (state_flat, concatenated_vector, rewards, next_state_flat, goal_state_flat)
@@ -285,7 +287,6 @@ class IgcAgentTrainer(RlBaseModule):
         goal_reached_flags = [goals['goal_reached'].item() for goals in info]
         goal_reached_count = sum(goal_reached_flags)
 
-        print("Done")
         rewards_sum_per_trajectory = torch.stack(rewards_per_trajectory, dim=0).sum(dim=0)
         return episode_experience, torch.sum(rewards_sum_per_trajectory, dim=0), goal_reached_count
 

--- a/igc/modules/igc_train_auto_state_encoder.py
+++ b/igc/modules/igc_train_auto_state_encoder.py
@@ -1,11 +1,10 @@
 """
-This class is used to train a state auto encoder.
+Train the state autoencoder over backbone hidden states.
 
-Here is idea. We take REST API and pass to GPT
-We take hidden representation and pass 1D conv layer with kernel size 2
-That essentially create a polling layer with stride 2
-We pass the two an encoder and reduce the dimension to fixed size block
-Then do standard autoencoder procedure and reconstruct.
+Tokenized Redfish batches are encoded by the configured Hugging Face backbone
+module, then ``AutoStateEncoder`` reconstructs the resulting hidden-state
+tensor. The trainer keeps backbone access shape-driven through
+``igc.modules.encoders.backbone_utils``.
 
 Author:Mus mbayramo@stanford.edu
 """
@@ -28,10 +27,7 @@ import torch.nn.functional as F
 
 class AutoencoderTrainer(IgcModule):
     """
-
-    Autoencoder trainer used to train the autoencoder to reduce
-    state dimension of latent space llm outputs.
-
+    Train an autoencoder over backbone hidden states for compact state features.
     """
     def __init__(self,
                  module_name: str,
@@ -43,12 +39,16 @@ class AutoencoderTrainer(IgcModule):
                  is_inference: Optional[bool] = False,
                  device: Optional[torch.device] = None):
         """
-        :param module_name: Name of the module.
-        :param spec: Specifications for trainer
-        :param llm_model:
-        :param llm_tokenizer:
-        :param ds: dataset
-        :param metric_logger: trainer metric logger
+        Initialize the backbone sampler, autoencoder, and optimizer.
+
+        :param module_name: Stable module name used for logging and checkpoints.
+        :param spec: Training configuration namespace parsed by the shared CLI.
+        :param llm_model: Backbone model that produces hidden states to reconstruct.
+        :param llm_tokenizer: Tokenizer paired with ``llm_model``.
+        :param ds: Redfish JSON dataset used for autoencoder batches.
+        :param metric_logger: Optional metric sink for reconstruction metrics.
+        :param is_inference: Whether to skip training-only setup in the base module.
+        :param device: Torch device used for hidden states and autoencoder tensors.
         """
         super().__init__(
             module_name,
@@ -91,10 +91,10 @@ class AutoencoderTrainer(IgcModule):
 
     def _get_reconstruction_loss(self, batch):
         """
-        Compute reconstruction loss
+        Compute per-element reconstruction loss for a tuple-style tensor batch.
 
-        :param batch:
-        :return:
+        :param batch: Tuple whose first item is the tensor to reconstruct.
+        :return: Per-element mean squared reconstruction loss from ``self.model``.
         """
         x, _ = batch
         x_hat = self.model.forward(x)
@@ -103,7 +103,7 @@ class AutoencoderTrainer(IgcModule):
 
     def encode(self):
         """
-        :return:
+        Attach a simple autoencoder encoder weight to the model embeddings.
         """
         input_dim = self.model.config.hidden_size
         latent_dim = 128
@@ -116,9 +116,10 @@ class AutoencoderTrainer(IgcModule):
 
     @staticmethod
     def custom_collate_fn(samples):
-        """Collate data before we pass to the model.
-        :param samples:
-        :return:
+        """Stack tokenized samples into a model batch.
+
+        :param samples: Dataset rows containing ``input_ids`` and ``attention_mask``.
+        :return: Batch dictionary with tensor values stacked on the leading axis.
         """
         included_keys = ['input_ids', 'attention_mask']
         batch = {key: torch.stack([s[key] for s in samples]) for key in included_keys}
@@ -126,6 +127,12 @@ class AutoencoderTrainer(IgcModule):
 
     @torch.no_grad()
     def sample(self, batch):
+        """
+        Encode one tokenized batch into hidden states.
+
+        :param batch: Tokenized batch accepted by the backbone model.
+        :return: Last hidden state tensor on the trainer device.
+        """
         with torch.no_grad():
             output = self._encoder_model(**batch)
         return output.last_hidden_state.to(self.device)
@@ -133,7 +140,9 @@ class AutoencoderTrainer(IgcModule):
     @torch.no_grad()
     def sample_all(self):
         """
-        :return:
+        Encode the training split into a list of CPU hidden-state tensors.
+
+        :return: List of detached hidden-state tensors sampled from the training split.
         """
         train_dataset, _ = self.split_slice_dataset()
         train_dataloader = DataLoader(
@@ -156,11 +165,10 @@ class AutoencoderTrainer(IgcModule):
 
     def measure_reconstruction(self, test_data):
         """
-        Measure the reconstruction performance
-        of the autoencoder on the test data.
+        Measure autoencoder reconstruction over hidden-state tensor batches.
 
-        :param test_data: Test dataset
-        :return: Average reconstruction loss
+        :param test_data: Iterable of tensors shaped for ``self.model_autoencoder``.
+        :return: Average reconstruction loss across the provided batches.
         """
         self.model_autoencoder.eval()
         total_loss = 0.0
@@ -178,7 +186,7 @@ class AutoencoderTrainer(IgcModule):
 
     def train(self):
         """
-        :return:
+        Train the autoencoder and save the resulting model.
         """
         self.logger.info(
             f"Rank {self.rank} starting train, device {self.device}")
@@ -190,7 +198,7 @@ class AutoencoderTrainer(IgcModule):
 
         # torch.cuda.empty_cache()
 
-        self.logger.info(f"Starting training")
+        self.logger.info("Starting training")
         train_dataloader = DataLoader(
             self.dataset,
             batch_size=self.batch_size,

--- a/igc/modules/llm_train_state_encoder.py
+++ b/igc/modules/llm_train_state_encoder.py
@@ -62,6 +62,25 @@ def build_causal_lm_labels(input_ids, attention_mask, pad_token_id=None):
     return labels
 
 
+def is_accum_boundary(micro_step_index: int, accum_steps: int, total_batches: int) -> bool:
+    """Whether a manually-accumulated optimizer step should fire on this micro-batch.
+
+    Used on the plain (non-accelerator) path, which has no accumulation wrapper: fire every
+    ``accum_steps`` micro-batches, and always on the final batch of the epoch so a trailing
+    partial accumulation window is flushed rather than silently dropped. Over one epoch this
+    yields ``ceil(total_batches / accum_steps)`` optimizer steps.
+
+    :param micro_step_index: zero-based index of the current micro-batch within the epoch.
+    :param accum_steps: gradient accumulation steps (coerced to ``>= 1``).
+    :param total_batches: number of micro-batches in the epoch.
+    :return: ``True`` to run optimizer.step()/scheduler.step()/zero_grad() now.
+    """
+    accum_steps = max(1, accum_steps)
+    reached_window = (micro_step_index + 1) % accum_steps == 0
+    is_last_batch = (micro_step_index + 1) == total_batches
+    return reached_window or is_last_batch
+
+
 class LlmEmbeddingsTrainer(LlmModule):
     """
     Large language model trainer. Its main job train a language
@@ -110,7 +129,12 @@ class LlmEmbeddingsTrainer(LlmModule):
         self._save_freq = 16
 
         self._is_shuffle = True
-        self._pin_memory = False if "pin_memory" not in spec else spec.pin_memory
+        # pin_memory enables overlapped host->device copies (helps only on GPU). The real
+        # flag is --dataloader_pin_memory; the old "pin_memory" key never existed on spec,
+        # so this was always False. Default it on when CUDA is present (the launcher does
+        # not emit the flag) and honor an explicit --dataloader_pin_memory.
+        self._pin_memory = bool(
+            getattr(spec, "dataloader_pin_memory", False)) or torch.cuda.is_available()
         self._reset_lr = False if "reset_lr" not in spec else spec.reset_lr
         self._num_workers = spec.num_workers
         self._lr = spec.llm_learning_rate
@@ -444,6 +468,13 @@ class LlmEmbeddingsTrainer(LlmModule):
         calculated_total_batches = dataset_size // self.batch_size
         batch_log_frequency = round(64 * 0.2)
 
+        # Gradient accumulation. On the plain path we step every `accum` micro-batches; under
+        # accelerate the prepared optimizer/scheduler gate themselves and accelerator.backward()
+        # scales the loss, so `accum` here only drives the manual (non-accelerator) path.
+        accum = max(1, int(getattr(self._trainer_args, "gradient_accumulation_steps", 1)))
+        if self.is_rank_zero():
+            self.logger.info(f"Gradient accumulation steps: {accum}")
+
         if total_batches == calculated_total_batches:
             print(f"Rank {self.rank}, Staring training, "
                   f"total_batches: {total_batches} "
@@ -464,8 +495,9 @@ class LlmEmbeddingsTrainer(LlmModule):
 
             for _, batch in enumerate(train_dataloader):
 
-                input_ids = batch['input_ids'].to(self.device)
-                attention_mask = batch['attention_mask'].to(self.device)
+                input_ids = batch['input_ids'].to(self.device, non_blocking=self._pin_memory)
+                attention_mask = batch['attention_mask'].to(
+                    self.device, non_blocking=self._pin_memory)
 
                 # Full-length labels: a HF CausalLM shifts internally (loss over
                 # logits[:-1] vs labels[1:]). Pre-shifting the target here as well
@@ -481,19 +513,35 @@ class LlmEmbeddingsTrainer(LlmModule):
                     'labels': labels,
                 }
 
-                outputs = self.model(**batch_inputs)
-                loss = outputs.loss
-
-                self.optimizer.zero_grad()
                 if self.is_accelerator:
-                    self.accelerator.backward(loss)
+                    # Accelerate owns accumulation: accelerator.backward() scales the loss by
+                    # gradient_accumulation_steps (DeepSpeed scales internally), and the prepared
+                    # optimizer/scheduler no-op on non-boundary micro-batches, so stepping every
+                    # iteration inside accumulate() is correct.
+                    with self.accelerator.accumulate(self.model):
+                        outputs = self.model(**batch_inputs)
+                        loss = outputs.loss
+                        self.accelerator.backward(loss)
+                        self.optimizer.step()
+                        self.scheduler.step()
+                        self.optimizer.zero_grad()
+                    is_step = self.accelerator.sync_gradients
                 else:
-                    loss.backward()
+                    # Plain path has no wrapper: accumulate by hand. Scale the loss by accum,
+                    # backward every micro-batch, and only step on the accumulation boundary so
+                    # --gradient_accumulation_steps is actually honored (it was ignored before).
+                    outputs = self.model(**batch_inputs)
+                    loss = outputs.loss
+                    (loss / accum).backward()
+                    is_step = is_accum_boundary(num_batches, accum, total_batches)
+                    if is_step:
+                        self.optimizer.step()
+                        self.scheduler.step()
+                        self.optimizer.zero_grad()
 
-                self.optimizer.step()
-                self.scheduler.step()
-
-                if self.is_rank_zero():
+                # Log once per real optimizer step so the curves track optimizer steps, not
+                # micro-batches. grad_norm here is measure-only (max_norm=inf never clips).
+                if is_step and self.is_rank_zero():
                     step = epoch * total_batches + num_batches
                     current_lr = self.optimizer.param_groups[0]['lr']
                     grad_norm = torch.nn.utils.clip_grad_norm_(
@@ -504,9 +552,7 @@ class LlmEmbeddingsTrainer(LlmModule):
 
                 batch_losses[num_batches] = loss.item()
                 total_loss += loss.item()
-                torch.cuda.empty_cache()
 
-                #
                 if self._is_quantize:
                     self.model.apply(torch.quantization.propagate_qconfig_)
                     self.model.apply(torch.nn.intrinsic.qat.freeze_bn_stats)

--- a/igc/modules/llm_train_state_encoder.py
+++ b/igc/modules/llm_train_state_encoder.py
@@ -247,6 +247,12 @@ class LlmEmbeddingsTrainer(LlmModule):
 
     @staticmethod
     def compute_perplexity(logits, labels):
+        """
+
+        :param logits:
+        :param labels:
+        :return:
+        """
         probabilities = F.softmax(logits, dim=-1)
         log_probabilities = torch.log(probabilities)
         loss = F.nll_loss(log_probabilities.view(-1, logits.size(-1)), labels.view(-1))
@@ -656,6 +662,160 @@ class LlmEmbeddingsTrainer(LlmModule):
         del self.optimizer
 
         print("Embedding extractor training complete.")
+
+    def cpu_train_pass(
+            self,
+            mask_type: List[Union[MaskingOption, MaskingType]] = None
+    ):
+        """Train LLM model to map high level goal to redfish actions.
+
+        :return:
+        """
+
+        self.model.resize_token_embeddings(
+            len(self.dataset.tokenizer)
+        )
+
+        self.logger.info(
+            f"Rank {self.rank} starting train, device {self.device}")
+
+        lr = self._lr if self._reset_lr else None
+        sampler = self.dataset_sampler()
+
+        self.logger.info(f"Creating dataloader "
+                         f"batch size {self.batch_size} "
+                         f"num worker {self._num_workers}")
+
+        train_data, eval_data = self.split_dataset()
+
+        train_dataloader = DataLoader(
+            train_data,
+            batch_size=self.batch_size,
+            sampler=sampler,
+            num_workers=self._num_workers,
+            shuffle=self._is_shuffle,
+            pin_memory=self._pin_memory,
+            collate_fn=LlmEmbeddingsTrainer.custom_collate_fn
+        )
+
+        eval_dataloader = DataLoader(
+            eval_data,
+            batch_size=self.batch_size,
+            sampler=sampler,
+            num_workers=self._num_workers,
+            shuffle=False,
+            drop_last=True,
+            pin_memory=self._pin_memory,
+            collate_fn=LlmEmbeddingsTrainer.custom_collate_fn,
+        )
+
+        last_epoch = 0
+        self._trainer_args.epochs = self.num_epochs - last_epoch
+        self._trainer_args.steps_per_epoch = len(train_dataloader)
+
+        print(self._trainer_args.epochs)
+        print(self._trainer_args.steps_per_epoch)
+
+        self.scheduler = TorchBuilder.create_scheduler(
+            self._trainer_args.llm_scheduler,
+            optimizer=self.optimizer,
+            **vars(self._trainer_args)
+        )
+
+        self.logger.info(f"Rank {self.rank}: "
+                         f"Memory utilization after we loaded model: "
+                         f"{torch.cuda.max_memory_allocated() / 1024 ** 3:.2f} GB")
+
+        if self._is_quantize:
+            self.model.qconfig = torch.quantization.get_default_qconfig('fbgemm')
+
+        total_batches = len(train_dataloader)
+        dataset_size = len(train_data)
+        calculated_total_batches = dataset_size // self.batch_size
+        batch_log_frequency = round(64 * 0.2)
+
+        if total_batches == calculated_total_batches:
+            print(f"Rank {self.rank}, Staring training, "
+                  f"total_batches: {total_batches} "
+                  f"train dataset size: {dataset_size} "
+                  f"batch_size {self.batch_size} "
+                  f"current lr {self._lr} "
+                  f"batch stats freq: {batch_log_frequency}.")
+
+        for epoch in range(last_epoch, self.num_epochs):
+            self.model.train()
+
+            total_loss = 0.0
+            num_batches = 0
+            batch_losses = np.zeros(total_batches)
+
+            # swap mask and pass a batch
+            self.swap_masking_method(epoch, mask_type)
+
+            for _, batch in enumerate(train_dataloader):
+
+                input_ids = batch['input_ids']
+                attention_mask = batch['attention_mask']
+
+                # Full-length labels; the HF CausalLM does the single internal shift.
+                # Pre-shifting here as well (the old target_ids = input_ids[:, 1:] +
+                # truncated input) double-shifts and trains for two-tokens-ahead — the
+                # same correction applied in _train via build_causal_lm_labels.
+                labels = build_causal_lm_labels(
+                    input_ids, attention_mask, self.tokenizer.pad_token_id)
+
+                batch_inputs = {
+                    'input_ids': input_ids,
+                    'attention_mask': attention_mask,
+                    'labels': labels,
+                }
+
+                outputs = self.model(**batch_inputs)
+                loss = outputs.loss
+
+                self.optimizer.zero_grad()
+                loss.backward()
+                self.optimizer.step()
+                self.scheduler.step()
+
+                current_lr = self.optimizer.param_groups[0]['lr']
+                self.metric_logger.log_metric("learning_rate", current_lr, epoch)
+
+                batch_losses[num_batches] = loss.item()
+                total_loss += loss.item()
+
+                # calculate the progress percentage
+                progress_percentage = int(round((num_batches + 1) / total_batches * 100))
+                if (num_batches % batch_log_frequency == 0) or (num_batches == total_batches - 1):
+                    lr = self.optimizer.param_groups[0]['lr']
+                    print(f"Rank {self.rank} Epoch {epoch + 1}/{self.num_epochs} - Batch "
+                          f"{num_batches + 1}/{total_batches} "
+                          f"- Progress: {progress_percentage:.2f}% - "
+                          f"Batch Loss mean: {batch_losses.mean():.4f} - lr: {lr:.5f}")
+                    self.metric_logger.log_metric("llm_emb_batch_loss", batch_losses.mean(), epoch)
+
+                num_batches += 1
+                self._current_mask_method_counter += 1
+
+            # validation on epoch or freq
+            if self.on_epoch_eval or ((epoch + 1) % self._eval_freq == 0):
+                validation_accuracy = self.validate(eval_dataloader)
+                if self.is_rank_zero():
+                    self.metric_logger.log_metric("llm_emb_accuracy", validation_accuracy, epoch)
+                    # self.metric_logger.log_metric("llm_emb_perplexity", perplexity, epoch)
+
+                print(f"Rank {self.rank} Epoch {epoch + 1} - Validation Accuracy: "
+                      f"{validation_accuracy} Best: {self._best_validation_metric}")
+
+            if num_batches > 0:
+                average_loss = total_loss / num_batches
+                if self.is_rank_zero():
+                    self.metric_logger.log_metric("llm_emb_epoch_loss", average_loss, epoch)
+                print(f"Rank {self.rank} Epoch {epoch + 1}/{self.num_epochs} - Average Loss: {average_loss}")
+
+        del train_dataloader
+        del eval_dataloader
+        del self.optimizer
 
     def train(self):
         """Train loop for the fine running.

--- a/igc/modules/llm_train_state_encoder.py
+++ b/igc/modules/llm_train_state_encoder.py
@@ -81,6 +81,20 @@ def is_accum_boundary(micro_step_index: int, accum_steps: int, total_batches: in
     return reached_window or is_last_batch
 
 
+def reached_max_steps(global_step: int, max_steps: Optional[int]) -> bool:
+    """Whether training should stop because the optimizer-step cap is reached.
+
+    ``--max_train_steps`` caps the number of OPTIMIZER updates (not micro-batches). A value of
+    ``None`` or ``<= 0`` means no cap. Without this check ``_train`` loops ``num_train_epochs``
+    (default 1000) and silently ignores the step cap.
+
+    :param global_step: optimizer steps taken so far this run.
+    :param max_steps: the configured cap, or ``None`` / ``<= 0`` for uncapped.
+    :return: ``True`` when ``max_steps`` is a positive int and ``global_step >= max_steps``.
+    """
+    return max_steps is not None and max_steps > 0 and global_step >= max_steps
+
+
 class LlmEmbeddingsTrainer(LlmModule):
     """
     Large language model trainer. Its main job train a language
@@ -475,6 +489,11 @@ class LlmEmbeddingsTrainer(LlmModule):
         if self.is_rank_zero():
             self.logger.info(f"Gradient accumulation steps: {accum}")
 
+        # Honor --max_train_steps: cap OPTIMIZER updates. Without this the loop runs
+        # num_train_epochs (default 1000) and ignores the cap entirely.
+        max_steps = getattr(self._trainer_args, "max_train_steps", None)
+        global_opt_steps = 0
+
         if total_batches == calculated_total_batches:
             print(f"Rank {self.rank}, Staring training, "
                   f"total_batches: {total_batches} "
@@ -484,6 +503,8 @@ class LlmEmbeddingsTrainer(LlmModule):
                   f"batch stats freq: {batch_log_frequency}.")
 
         for epoch in range(last_epoch, self.num_epochs):
+            if reached_max_steps(global_opt_steps, max_steps):
+                break
             self.model.train()
 
             total_loss = 0.0
@@ -550,6 +571,9 @@ class LlmEmbeddingsTrainer(LlmModule):
                     self.metric_logger.log_metric("train/lr", current_lr, step)
                     self.metric_logger.log_metric("train/grad_norm", grad_norm, step)
 
+                if is_step:
+                    global_opt_steps += 1
+
                 batch_losses[num_batches] = loss.item()
                 total_loss += loss.item()
 
@@ -568,6 +592,9 @@ class LlmEmbeddingsTrainer(LlmModule):
 
                 num_batches += 1
                 self._current_mask_method_counter += 1
+
+                if reached_max_steps(global_opt_steps, max_steps):
+                    break
 
             # one monotonic step at the epoch boundary for per-epoch metrics
             epoch_step = (epoch + 1) * total_batches - 1

--- a/igc/modules/llm_train_state_encoder.py
+++ b/igc/modules/llm_train_state_encoder.py
@@ -1,18 +1,10 @@
 """
-This class is used to train a goal extractor from input query.
+Train the language-model state encoder on masked Redfish JSON examples.
 
-Given input text provided by the user, or external system.
-The goal is to extract a goal for the agent and parameters
-that agent need used.
-
-For example given input text: "Update raid with raid0"
-The goal here update raid configuration and the
-parameter is raid0.
-
-In downstream task the goal encoded as one hot vector.
-This what used to train RL agent.
-
-Parameters just passed to agent. i.e. we don't train on parameters.
+The ``MaskedJSONDataset`` provided by ``igc.ds.redfish_masked_dataset`` supplies
+tokenized REST response sequences and masking callbacks. This trainer applies a
+next-token objective, cycles the configured masking methods, and saves
+fine-tuned language-model checkpoints for downstream state encoding.
 
 Author:Mus mbayramo@stanford.edu
 """
@@ -41,8 +33,10 @@ from igc.ds.redfish_masked_dataset import (
 
 class LlmEmbeddingsTrainer(LlmModule):
     """
-    Large language model trainer. Its main job train a language
-    model for fine-tuning a latent representation
+    Train a language model on masked Redfish JSON sequences.
+
+    The trainer fine-tunes the configured causal model with dataset-controlled
+    masking methods and reports loss, accuracy, perplexity, and scheduler state.
     """
 
     def __init__(self,
@@ -55,13 +49,16 @@ class LlmEmbeddingsTrainer(LlmModule):
                  is_inference=False,
                  device=None):
         """
-        Note that tokenizer must IGC since we extend it to support masking , JSON etc
+        Initialize model, optimizer, masking schedule, and training controls.
 
-        :param llm_model:
-        :param llm_tokenizer:
-        :param spec: specs for llm trainer
-        :param dataset: Union[JSONDataset, MaskedJSONDataset].
-        :param metric_logger:  a metric logger used to log training progress
+        :param module_name: Stable module name used for logging and checkpoints.
+        :param spec: Training configuration namespace parsed by the shared CLI.
+        :param llm_model: Causal language model to fine-tune.
+        :param llm_tokenizer: Tokenizer paired with ``llm_model`` and the dataset.
+        :param dataset: Masked JSON dataset that owns masking callbacks.
+        :param metric_logger: Optional metric sink for training and evaluation metrics.
+        :param is_inference: Whether to skip training-only setup in the base module.
+        :param device: Torch device used for model and batch tensors.
         """
         super().__init__(
             module_name,
@@ -132,14 +129,16 @@ class LlmEmbeddingsTrainer(LlmModule):
         self._masking_method_dispatcher = LlmEmbeddingsTrainer.create_masking_method(dataset)
 
     def get_model(self) -> PreTrainedModel:
-        """Return module model.
-        :return:
+        """Return the underlying language model.
+
+        :return: The model managed by this trainer.
         """
         return self.model
 
     def get_tokenizer(self) -> PreTrainedTokenizer:
-        """Return module model.
-        :return:
+        """Return the dataset tokenizer, loading it on demand when needed.
+
+        :return: Tokenizer used for Redfish JSON training examples.
         """
         if self.dataset.tokenizer is None:
             self.dataset.load_tokenizer()
@@ -148,9 +147,10 @@ class LlmEmbeddingsTrainer(LlmModule):
 
     @staticmethod
     def custom_collate_fn(samples):
-        """Collate data before we pass to the model.
-        :param samples:
-        :return:
+        """Stack tokenized samples into a model batch.
+
+        :param samples: Dataset rows containing ``input_ids`` and ``attention_mask``.
+        :return: Batch dictionary with tensor values stacked on the leading axis.
         """
         included_keys = ['input_ids', 'attention_mask']
         batch = {key: torch.stack([s[key] for s in samples]) for key in included_keys}
@@ -165,9 +165,11 @@ class LlmEmbeddingsTrainer(LlmModule):
     @staticmethod
     def get_batch(src: Tensor, idx: int, chunk_size=35) -> Tuple[Tensor, Tensor]:
         """
+        Slice a language-model training window and its shifted target.
+
         :param src: [full_seq_len, batch_size]
-        :param idx
-        :param chunk_size:
+        :param idx: Starting index in ``src``.
+        :param chunk_size: Maximum sequence length for the returned window.
         :return: tuple (data, target),  shape [seq_len, batch_size], [seq_len * batch_size]
         """
         seq_len = min(chunk_size, len(src) - 1 - idx)
@@ -177,7 +179,9 @@ class LlmEmbeddingsTrainer(LlmModule):
 
     def dataset_sampler(self):
         """
-        :return:
+        Build the optional dataset sampler configured by trainer arguments.
+
+        :return: ``RandomSampler`` when random sampling is enabled, otherwise ``None``.
         """
         if 'random_sampler_enabled' in self._trainer_args:
             sampler = RandomSampler(self.dataset) if self._trainer_args.random_sampler_enabled else None
@@ -193,10 +197,10 @@ class LlmEmbeddingsTrainer(LlmModule):
         return perplexity
 
     def validate(self, validation_dataset):
-        """ Perform validation on the emb llm model.
+        """Perform validation on the embedding language model.
 
-        :param validation_dataset: Dataset for validation
-        :return: Accuracy on the validation dataset
+        :param validation_dataset: Iterable validation dataloader of tokenized batches.
+        :return: Accuracy percentage on the validation dataset.
         """
 
         self.model.eval()
@@ -234,13 +238,17 @@ class LlmEmbeddingsTrainer(LlmModule):
 
     def is_distributed(self):
         """
-        :return:
+        Check whether this trainer is running under distributed execution.
+
+        :return: ``True`` when the local rank indicates distributed training.
         """
         return self.rank != -1
 
     def is_rank_zero(self):
         """
-        :return:
+        Check whether the current process should emit rank-zero side effects.
+
+        :return: ``True`` for single-process execution or distributed rank zero.
         """
         return self.rank == -1 or self.rank == 0
 
@@ -248,7 +256,9 @@ class LlmEmbeddingsTrainer(LlmModule):
     def create_masking_method(dataset: MaskedJSONDataset):
         """
         Return dict that store all callable masking methods.
-        :return:
+
+        :param dataset: Masked dataset that provides masking callbacks.
+        :return: Mapping from masking enum values to dataset callback methods.
         """
         masking_methods = {
             MaskingType.MASK_SECTION: dataset.mask_section,
@@ -272,7 +282,8 @@ class LlmEmbeddingsTrainer(LlmModule):
     ):
         """
         Receive mask enum and dispatch to its callback.
-        :param mask_type:
+
+        :param mask_type: Masking enum to activate for subsequent dataset samples.
         """
         if mask_type in self.masking_methods:
             print(f"Got mask type {mask_type}")
@@ -286,16 +297,15 @@ class LlmEmbeddingsTrainer(LlmModule):
             mask_type: List[Union[MaskingOption, MaskingType]] = None
     ):
         """
-        Switch to masking method to next masking method after every epoch freq
-        dictated by self._masked_freq.
+        Enable the next masking method at the configured epoch boundary.
 
-        For example if we have 2 masking method let say mask freq is 2
-        then we will switch to first method , on next epoch we will switch to off
-        on third epoch we will switch to second method.
+        A new method is activated only when ``(epoch + 1)`` is divisible by
+        ``self._masked_freq`` and the batch counter is reset. After
+        ``self._num_mask_passed`` batches, masking is disabled and the counter
+        is reset for the next cycle.
 
-        So we cycle between methods.
-
-        :return:
+        :param epoch: Zero-based epoch index used to decide when to swap masks.
+        :param mask_type: Ordered masking methods to cycle through.
         """
         if (epoch + 1) % self._masked_freq == 0 and self._current_mask_method_counter == 0:
             # switch to masking pass, mask freq how fast i.e after epoch
@@ -314,9 +324,9 @@ class LlmEmbeddingsTrainer(LlmModule):
             self,
             mask_type: List[Union[MaskingOption, MaskingType]] = None
     ):
-        """Train LLM model to map high level goal to redfish actions.
+        """Train the language model with shifted-token Redfish JSON targets.
 
-        :return:
+        :param mask_type: Masking methods active during the training schedule.
         """
 
         self.model.resize_token_embeddings(
@@ -564,8 +574,7 @@ class LlmEmbeddingsTrainer(LlmModule):
         print("Embedding extractor training complete.")
 
     def train(self):
-        """Train loop for the fine running.
-        :return:
+        """Run the fine-tuning loop with the configured masking schedule.
         """
 
         self._train(
@@ -578,9 +587,11 @@ class LlmEmbeddingsTrainer(LlmModule):
             attention_mask: torch.Tensor
     ):
         """
-        :param input_ids:
-        :param attention_mask:
-        :return:
+        Decode non-padding tokens for each sequence in a masked batch.
+
+        :param input_ids: Token id tensor shaped ``[batch, sequence]``.
+        :param attention_mask: Attention mask for the same batch, kept for API symmetry.
+        :return: List of decoded strings without padding tokens.
         """
         decoded_batch = []
         for batch_idx in range(input_ids.shape[0]):
@@ -598,6 +609,11 @@ class LlmEmbeddingsTrainer(LlmModule):
     def custom_loss(
             logits: torch.tensor, targets: torch.tensor) -> torch.tensor:
         """
+        Compute cross-entropy for classification or shifted token generation.
+
+        :param logits: Model output logits.
+        :param targets: Target labels aligned with ``logits``.
+        :return: Cross-entropy loss with ignored padding labels.
         """
         if logits.dim() == 2:
             return F.cross_entropy(logits, targets, ignore_index=-100)
@@ -618,12 +634,16 @@ class LlmEmbeddingsTrainer(LlmModule):
             original_mask: torch.Tensor
     ):
         """
-        Computes  accuracy for either sequence classification or generation.
+        Compute raw class or shifted-token accuracy.
 
-        :param logits:
-        :param targets:
-        :param original_mask:
-        :return:
+        The sequence path averages over all shifted positions produced by the
+        current implementation. ``original_mask`` is accepted for API
+        compatibility, but it is not applied inside this helper.
+
+        :param logits: Model output logits.
+        :param targets: Target ids or labels aligned with ``logits``.
+        :param original_mask: Original attention mask for the unshifted batch.
+        :return: Mean raw token or class accuracy.
         """
         if logits.dim() == 2:
             y = torch.argmax(logits, dim=-1) == targets
@@ -643,10 +663,9 @@ class LlmEmbeddingsTrainer(LlmModule):
 
     def test_inference(self):
         """
-          Does inference pass for entire dataset used for validation
-          and report all metrics.
+        Run inference over the validation split and report aggregate metrics.
 
-        :return:
+        :return: Tuple of accuracy percentage and perplexity.
         """
         train_data, eval_data = self.split_dataset()
         sampler = self.dataset_sampler()

--- a/igc/modules/rl/q_targets.py
+++ b/igc/modules/rl/q_targets.py
@@ -36,13 +36,24 @@ def q_learning_target(
         (the goal was reached). This is NOT truncation: an episode cut for a time
         or step limit must keep bootstrapping, so its ``done`` stays 0.0.
     :param next_q: target-network Q-values for the next state, shape ``[B, A]``.
+        Illegal actions may be masked to ``-inf`` (the pointer-policy legality
+        convention). A row that is *entirely* ``-inf`` is a dead-end next state
+        with no legal action; it is treated as terminal — no bootstrap — so the
+        target stays finite (``max`` over an all-``-inf`` row is ``-inf``).
     :param gamma: discount factor.
-    :return: the target tensor, shape ``[B]``. At a terminal the bootstrap term is
-        masked out, so the target equals ``reward`` — a ``+1`` success is preserved
+    :return: the target tensor, shape ``[B]``. At a terminal (``done=1`` or a
+        dead-end next state with no legal action) the bootstrap term is masked
+        out, so the target equals ``reward`` — a ``+1`` success is preserved
         instead of being clipped to ``<= 0`` as the legacy code did.
     """
     done = done.to(reward.dtype)
     max_next_q = next_q.max(dim=-1).values
+    # A next state with no legal action (all actions masked to -inf) is a dead
+    # end: treat it as terminal so we don't bootstrap a non-finite value into
+    # the target. max_next_q is -inf exactly for those all-masked rows.
+    dead_end = ~torch.isfinite(max_next_q)
+    max_next_q = torch.where(dead_end, torch.zeros_like(max_next_q), max_next_q)
+    done = torch.where(dead_end, torch.ones_like(done), done)
     return reward + gamma * (1.0 - done) * max_next_q
 
 

--- a/igc/shared/shared_accelerator.py
+++ b/igc/shared/shared_accelerator.py
@@ -24,6 +24,13 @@ import argparse
 
 _ZERO_STAGE = {"zero2": 2, "zero3": 3, "zero3_offload": 3}
 
+# Sharding modes this builder knows how to wire. The CLI restricts ``--sharding`` to this
+# set (:mod:`igc.shared.shared_arg_parser`), but :func:`sharding_config` also runs on
+# Namespaces built directly (train profiles, config-driven launches, tests) that bypass the
+# parser, so it validates too — an unknown mode must fail fast rather than silently produce a
+# ``sharded`` run with ``zero_stage=None`` (a broken DeepSpeed plugin on a real GB300 job).
+_VALID_SHARDING = ("none", "ddp", "zero2", "zero3", "zero3_offload", "fsdp")
+
 
 def sharding_config(cmd: argparse.Namespace) -> dict:
     """Pure mapping of CLI flags to a sharding/precision config (no accelerate import).
@@ -34,8 +41,13 @@ def sharding_config(cmd: argparse.Namespace) -> dict:
         ``none``/``ddp`` (plain replication) and True for any ZeRO/FSDP mode; a sharded run
         defaults to ``bf16`` and disables Accelerate ``device_placement`` (DeepSpeed/FSDP
         place the model themselves).
+    :raises ValueError: if ``sharding`` is not one of :data:`_VALID_SHARDING`.
     """
     sharding = getattr(cmd, "sharding", "none") or "none"
+    if sharding not in _VALID_SHARDING:
+        raise ValueError(
+            f"Unsupported sharding mode {sharding!r}; expected one of {_VALID_SHARDING}"
+        )
     mixed_precision = getattr(cmd, "mixed_precision", None)
     sharded = sharding not in ("none", "ddp")
     if mixed_precision is None and sharded:

--- a/scripts/submit_train.sh
+++ b/scripts/submit_train.sh
@@ -8,7 +8,7 @@
 #   IGC_MODEL=<hf-id> IGC_USE_PEFT=1 EPOCHS=3 ./scripts/submit_train.sh m1
 #   ./scripts/submit_train.sh m6 -w gb300-poc1-slot7   # pin to a node where data is staged
 #
-# Never targets slot2 (Flash), slot15 (download), slot16 (down).
+# Never targets slot2 (Flash), slot15/.55 (Pro, TP=4 — busy), slot16 (down). slot1/.41 is also down.
 
 set -euo pipefail
 
@@ -33,7 +33,7 @@ echo "== per-node GRES + state =="
 sinfo -o "%n %G %t" || true
 
 echo
-echo "Reminder: Slurm cannot see the out-of-band Flash containers. Before a long run, confirm your"
+echo "Reminder: Slurm cannot see the out-of-band Flash/Pro containers. Before a long run, confirm your"
 echo "target node is truly free:  ssh nvidia@<node> nvidia-smi   (a Flash replica sits on its GPU 0)."
 echo "Excluding: ${EXCLUDE}"
 echo

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,69 @@
+"""Shared offline pytest fixtures for the igc test suite.
+
+This module provides a deterministic, CPU-only ``StubEncoder`` and matching
+fixtures so tests that need a state/observation encoder do not have to build
+one inline (and do not pull a real HuggingFace backbone). The encoder mirrors
+the small surface ``igc.envs.rest_gym_env.RestApiEnv`` expects from
+``RestBaseEncoder``: a ``(model, tokenizer)`` constructor, an ``emb_shape``
+attribute, and an ``encode(str) -> torch.Tensor`` method whose output depends
+only on the input string (deterministic, no randomness, no I/O).
+
+Fixtures exposed:
+
+- ``stub_encoder_cls`` — the ``StubEncoder`` class, e.g. for
+  ``monkeypatch.setattr(rest_gym_env, "RestBaseEncoder", stub_encoder_cls)``.
+- ``stub_encoder`` — a ready ``StubEncoder`` instance.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import pytest
+import torch
+
+
+class StubEncoder:
+    """Deterministic, dependency-free stand-in for the state encoder.
+
+    The encoder returns a tensor of shape :attr:`emb_shape` whose values are a
+    fixed ramp offset by a hash of the observation string, so equal inputs map
+    to equal outputs and different inputs (almost always) differ. It records
+    every observation it was asked to encode in :attr:`calls` so tests can
+    assert on what the environment fed it.
+
+    :param model: ignored; accepted for constructor parity with the real encoder.
+    :param tokenizer: ignored; accepted for constructor parity.
+    """
+
+    emb_shape = (2, 3)
+
+    def __init__(self, model=None, tokenizer=None) -> None:
+        self.model = model
+        self.tokenizer = tokenizer
+        self.calls: list[str] = []
+
+    def encode(self, observation: str) -> torch.Tensor:
+        """Encode an observation string into a deterministic embedding.
+
+        :param observation: the observation text (e.g. a Redfish JSON body).
+        :return: a ``float32`` tensor of shape :attr:`emb_shape`.
+        """
+        self.calls.append(observation)
+        size = int(torch.tensor(self.emb_shape).prod().item())
+        seed = sum(observation.encode("utf-8")) % 97
+        return torch.arange(size, dtype=torch.float32).reshape(self.emb_shape) + seed
+
+
+@pytest.fixture
+def stub_encoder_cls() -> type[StubEncoder]:
+    """Return the :class:`StubEncoder` class for monkeypatching a real encoder."""
+    return StubEncoder
+
+
+@pytest.fixture
+def stub_encoder() -> StubEncoder:
+    """Return a fresh :class:`StubEncoder` instance."""
+    return StubEncoder()
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/ds/test_corpus_io.py
+++ b/tests/ds/test_corpus_io.py
@@ -1,0 +1,104 @@
+"""
+Offline tests for the training-corpus JSONL writer/reader.
+
+Pins that examples round-trip through JSONL equal to their to_dict() form, that iter_examples
+streams and skips blank lines, that the manifest sidecar round-trips, that write_corpus emits
+both files with a correct count, and that empty input and nested output dirs are handled. Pure
+stdlib + tmp_path — no torch, no network.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+from pathlib import Path
+
+from igc.ds.sources.base import SourceRecord, TrustLevel
+from igc.ds.sources.corpus_io import (
+    iter_examples,
+    read_examples,
+    read_manifest,
+    write_corpus,
+    write_examples,
+    write_manifest,
+)
+from igc.ds.sources.mixer import SourceMix
+from igc.ds.sources.training_object import normalize
+
+
+class _FakeSource:
+    """Minimal source yielding fixed records (avoids the logger base in tests)."""
+
+    def __init__(self, source, trust_level, records):
+        self.source = source
+        self.trust_level = trust_level
+        self._records = records
+
+    def iter_records(self):
+        return iter(self._records)
+
+
+def _examples(n=5):
+    """n normalized TrainingExamples from synthetic REAL records."""
+    recs = [SourceRecord(url=f"/redfish/v1/R/{i}", response={"@odata.id": f"/redfish/v1/R/{i}",
+                         "@odata.type": "#T", "Id": str(i)}, source="real_dell",
+                         trust_level=TrustLevel.REAL, allowed_methods=["GET"], vendor="dell")
+            for i in range(n)]
+    return normalize(recs)
+
+
+def test_examples_round_trip(tmp_path: Path):
+    """write_examples then read_examples reconstructs the to_dict() forms in order."""
+    exs = _examples(4)
+    path = str(tmp_path / "examples.jsonl")
+    assert write_examples(exs, path) == 4
+    back = read_examples(path)
+    assert back == [e.to_dict() for e in exs]
+    assert back[0]["trust_level"] == "REAL"
+
+
+def test_iter_examples_streams_and_skips_blank_lines(tmp_path: Path):
+    """iter_examples yields a generator and ignores blank/whitespace lines."""
+    path = tmp_path / "e.jsonl"
+    path.write_text('{"a": 1}\n\n   \n{"a": 2}\n')
+    it = iter_examples(str(path))
+    assert iter(it) is it  # a generator, not a materialized list
+    assert list(it) == [{"a": 1}, {"a": 2}]
+
+
+def test_manifest_round_trips(tmp_path: Path):
+    """write_manifest/read_manifest preserve the manifest fields."""
+    mix = SourceMix([_FakeSource("real_dell", TrustLevel.REAL,
+                                 [SourceRecord(url=f"/r/{i}", response={}, source="real_dell",
+                                               trust_level=TrustLevel.REAL) for i in range(6)])],
+                    eval_fraction=0.2, seed=1)
+    m = mix.manifest()
+    path = str(tmp_path / "manifest.json")
+    write_manifest(m, path)
+    loaded = read_manifest(path)
+    assert loaded["total"] == 6
+    assert loaded["by_source"] == {"real_dell": 6}
+    assert loaded["eval_trust_floor"] == "REAL"
+
+
+def test_write_corpus_emits_both_files(tmp_path: Path):
+    """write_corpus writes examples.jsonl + manifest.json into out_dir with a count."""
+    exs = _examples(7)
+    mix = SourceMix([_FakeSource("real_dell", TrustLevel.REAL,
+                                 [SourceRecord(url=f"/r/{i}", response={}, source="real_dell",
+                                               trust_level=TrustLevel.REAL) for i in range(7)])])
+    out = tmp_path / "corpus"
+    paths = write_corpus(exs, mix.manifest(), str(out))
+    assert paths["count"] == "7"
+    assert (out / "examples.jsonl").exists() and (out / "manifest.json").exists()
+    assert len(read_examples(paths["examples"])) == 7
+    assert read_manifest(paths["manifest"])["total"] == 7
+
+
+def test_empty_and_nested_dirs(tmp_path: Path):
+    """Empty input writes an empty file; missing parent dirs are created."""
+    nested = str(tmp_path / "a" / "b" / "examples.jsonl")
+    assert write_examples([], nested) == 0
+    assert read_examples(nested) == []
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/ds/test_redfish_enum_space.py
+++ b/tests/ds/test_redfish_enum_space.py
@@ -1,0 +1,295 @@
+"""
+Offline tests for the Redfish enum-space extraction layer.
+
+Pins that captured resource bodies are classified by ``@odata.type`` (with URL
+fallbacks), that the three extractors reproduce the shapes observed in the real
+vendor captures — Dell/Supermicro ``#AttributeRegistry`` bodies, DMTF
+``#ActionInfo`` parameters, and inline ``@Redfish.AllowableValues`` annotations
+— and that :class:`EnumSpaceIndex` folds a record stream into ``arg_schema``
+fragments the stage-2 argument decoder consumes verbatim. Fixture bodies are
+minimal copies of the captured Dell / Supermicro / HPE shapes; pure stdlib, no
+network, no fixture trees on disk.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import json
+from pathlib import Path
+
+from igc.core.types import ToolSpec
+from igc.ds.sources import (
+    EnumSpaceIndex,
+    RedfishFixtureSource,
+    ResourceKind,
+    SourceRecord,
+    TrustLevel,
+    classify_resource,
+    normalize_enriched,
+    slots_from_action_info,
+    slots_from_attribute_registry,
+    slots_from_inline_annotations,
+    to_arg_schema,
+)
+from igc.modules.policy.argument_decoder import arg_slots_for
+
+
+def _record(url: str, body: dict, source: str = "real_dell",
+            trust: TrustLevel = TrustLevel.REAL) -> SourceRecord:
+    """Build a minimal GET-observation record around ``body``."""
+    return SourceRecord(url=url, response=body, source=source, trust_level=trust)
+
+
+def _registry_body() -> dict:
+    """A minimal ``#AttributeRegistry`` body in the captured Dell/Supermicro shape."""
+    return {
+        "@odata.type": "#AttributeRegistry.v1_3_0.AttributeRegistry",
+        "RegistryEntries": {
+            "Attributes": [
+                {"AttributeName": "ProcCStates", "Type": "Enumeration",
+                 "CurrentValue": "Disabled", "ReadOnly": False,
+                 "Value": [{"ValueName": "Enabled"}, {"ValueName": "Disabled"}]},
+                {"AttributeName": "ActiveCores", "Type": "Integer", "ReadOnly": False},
+                {"AttributeName": "SystemServiceTag", "Type": "String", "ReadOnly": True},
+            ]
+        },
+    }
+
+
+def _action_info_body() -> dict:
+    """A minimal DMTF ``#ActionInfo`` body (``Parameters[].AllowableValues``)."""
+    return {
+        "@odata.type": "#ActionInfo.v1_4_2.ActionInfo",
+        "Id": "ResetActionInfo",
+        "Parameters": [
+            {"Name": "ResetType", "Required": True, "DataType": "String",
+             "AllowableValues": ["On", "ForceOff", "GracefulRestart"]},
+        ],
+    }
+
+
+def _system_body() -> dict:
+    """A minimal ``#ComputerSystem`` with inline annotations in the captured shape."""
+    return {
+        "@odata.type": "#ComputerSystem.v1_20_0.ComputerSystem",
+        "Boot": {
+            "BootSourceOverrideTarget": "None",
+            "BootSourceOverrideTarget@Redfish.AllowableValues": ["None", "Pxe", "Hdd"],
+        },
+        "Actions": {
+            "#ComputerSystem.Reset": {
+                "ResetType@Redfish.AllowableValues": ["On", "ForceOff"],
+                "target": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+            }
+        },
+    }
+
+
+def test_classify_by_odata_type() -> None:
+    """Each captured @odata.type prefix maps to its resource kind."""
+    cases = [
+        ("#Bios.v1_2_0.Bios", "/redfish/v1/Systems/1/Bios", ResourceKind.BIOS),
+        ("#AttributeRegistry.v1_3_0.AttributeRegistry", "/x", ResourceKind.ATTRIBUTE_REGISTRY),
+        ("#MessageRegistryFile.v1_0_4.MessageRegistryFile", "/x", ResourceKind.REGISTRY_FILE),
+        ("#BootOptionCollection.BootOptionCollection", "/x", ResourceKind.BOOT_OPTION_COLLECTION),
+        ("#BootOption.v1_0_4.BootOption", "/x", ResourceKind.BOOT_OPTION),
+        ("#ActionInfo.v1_4_2.ActionInfo", "/x", ResourceKind.ACTION_INFO),
+        ("#ComputerSystem.v1_20_0.ComputerSystem", "/x", ResourceKind.COMPUTER_SYSTEM),
+        ("#Chassis.v1_25_0.Chassis", "/x", ResourceKind.OTHER),
+    ]
+    for odata_type, url, expected in cases:
+        assert classify_resource(url, {"@odata.type": odata_type}) is expected
+
+
+def test_classify_bios_pending_by_settings_url() -> None:
+    """A #Bios body at .../Bios/Settings is the pending-settings resource (any case)."""
+    body = {"@odata.type": "#Bios.v1_2_0.Bios"}
+    assert classify_resource(
+        "/redfish/v1/Systems/1/Bios/Settings", body) is ResourceKind.BIOS_PENDING
+    assert classify_resource(
+        "/redfish/v1/systems/1/bios/settings", body) is ResourceKind.BIOS_PENDING
+    assert classify_resource("/redfish/v1/Systems/1/Bios", body) is ResourceKind.BIOS
+
+
+def test_classify_url_fallback_without_odata_type() -> None:
+    """Old-firmware captures without @odata.type classify from the URL."""
+    assert classify_resource("/redfish/v1/systems/1/bios", {}) is ResourceKind.BIOS
+    assert classify_resource(
+        "/redfish/v1/systems/1/bios/settings", {}) is ResourceKind.BIOS_PENDING
+    assert classify_resource(
+        "/redfish/v1/Systems/1/BootOptions", {}) is ResourceKind.BOOT_OPTION_COLLECTION
+    assert classify_resource(
+        "/redfish/v1/Systems/1/BootOptions/1", {}) is ResourceKind.BOOT_OPTION
+    assert classify_resource("/redfish/v1/Chassis/1", {}) is ResourceKind.OTHER
+
+
+def test_registry_enumeration_yields_categorical_slot() -> None:
+    """An Enumeration registry attribute becomes a categorical slot with its values."""
+    slots = {s.name: s for s in slots_from_attribute_registry("/reg", _registry_body())}
+    slot = slots["ProcCStates"]
+    assert slot.choices == ("Enabled", "Disabled")
+    assert slot.type == "string" and not slot.read_only
+    assert slot.current_value == "Disabled"
+    assert slot.extracted_from == "registry"
+
+
+def test_registry_non_enum_types_yield_typed_freeform_slots() -> None:
+    """Integer/String registry attributes become typed slots without choices."""
+    slots = {s.name: s for s in slots_from_attribute_registry("/reg", _registry_body())}
+    assert slots["ActiveCores"].type == "integer" and slots["ActiveCores"].choices is None
+    assert slots["SystemServiceTag"].type == "string"
+    assert slots["SystemServiceTag"].read_only
+
+
+def test_registry_pointer_and_malformed_entries_yield_nothing() -> None:
+    """An HPE-style registry pointer (no RegistryEntries) and junk entries yield no slots."""
+    pointer = {"@odata.type": "#MessageRegistryFile.v1_0_4.MessageRegistryFile",
+               "Location": [{"Language": "en", "Uri": "/registrystore/x"}]}
+    assert slots_from_attribute_registry("/reg", pointer) == []
+    junk = {"RegistryEntries": {"Attributes": ["not-a-dict", {"Type": "Enumeration"}]}}
+    assert slots_from_attribute_registry("/reg", junk) == []
+    assert slots_from_attribute_registry("/reg", {"RegistryEntries": {}}) == []
+
+
+def test_registry_enum_without_value_names_degrades_to_freeform() -> None:
+    """An Enumeration attribute with an empty/malformed Value list has no choices."""
+    body = {"RegistryEntries": {"Attributes": [
+        {"AttributeName": "Odd", "Type": "Enumeration", "Value": []},
+        {"AttributeName": "Odder", "Type": "Enumeration", "Value": ["bare-string"]},
+    ]}}
+    slots = {s.name: s for s in slots_from_attribute_registry("/reg", body)}
+    assert slots["Odd"].choices is None
+    assert slots["Odder"].choices is None
+
+
+def test_action_info_parameters_become_required_categorical_slots() -> None:
+    """ActionInfo Parameters carry name, required, type, and allowable values."""
+    (slot,) = slots_from_action_info("/ai", _action_info_body())
+    assert slot.name == "ResetType" and slot.required
+    assert slot.choices == ("On", "ForceOff", "GracefulRestart")
+    assert slot.extracted_from == "action_info"
+    assert slots_from_action_info("/ai", {"Parameters": []}) == []
+    assert slots_from_action_info("/ai", {}) == []
+
+
+def test_inline_annotations_record_dotted_path() -> None:
+    """@Redfish.AllowableValues anywhere in a body yield slots with their location."""
+    slots = {s.path: s for s in slots_from_inline_annotations("/sys", _system_body())}
+    boot = slots["Boot.BootSourceOverrideTarget"]
+    assert boot.choices == ("None", "Pxe", "Hdd")
+    assert boot.current_value == "None"
+    reset = slots["Actions.#ComputerSystem.Reset.ResetType"]
+    assert reset.choices == ("On", "ForceOff")
+    assert slots_from_inline_annotations("/sys", {"Boot": {}}) == []
+
+
+def test_index_routes_kinds_and_splits_action_vs_settings() -> None:
+    """The index buckets registry, action, and patchable-property slots separately."""
+    index = EnumSpaceIndex.from_records([
+        _record("/redfish/v1/Systems/1/Bios/BiosRegistry", _registry_body()),
+        _record("/redfish/v1/Systems/1", _system_body()),
+        _record("/redfish/v1/Systems/1/ResetActionInfo", _action_info_body()),
+    ])
+    patch = index.patch_arg_schema()["PATCH"]
+    assert patch["ProcCStates"]["enum"] == ["Enabled", "Disabled"]
+    assert patch["BootSourceOverrideTarget"]["enum"] == ["None", "Pxe", "Hdd"]
+    assert "SystemServiceTag" not in patch  # read-only never patchable
+    post = index.post_arg_schema()["POST"]
+    assert post["ResetType"]["enum"] == ["On", "ForceOff", "GracefulRestart"]
+    assert post["ResetType"]["required"] is True
+    assert index.by_kind == {"ATTRIBUTE_REGISTRY": 1, "COMPUTER_SYSTEM": 1, "ACTION_INFO": 1}
+
+
+def test_index_counts_registry_pointers_without_slots() -> None:
+    """HPE registry pointers are counted but contribute no slots."""
+    pointer = {"@odata.type": "#MessageRegistryFile.v1_0_4.MessageRegistryFile",
+               "Location": [{"Language": "en", "Uri": "/registrystore/x"}]}
+    index = EnumSpaceIndex.from_records([_record("/redfish/v1/Registries/U58", pointer)])
+    assert index.num_registry_pointers == 1
+    assert index.patch_arg_schema() == {"PATCH": {}}
+
+
+def test_boot_option_references_dedupe_in_order() -> None:
+    """BootOption records build the ordered unique BootOrder id space."""
+    def boot(ref: str) -> dict:
+        return {"@odata.type": "#BootOption.v1_0_4.BootOption",
+                "Id": ref, "BootOptionReference": ref}
+    index = EnumSpaceIndex.from_records([
+        _record("/redfish/v1/Systems/1/BootOptions/1", boot("Boot0005")),
+        _record("/redfish/v1/Systems/1/BootOptions/2", boot("Boot0002")),
+        _record("/redfish/v1/Systems/1/BootOptions/3", boot("Boot0005")),  # dup
+        _record("/redfish/v1/Systems/1/BootOptions/4",
+                {"@odata.type": "#BootOption.v1_0_4.BootOption", "Id": "Boot0009"}),
+    ])
+    assert index.boot_reference_space() == ("Boot0005", "Boot0002", "Boot0009")
+
+
+def test_first_seen_wins_on_duplicate_slot_names() -> None:
+    """Feeding higher-trust records first keeps their fragment on a name clash."""
+    real = _registry_body()
+    sim = {"RegistryEntries": {"Attributes": [
+        {"AttributeName": "ProcCStates", "Type": "Enumeration",
+         "Value": [{"ValueName": "Simulated"}]},
+    ]}}
+    index = EnumSpaceIndex.from_records([
+        _record("/real/reg", real),
+        _record("/sim/reg", sim, source="sim", trust=TrustLevel.SIM_GENERIC),
+    ])
+    assert index.patch_arg_schema()["PATCH"]["ProcCStates"]["enum"] == ["Enabled", "Disabled"]
+
+
+def test_extracted_schema_round_trips_through_argument_decoder() -> None:
+    """The exported arg_schema is consumed verbatim by the stage-2 decoder."""
+    index = EnumSpaceIndex.from_records([
+        _record("/redfish/v1/Systems/1/ResetActionInfo", _action_info_body()),
+    ])
+    spec = ToolSpec(tool_name="redfish", ops=["POST"], arg_schema=index.post_arg_schema())
+    (slot,) = arg_slots_for(spec, "POST")
+    assert slot.name == "ResetType" and slot.is_categorical and slot.required
+    assert slot.choices == ("On", "ForceOff", "GracefulRestart")
+
+
+def test_index_over_fixture_source_stream(tmp_path: Path) -> None:
+    """End-to-end: a capture directory feeds the index through RedfishFixtureSource."""
+    root = tmp_path / "capture"
+    root.mkdir()
+    files = {
+        "_redfish_v1_Systems_1_Bios_BiosRegistry.json": _registry_body(),
+        "_redfish_v1_Systems_1.json": dict(_system_body(),
+                                           **{"@odata.id": "/redfish/v1/Systems/1"}),
+    }
+    for name, body in files.items():
+        (root / name).write_text(json.dumps(body))
+    source = RedfishFixtureSource(str(root), "real_dell", TrustLevel.REAL, vendor="dell")
+    index = EnumSpaceIndex.from_records(source)
+    patch = index.patch_arg_schema()["PATCH"]
+    assert set(patch) == {"ProcCStates", "ActiveCores", "BootSourceOverrideTarget"}
+    assert index.post_arg_schema()["POST"]["ResetType"]["enum"] == ["On", "ForceOff"]
+
+
+def test_normalize_enriched_stamps_resource_kind() -> None:
+    """Enriched normalization tags each example with its classified kind."""
+    examples = normalize_enriched([
+        _record("/redfish/v1/Systems/1/Bios",
+                {"@odata.type": "#Bios.v1_2_0.Bios", "Attributes": {"BootMode": "Uefi"}}),
+        _record("/redfish/v1/Chassis/1", {"@odata.type": "#Chassis.v1_25_0.Chassis"}),
+    ])
+    assert examples[0].expected_semantics["resource_kind"] == "bios"
+    assert examples[1].expected_semantics["resource_kind"] == "other"
+    # the base normalization contract is preserved
+    assert examples[0].expected_semantics["read_only"] is True
+    assert examples[0].to_dict()["expected_semantics"]["resource_kind"] == "bios"
+
+
+def test_to_arg_schema_fragment_shape() -> None:
+    """Fragments carry type/required and a list enum only when categorical."""
+    from igc.ds.sources import EnumSlot
+    schema = to_arg_schema("PATCH", [
+        EnumSlot(name="A", type="string", choices=("x", "y")),
+        EnumSlot(name="B", type="integer"),
+    ])
+    assert schema == {"PATCH": {"A": {"type": "string", "required": False, "enum": ["x", "y"]},
+                                "B": {"type": "integer", "required": False}}}
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/ds/test_redfish_fixture_source.py
+++ b/tests/ds/test_redfish_fixture_source.py
@@ -79,6 +79,36 @@ def test_allowed_methods_matched_by_url(tmp_path: Path) -> None:
     assert by_url["/redfish/v1/Chassis/1"].allowed_methods is None  # not in map
 
 
+def test_allowed_methods_match_filename_fallback_url(tmp_path: Path) -> None:
+    """The .npy method map still applies when URL comes from the filename."""
+    amap = {"/redfish/v1/Chassis/1": ["GET", "HEAD"]}
+    src = RedfishFixtureSource(str(_corpus(tmp_path)), "real_dell", TrustLevel.REAL,
+                               allowed_methods_map=amap)
+    rec = next(r for r in src.iter_records()
+               if r.provenance["file"] == "_redfish_v1_Chassis_1.json")
+    assert rec.url == "/redfish/v1/Chassis/1"
+    assert rec.allowed_methods == ["GET", "HEAD"]
+
+
+def test_glob_pattern_limits_selected_fixture_files(tmp_path: Path) -> None:
+    """A custom glob selects only matching corpus files and skips sidecars."""
+    root = tmp_path / "capture"
+    _write(root, "_redfish_v1_Systems_1.json",
+           {"@odata.id": "/redfish/v1/Systems/1", "Id": "1"})
+    _write(root, "_redfish_v1_Systems_2.extra.json",
+           {"@odata.id": "/redfish/v1/Systems/2", "Id": "2"})
+    _write(root, "_redfish_v1_Chassis_1.txt",
+           {"@odata.id": "/redfish/v1/Chassis/1", "Id": "1"})
+
+    src = RedfishFixtureSource(str(root), "real_dell", TrustLevel.REAL,
+                               glob_pattern="*_Systems_1.json")
+
+    recs = list(src.iter_records())
+    assert [r.url for r in recs] == ["/redfish/v1/Systems/1"]
+    assert src.num_emitted == 1
+    assert src.num_skipped == 0
+
+
 def test_url_from_filename_helper() -> None:
     """The filename->URL reconstruction strips markers and maps '_'->'/'."""
     f = RedfishFixtureSource.url_from_filename

--- a/tests/ds/test_source_mixer.py
+++ b/tests/ds/test_source_mixer.py
@@ -1,0 +1,160 @@
+"""
+Offline tests for the multi-source mixer and its trust-tier train/eval split.
+
+Independent verification of the mixer contract: deterministic hashing, dedup that keeps the
+highest-trust copy of a URL, an eval split drawn ONLY from the trusted tier (so ground truth
+is held out while synthetic tiers always train), conservation of records across the split,
+monotonic eval growth with eval_fraction, and a serializable manifest with a stable content
+hash. Pure stdlib — no torch, no network, no fixtures on disk.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import pytest
+
+from igc.ds.sources.base import SourceAdapter, SourceRecord, TrustLevel
+from igc.ds.sources.mixer import DataManifest, SourceMix, unit_hash
+
+
+class _FakeSource(SourceAdapter):
+    """A SourceAdapter that replays a fixed list of records (test double)."""
+
+    def __init__(self, source, trust_level, records):
+        super().__init__(module_name=f"fake[{source}]")
+        self.source = source
+        self.trust_level = trust_level
+        self._records = records
+
+    def iter_records(self):
+        return iter(self._records)
+
+
+def _rec(url, source, trust, vendor=None):
+    """Build a minimal SourceRecord for the mixer under test."""
+    return SourceRecord(url=url, response={"@odata.id": url}, source=source,
+                        trust_level=trust, vendor=vendor)
+
+
+def _real_source(n, source="real_dell", vendor="dell"):
+    """A source of n REAL records with distinct urls."""
+    return _FakeSource(source, TrustLevel.REAL,
+                       [_rec(f"/redfish/v1/R/{i}", source, TrustLevel.REAL, vendor) for i in range(n)])
+
+
+def test_unit_hash_deterministic_and_ranged():
+    """unit_hash is stable, lands in [0,1), and varies with key and seed."""
+    assert unit_hash("/a", 0) == unit_hash("/a", 0)
+    assert 0.0 <= unit_hash("/a", 0) < 1.0
+    assert unit_hash("/a", 0) != unit_hash("/b", 0)
+    assert unit_hash("/a", 0) != unit_hash("/a", 1)
+
+
+def test_records_dedup_keeps_highest_trust():
+    """The same url from two tiers collapses to the highest-trust copy."""
+    real = _FakeSource("real_dell", TrustLevel.REAL, [_rec("/x", "real_dell", TrustLevel.REAL)])
+    mock = _FakeSource("dmtf", TrustLevel.REPLAY, [_rec("/x", "dmtf", TrustLevel.REPLAY)])
+    mix = SourceMix([mock, real], dedup=True)  # mock first, but real must win
+    recs = mix.records()
+    assert len(recs) == 1
+    assert recs[0].trust_level is TrustLevel.REAL and recs[0].source == "real_dell"
+
+
+def test_records_no_dedup_keeps_all():
+    """dedup=False keeps every copy of a repeated url."""
+    real = _FakeSource("real_dell", TrustLevel.REAL, [_rec("/x", "real_dell", TrustLevel.REAL)])
+    mock = _FakeSource("dmtf", TrustLevel.REPLAY, [_rec("/x", "dmtf", TrustLevel.REPLAY)])
+    assert len(SourceMix([mock, real], dedup=False).records()) == 2
+
+
+def test_split_is_deterministic():
+    """Two calls to split() produce the identical partition."""
+    mix = SourceMix([_real_source(30)], eval_fraction=0.3, seed=7)
+    t1, e1 = mix.split()
+    t2, e2 = mix.split()
+    assert [r.url for r in e1] == [r.url for r in e2]
+    assert [r.url for r in t1] == [r.url for r in t2]
+
+
+def test_eval_only_from_trusted_tier():
+    """Eval holds only trust >= floor; every sub-floor record trains."""
+    real = _real_source(20)
+    sim = _FakeSource("sim", TrustLevel.SIM_GENERIC,
+                      [_rec(f"/redfish/v1/S/{i}", "sim", TrustLevel.SIM_GENERIC) for i in range(20)])
+    mix = SourceMix([real, sim], eval_fraction=0.5, eval_trust_floor=TrustLevel.REAL, seed=1)
+    train, ev = mix.split()
+    assert all(r.trust_level >= TrustLevel.REAL for r in ev)
+    assert all(r.source == "sim" for r in train if r.trust_level < TrustLevel.REAL)
+    # none of the SIM_GENERIC records may appear in eval
+    assert not any(r.source == "sim" for r in ev)
+
+
+def test_eval_fraction_zero_and_one():
+    """fraction 0 -> empty eval; fraction 1 -> all eligible records held out."""
+    real = _real_source(15)
+    assert SourceMix([real], eval_fraction=0.0).split()[1] == []
+    train, ev = SourceMix([real], eval_fraction=1.0).split()
+    assert len(ev) == 15 and train == []
+
+
+def test_split_conserves_records():
+    """train + eval is exactly records(), no loss or duplication."""
+    mix = SourceMix([_real_source(25), _FakeSource(
+        "sim", TrustLevel.SIM_VENDOR,
+        [_rec(f"/redfish/v1/S/{i}", "sim", TrustLevel.SIM_VENDOR) for i in range(10)])],
+        eval_fraction=0.4)
+    train, ev = mix.split()
+    assert sorted(r.url for r in train + ev) == sorted(r.url for r in mix.records())
+
+
+def test_eval_fraction_is_monotone_superset():
+    """A larger eval_fraction yields a superset of the smaller one's eval urls."""
+    src = _real_source(40)
+    small = {r.url for r in SourceMix([src], eval_fraction=0.2, seed=3).split()[1]}
+    large = {r.url for r in SourceMix([src], eval_fraction=0.6, seed=3).split()[1]}
+    assert small and small < large
+
+
+def test_manifest_counts_and_breakdowns():
+    """Manifest totals and by-source/trust/vendor breakdowns match the corpus."""
+    real = _real_source(12, source="real_hpe", vendor="hpe")
+    sim = _FakeSource("sim", TrustLevel.SIM_DRIFT,
+                      [_rec(f"/redfish/v1/S/{i}", "sim", TrustLevel.SIM_DRIFT, vendor=None) for i in range(8)])
+    mix = SourceMix([real, sim], eval_fraction=0.25, seed=2)
+    m = mix.manifest()
+    assert isinstance(m, DataManifest)
+    assert m.total == 20 and m.train_count + m.eval_count == 20
+    assert m.by_source == {"real_hpe": 12, "sim": 8}
+    assert m.by_trust == {"REAL": 12, "SIM_DRIFT": 8}
+    assert m.by_vendor == {"hpe": 12, "unknown": 8}
+    assert m.sources == ["real_hpe", "sim"]
+    assert m.eval_trust_floor == "REAL" and m.eval_fraction == 0.25 and m.seed == 2
+
+
+def test_manifest_content_hash_stable_and_sensitive():
+    """Identical manifests hash equal; a changed field changes the hash."""
+    a = SourceMix([_real_source(10)], eval_fraction=0.2, seed=5).manifest()
+    b = SourceMix([_real_source(10)], eval_fraction=0.2, seed=5).manifest()
+    c = SourceMix([_real_source(10)], eval_fraction=0.3, seed=5).manifest()
+    assert a.content_hash() == b.content_hash()
+    assert a.content_hash() != c.content_hash()
+
+
+def test_empty_adapters_are_safe():
+    """No adapters -> empty split and a zeroed manifest, no crash."""
+    mix = SourceMix([], eval_fraction=0.2)
+    assert mix.records() == []
+    assert mix.split() == ([], [])
+    m = mix.manifest()
+    assert m.total == 0 and m.train_count == 0 and m.eval_count == 0
+    assert m.by_source == {} and m.sources == []
+
+
+@pytest.mark.parametrize("bad", [-0.1, 1.5, 2.0])
+def test_invalid_eval_fraction_raises(bad):
+    """eval_fraction outside [0, 1] is rejected."""
+    with pytest.raises(ValueError):
+        SourceMix([], eval_fraction=bad)
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/ds/test_source_mixer.py
+++ b/tests/ds/test_source_mixer.py
@@ -157,4 +157,36 @@ def test_invalid_eval_fraction_raises(bad):
         SourceMix([], eval_fraction=bad)
 
 
+def test_eval_split_id_encodes_policy():
+    """eval_split_id depends on floor/fraction/seed, not on the corpus contents."""
+    same_policy_a = SourceMix([_real_source(5)], eval_fraction=0.15, seed=0).manifest()
+    same_policy_b = SourceMix([_real_source(9)], eval_fraction=0.15, seed=0).manifest()
+    other_fraction = SourceMix([_real_source(5)], eval_fraction=0.30, seed=0).manifest()
+    assert same_policy_a.eval_split_id() == same_policy_b.eval_split_id()
+    assert same_policy_a.eval_split_id() != other_fraction.eval_split_id()
+    assert "REAL" in same_policy_a.eval_split_id() and "0.15" in same_policy_a.eval_split_id()
+
+
+def test_to_run_manifest_fields_feed_fair_comparison():
+    """DataManifest fields populate RunManifest so the report's fairness check sees the mix."""
+    from igc.modules.train.report import ResultBundle, RunManifest, compare
+
+    dm = SourceMix([_real_source(20)], eval_fraction=0.15, seed=0).manifest()
+    dm_same = SourceMix([_real_source(20)], eval_fraction=0.15, seed=0).manifest()
+    dm_other = SourceMix([_real_source(50)], eval_fraction=0.15, seed=0).manifest()  # different corpus
+
+    fields = dm.to_run_manifest_fields()
+    assert set(fields) == {"data_manifest", "eval_split"}
+
+    b1 = ResultBundle(manifest=RunManifest(run_id="r1", profile="p", model="m",
+                      adapter_method="lora", **dm.to_run_manifest_fields()), metrics={"recall@1": 0.6})
+    b2 = ResultBundle(manifest=RunManifest(run_id="r2", profile="p", model="m",
+                      adapter_method="rslora", **dm_same.to_run_manifest_fields()), metrics={"recall@1": 0.7})
+    b3 = ResultBundle(manifest=RunManifest(run_id="r3", profile="p", model="m",
+                      adapter_method="dora", **dm_other.to_run_manifest_fields()), metrics={"recall@1": 0.9})
+
+    assert not compare([b1, b2]).fairness_issues            # same mix + policy -> fair
+    assert "data_manifest" in " ".join(compare([b1, b3]).fairness_issues)  # different mix -> flagged
+
+
 # Author: Mus mbayramo@stanford.edu

--- a/tests/ds/test_training_object.py
+++ b/tests/ds/test_training_object.py
@@ -1,0 +1,109 @@
+"""
+Offline tests for the SourceRecord -> TrainingExample normalizer.
+
+Independent verification of the normalization contract: a compact resource summary that drops
+``@``-prefixed keys, a GET observation mapped to a (state, action, next_state, semantics) tuple
+where before/after are equal-but-separate (a read does not mutate), read-only/idempotent
+semantics, ``mutable_endpoint`` derived from allowed methods, provenance carried through, and a
+JSON-serializable to_dict with the trust tier as its name. Pure stdlib — no torch, no network.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import json
+
+from igc.ds.sources.base import SourceRecord, TrustLevel
+from igc.ds.sources.training_object import (
+    TrainingExample,
+    compact_resource,
+    normalize,
+    normalize_record,
+)
+
+
+def _rec(url="/redfish/v1/Systems/1", method="GET", allowed=None, body=None,
+         trust=TrustLevel.REAL, vendor="dell"):
+    """Build a SourceRecord for the normalizer under test."""
+    if body is None:
+        body = {"@odata.id": url, "@odata.type": "#ComputerSystem.v1.ComputerSystem",
+                "Id": "1", "Name": "Sys"}
+    return SourceRecord(url=url, response=body, source="real_dell", trust_level=trust,
+                        method=method, allowed_methods=allowed, vendor=vendor,
+                        schema_version="#ComputerSystem.v1.ComputerSystem",
+                        provenance={"file": "x.json", "url_from": "odata"})
+
+
+def test_compact_resource_summarizes_and_drops_odata_keys():
+    """compact_resource keeps @odata.id/type and the sorted non-@ top-level keys."""
+    r = compact_resource({"@odata.id": "/a", "@odata.type": "#T",
+                          "Name": "n", "Id": "1", "@odata.etag": "x"})
+    assert r == {"@odata.id": "/a", "@odata.type": "#T", "keys": ["Id", "Name"]}
+
+
+def test_compact_resource_handles_empty_and_non_dict():
+    """A non-dict or empty body yields the empty summary, not a crash."""
+    empty = {"@odata.id": "", "@odata.type": "", "keys": []}
+    assert compact_resource({}) == empty
+    assert compact_resource(None) == empty
+
+
+def test_normalize_get_is_a_nonmutating_observation():
+    """A GET maps to a read-only tuple with before == after but separate objects."""
+    ex = normalize_record(_rec(allowed=["GET", "PATCH"]))
+    assert isinstance(ex, TrainingExample)
+    assert ex.request_or_action == {"method": "GET", "url": "/redfish/v1/Systems/1", "body": None}
+    assert list(ex.resource_graph_before) == ["/redfish/v1/Systems/1"]
+    assert ex.resource_graph_before == ex.resource_graph_after
+    assert ex.resource_graph_before is not ex.resource_graph_after  # equal, not aliased
+    assert ex.resource_graph_before["/redfish/v1/Systems/1"]["keys"] == ["Id", "Name"]
+
+
+def test_get_semantics_are_read_only_idempotent():
+    """expected_semantics marks a GET read-only, idempotent, non-mutating, status 200."""
+    sem = normalize_record(_rec(allowed=["GET", "PATCH"])).expected_semantics
+    assert sem["method"] == "GET"
+    assert sem["mutating"] is False and sem["read_only"] is True
+    assert sem["idempotent"] is True and sem["expected_status"] == 200
+    assert sem["mutable_endpoint"] is True  # PATCH allowed on the endpoint
+
+
+def test_mutable_endpoint_and_allowed_methods_default():
+    """mutable_endpoint is False for a read-only endpoint; None methods -> []."""
+    read_only = normalize_record(_rec(allowed=["GET"]))
+    assert read_only.expected_semantics["mutable_endpoint"] is False
+    none_methods = normalize_record(_rec(allowed=None))
+    assert none_methods.allowed_methods == []
+    assert none_methods.expected_semantics["mutable_endpoint"] is False
+
+
+def test_provenance_carried_through():
+    """source / trust / schema / vendor / provenance survive normalization."""
+    ex = normalize_record(_rec())
+    assert ex.source == "real_dell" and ex.trust_level is TrustLevel.REAL
+    assert ex.vendor == "dell" and ex.schema_version == "#ComputerSystem.v1.ComputerSystem"
+    assert ex.provenance["url_from"] == "odata"
+
+
+def test_to_dict_is_json_serializable_with_trust_name():
+    """to_dict emits the trust tier as its name and is JSON-serializable."""
+    d = normalize_record(_rec()).to_dict()
+    assert d["trust_level"] == "REAL"
+    json.dumps(d)  # must not raise
+
+
+def test_normalize_maps_over_records():
+    """normalize applies normalize_record to each record, preserving order."""
+    exs = normalize([_rec(url="/a"), _rec(url="/b")])
+    assert [list(e.resource_graph_before)[0] for e in exs] == ["/a", "/b"]
+
+
+def test_head_is_read_only_post_is_mutating():
+    """Method drives semantics: HEAD read-only/idempotent, a POST mutating/non-idempotent."""
+    head = normalize_record(_rec(method="HEAD")).expected_semantics
+    assert head["read_only"] is True and head["idempotent"] is True
+    post = normalize_record(_rec(method="POST")).expected_semantics
+    assert post["mutating"] is True and post["read_only"] is False and post["idempotent"] is False
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/envs/test_rest_gym_env_reset_step.py
+++ b/tests/envs/test_rest_gym_env_reset_step.py
@@ -1,0 +1,173 @@
+"""Offline RestApiEnv reset/step tests backed by local stubs.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import argparse
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+import igc.envs.rest_gym_env as rest_gym_env
+import torch
+from igc.envs.rest_gym_env import GoalTypeState, RestApiEnv
+from igc.envs.rest_mock_server import MockServer
+from igc.interfaces.rest_mapping_interface import RestMappingInterface
+
+
+ROOT_URI = "/redfish/v1"
+SYSTEM_URI = "/redfish/v1/Systems/1"
+
+ROOT_PAYLOAD = {
+    "@odata.id": ROOT_URI,
+    "Systems": {"@odata.id": "/redfish/v1/Systems"},
+}
+SYSTEM_PAYLOAD = {
+    "@odata.id": SYSTEM_URI,
+    "Name": "Tiny offline system",
+    "PowerState": "Off",
+}
+
+
+class StubEncoder:
+    """Deterministic encoder with the shape RestApiEnv expects."""
+
+    emb_shape = (2, 3)
+
+    def __init__(self, model=None, tokenizer=None) -> None:
+        self.model = model
+        self.tokenizer = tokenizer
+        self.calls: list[str] = []
+
+    def encode(self, observation: str) -> torch.Tensor:
+        self.calls.append(observation)
+        seed = sum(observation.encode("utf-8")) % 97
+        return torch.arange(6, dtype=torch.float32).reshape(self.emb_shape) + seed
+
+
+class TinyRestMapping(RestMappingInterface):
+    """Small RestMappingInterface double with action lookup helpers."""
+
+    def __init__(self, mappings: dict[str, Path]) -> None:
+        self._uris = list(mappings)
+        self._mappings = mappings
+
+    def lookup_rest_api_to_respond(self, rest_api: str) -> str:
+        path = self._mappings.get(rest_api)
+        return "" if path is None else str(path)
+
+    def lookup_rest_api_to_method(self, rest_api: str) -> str:
+        return "GET" if rest_api in self._mappings else ""
+
+    def get_rest_api_mappings(self) -> Iterator[tuple[str, str]]:
+        for rest_api, path in self._mappings.items():
+            yield rest_api, str(path)
+
+    def get_rest_api_methods(self) -> Iterator[tuple[str, str]]:
+        for rest_api in self._uris:
+            yield rest_api, "GET"
+
+    @property
+    def num_actions(self) -> int:
+        return len(self._uris)
+
+    def entry_rest_api(self) -> tuple[str, torch.Tensor]:
+        return ROOT_URI, self.action_for(ROOT_URI)
+
+    def one_hot_vector_to_action(self, one_hot: torch.Tensor) -> str:
+        return self._uris[int(torch.argmax(one_hot).item())]
+
+    def action_for(self, rest_api: str) -> torch.Tensor:
+        action = torch.zeros(len(self._uris), dtype=torch.float32)
+        action[self._uris.index(rest_api)] = 1.0
+        return action
+
+
+@pytest.fixture
+def rest_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> RestApiEnv:
+    """Create a RestApiEnv that only uses tmp JSON files and a StubEncoder."""
+    root_path = tmp_path / "root.json"
+    root_path.write_text(json.dumps(ROOT_PAYLOAD), encoding="utf-8")
+    system_path = tmp_path / "system.json"
+    system_path.write_text(json.dumps(SYSTEM_PAYLOAD), encoding="utf-8")
+
+    mapping = TinyRestMapping({ROOT_URI: root_path, SYSTEM_URI: system_path})
+    monkeypatch.setattr(rest_gym_env, "RestBaseEncoder", StubEncoder)
+
+    args = argparse.Namespace(raw_data_dir=str(tmp_path))
+    return RestApiEnv(
+        args=args,
+        model=None,
+        tokenizer=None,
+        discovered_rest_api=mapping,
+        max_episode=5,
+    )
+
+
+def _action(mapping: TinyRestMapping, rest_api: str, method: str) -> torch.Tensor:
+    return RestApiEnv.concat_rest_api_method(
+        mapping.action_for(rest_api),
+        RestApiEnv.encode_rest_api_method(method),
+    )
+
+
+def test_reset_returns_entry_observation_and_clears_step_count(rest_env: RestApiEnv):
+    """reset encodes the entry REST resource and clears episode counters."""
+    rest_env.step_count = 3
+
+    observation, info = rest_env.reset()
+
+    root_json = json.dumps(ROOT_PAYLOAD)
+    assert rest_env.step_count == 0
+    assert info == {"goal": None}
+    assert rest_env.action_space.shape == (2 + len(RestApiEnv.METHOD_MAPPING),)
+    assert rest_env.observation_space.shape == StubEncoder.emb_shape
+    assert torch.equal(observation, rest_env.encoder.encode(root_json))
+    assert torch.equal(rest_env.last_observation, observation)
+    assert root_json in rest_env.encoder.calls
+
+
+def test_step_get_known_resource_returns_success_observation(rest_env: RestApiEnv):
+    """A valid GET action replays the stored response with a small reward."""
+    _, info = rest_env.reset()
+    action = _action(rest_env._discovered_rest_api, SYSTEM_URI, "GET")
+
+    observation, reward, done, terminated, step_info = rest_env.step(action)
+
+    assert info == {"goal": None}
+    assert reward == pytest.approx(0.1)
+    assert done is False
+    assert terminated is False
+    assert step_info == {}
+    assert rest_env.step_count == 1
+    assert torch.equal(observation, rest_env.encoder.encode(json.dumps(SYSTEM_PAYLOAD)))
+    assert torch.equal(rest_env.last_observation, observation)
+
+
+def test_step_http_500_returns_terminal_error_observation(rest_env: RestApiEnv):
+    """Mock HTTP 500 responses are terminal and use the synthesized error body."""
+    rest_env.reset()
+    rest_env.mock_server().set_simulate_http_500_error(True)
+    action = _action(rest_env._discovered_rest_api, SYSTEM_URI, "GET")
+
+    observation, reward, done, terminated, info = rest_env.step(action)
+
+    error_json = MockServer.generate_error_response()
+    assert reward == pytest.approx(-0.5)
+    assert done is True
+    assert terminated is False
+    assert info == {}
+    assert torch.equal(observation, rest_env.encoder.encode(error_json))
+    assert torch.equal(rest_env.last_observation, observation)
+
+
+def test_reset_rejects_fixed_state_goal_with_wrong_shape(rest_env: RestApiEnv):
+    """FixedState goals must match the encoder-backed observation shape."""
+    with pytest.raises(ValueError, match="Fixed state goal dimensions"):
+        rest_env.reset(goal=torch.zeros(1), goal_type=GoalTypeState.FixedState)
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_action_codec_card.py
+++ b/tests/modules/test_action_codec_card.py
@@ -79,4 +79,36 @@ def test_card_triggers_exactly_one_new_embedding() -> None:
     assert enc.encoded_count == 3  # only the carded candidate is new
 
 
+def test_carded_actions_dedup_values_but_preserve_target_type() -> None:
+    """Carded cache keys collapse value-only changes, not distinct targets."""
+    enc = CountingEncoder(hidden_size=16)
+    codec = ActionCodec(enc, specs=_specs())
+    actions = [
+        ToolAction(
+            "ComputerSystem",
+            "Reset",
+            target="/redfish/v1/Systems/1",
+            arguments={"ResetType": "On"},
+        ),
+        ToolAction(
+            "ComputerSystem",
+            "Reset",
+            target="/redfish/v1/Systems/1",
+            arguments={"ResetType": "ForceOff"},
+        ),
+        ToolAction(
+            "ComputerSystem",
+            "Reset",
+            target="/redfish/v1/Systems/2",
+            arguments={"ResetType": "On"},
+        ),
+    ]
+
+    keys = codec.encode(actions, cards={("ComputerSystem", "Reset"): _card()})
+
+    assert enc.encoded_count == 2
+    assert torch.equal(keys[0], keys[1])
+    assert not torch.equal(keys[0], keys[2])
+
+
 # Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_argument_decoder.py
+++ b/tests/modules/test_argument_decoder.py
@@ -37,6 +37,33 @@ def _reset_spec():
     )
 
 
+def _bios_patch_spec():
+    """A PATCH tool with independent categorical and free-form slots."""
+    return ToolSpec(
+        tool_name="redfish",
+        ops=["PATCH"],
+        arg_schema={
+            "PATCH": {
+                "BootMode": {
+                    "type": "string",
+                    "choices": ["Bios", "Uefi"],
+                    "required": True,
+                },
+                "OneTimeBoot": {
+                    "type": "boolean",
+                    "enum": [True, False],
+                    "required": False,
+                },
+                "Attributes": {
+                    "type": "object",
+                    "required": True,
+                },
+            }
+        },
+        risk_level=RiskLevel.MUTATING,
+    )
+
+
 def test_arg_slots_for_reads_enum_required_and_type():
     """arg_slots_for maps an enum to choices and carries type/required."""
     slots = arg_slots_for(_reset_spec(), "POST")
@@ -45,6 +72,24 @@ def test_arg_slots_for_reads_enum_required_and_type():
     assert slot.name == "ResetType" and slot.type == "string"
     assert slot.choices == ("On", "ForceOff", "GracefulShutdown")
     assert slot.required and slot.is_categorical
+
+
+def test_arg_slots_for_multi_slot_schema_preserves_independent_slots():
+    """Multi-slot schemas keep per-slot choices separate rather than cross-producting."""
+    boot_mode, one_time_boot, attributes = arg_slots_for(_bios_patch_spec(), "PATCH")
+
+    assert boot_mode.name == "BootMode"
+    assert boot_mode.choices == ("Bios", "Uefi")
+    assert boot_mode.required
+
+    assert one_time_boot.name == "OneTimeBoot"
+    assert one_time_boot.choices == (True, False)
+    assert not one_time_boot.required
+
+    assert attributes.name == "Attributes"
+    assert attributes.choices is None
+    assert attributes.required
+    assert not attributes.is_categorical
 
 
 def test_arg_slots_for_read_op_has_no_slots():
@@ -58,6 +103,12 @@ def test_arg_slots_for_non_dict_fragment_is_freeform():
     spec = ToolSpec(tool_name="t", ops=["POST"], arg_schema={"POST": {"raw": "string"}})
     slot = arg_slots_for(spec, "POST")[0]
     assert slot.name == "raw" and not slot.is_categorical
+
+
+def test_arg_slots_for_missing_enum_is_required_freeform_stub():
+    """A required schema entry without enum/choices remains a free-form stub slot."""
+    slot = arg_slots_for(_bios_patch_spec(), "PATCH")[2]
+    assert slot == ArgumentSlot(name="Attributes", type="object", choices=None, required=True)
 
 
 def test_select_categorical_is_argmax_over_choice_width():
@@ -77,6 +128,14 @@ def test_select_categorical_rejects_wrong_width_and_freeform():
         select_categorical(free, [1.0])
 
 
+def test_select_categorical_scores_each_slot_independently():
+    """Independent slots can choose values without enumerating every combination."""
+    boot_mode, one_time_boot, _ = arg_slots_for(_bios_patch_spec(), "PATCH")
+
+    assert select_categorical(boot_mode, [0.1, 0.9]) == "Uefi"
+    assert select_categorical(one_time_boot, [0.8, 0.2]) is True
+
+
 def test_assemble_arguments_enforces_required_and_skips_optional_none():
     """Required slots must be present; an unset optional slot is simply omitted."""
     required = arg_slots_for(_reset_spec(), "POST")
@@ -85,6 +144,25 @@ def test_assemble_arguments_enforces_required_and_skips_optional_none():
         assemble_arguments(required, {})  # required ResetType missing
     optional = [ArgumentSlot(name="Note")]
     assert assemble_arguments(optional, {"Note": None}) == {}
+
+
+def test_assemble_arguments_requires_freeform_stub_and_keeps_falsey_values():
+    """Free-form required slots still need values; falsey values are valid choices."""
+    slots = arg_slots_for(_bios_patch_spec(), "PATCH")
+
+    with pytest.raises(ValueError):
+        assemble_arguments(slots, {"BootMode": "Uefi"})
+
+    args = assemble_arguments(
+        slots,
+        {
+            "BootMode": "Uefi",
+            "OneTimeBoot": False,
+            "Attributes": {},
+        },
+    )
+
+    assert args == {"BootMode": "Uefi", "OneTimeBoot": False, "Attributes": {}}
 
 
 def test_apply_arguments_fills_template_values_only():
@@ -99,6 +177,17 @@ def test_apply_arguments_fills_template_values_only():
     assert action.tool_name == "redfish" and action.op == "POST"
     assert action.target == template.target and action.risk_level == RiskLevel.MUTATING
     assert template.arguments == {}  # original template unchanged
+
+
+def test_apply_arguments_copies_input_mapping():
+    """Mutating the caller's dict after apply_arguments does not affect the action."""
+    template = ToolAction(tool_name="redfish", op="PATCH", target="/redfish/v1/Systems/1/Bios")
+    arguments = {"Attributes": {"BootMode": "Uefi"}}
+
+    action = apply_arguments(template, arguments)
+    arguments["Attributes"] = {"BootMode": "Bios"}
+
+    assert action.arguments == {"Attributes": {"BootMode": "Uefi"}}
 
 
 def test_categorical_scorer_output_width_tracks_choices():

--- a/tests/modules/test_checkpoint_sentinel.py
+++ b/tests/modules/test_checkpoint_sentinel.py
@@ -1,0 +1,40 @@
+"""Offline regression for the ``best_accuracy`` sentinel in ``IgcModule.load_checkpoint``.
+
+The early-return checkpoint states seed ``best_accuracy`` with the "no best yet" sentinel.
+Best-accuracy tracking is higher-is-better (``validation_accuracy > best``), so the sentinel
+must be ``-inf`` (the first real accuracy beats it). A prior ``-float('-inf')`` typo evaluated
+to ``+inf``, which would make no accuracy ever register as best once the field is consumed on
+resume. This test pins the sentinel to negative infinity, consistent with the loaded-value
+default. Runs on CPU with no checkpoint files.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+import math
+
+from igc.modules.base.igc_base_module import IgcModule
+
+
+def _module_without_checkpoint_dir():
+    """An IgcModule with no checkpoint dir (bypasses the heavy __init__)."""
+    module = IgcModule.__new__(IgcModule)
+    module._module_checkpoint_dir = None
+    return module
+
+
+def test_no_checkpoint_dir_seeds_negative_infinity_best_accuracy():
+    """With no checkpoint dir, best_accuracy is -inf so the first accuracy wins."""
+    state = _module_without_checkpoint_dir().load_checkpoint("ignored")
+    assert math.isinf(state.best_accuracy)
+    assert state.best_accuracy < 0
+    assert state.best_accuracy == float("-inf")
+
+
+def test_sentinel_loses_to_any_finite_accuracy():
+    """The seeded sentinel is strictly less than any finite validation accuracy."""
+    state = _module_without_checkpoint_dir().load_checkpoint("ignored")
+    for accuracy in (-1.0, 0.0, 0.5, 1.0, 1e9):
+        assert accuracy > state.best_accuracy
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_experience_buffer.py
+++ b/tests/modules/test_experience_buffer.py
@@ -7,14 +7,19 @@ fallback for experiences added without one.
 Author:
 Mus mbayramo@stanford.edu
 """
+import pytest
 import torch
 
 from igc.modules.igc_experience_buffer import Buffer
 
 
-def _exp(done):
+def _exp(done, value=0.0):
     """A tiny experience: state[1,2], action[1,3], reward[1], next_state[1,2], done."""
-    return (torch.zeros(1, 2), torch.zeros(1, 3), torch.ones(1), torch.zeros(1, 2), done)
+    state = torch.full((1, 2), value)
+    action = torch.full((1, 3), value)
+    reward = torch.tensor([value])
+    next_state = torch.full((1, 2), value + 10.0)
+    return state, action, reward, next_state, done
 
 
 def test_sample_batch_returns_done_tensor():
@@ -34,6 +39,36 @@ def test_add_default_done_is_zero():
     _, _, reward, _, done = buf.sample_batch()
     assert done.shape == reward.shape
     assert float(done.sum().item()) == 0.0
+
+
+@pytest.mark.parametrize("sample_api", ["sample", "sample_batch"])
+def test_mixed_scalar_and_tensor_done_flags_keep_reward_shape(sample_api):
+    """Scalar bools and tensor done flags are returned in reward-aligned order."""
+    buf = Buffer(size=5, sample_size=5)
+    buf.add(*_exp(True, value=1.0))
+    buf.add(*_exp(False, value=2.0))
+    buf.add(*_exp(torch.tensor([1.0]), value=3.0))
+
+    _, _, reward, _, done = getattr(buf, sample_api)()
+
+    assert done.shape == reward.shape
+    assert done.flatten().tolist() == [1.0, 0.0, 1.0]
+
+
+def test_sample_batch_returns_only_capacity_retained_experiences():
+    """The deque capacity evicts oldest transitions before batch reshaping."""
+    buf = Buffer(size=2, sample_size=3)
+    buf.add(*_exp(False, value=1.0))
+    buf.add(*_exp(True, value=2.0))
+    buf.add(*_exp(False, value=3.0))
+
+    state, action, reward, next_state, done = buf.sample_batch()
+
+    assert state.tolist() == [[2.0, 2.0], [3.0, 3.0]]
+    assert action.tolist() == [[2.0, 2.0, 2.0], [3.0, 3.0, 3.0]]
+    assert reward.tolist() == [2.0, 3.0]
+    assert next_state.tolist() == [[12.0, 12.0], [13.0, 13.0]]
+    assert done.tolist() == [1.0, 0.0]
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_experience_buffer_done_shapes.py
+++ b/tests/modules/test_experience_buffer_done_shapes.py
@@ -1,0 +1,55 @@
+"""Offline regression for ragged done-flag stacking in ``Buffer._stack_done``.
+
+A replay batch can mix a scalar ``[]`` terminal tensor with a ``[1]`` one (HER relabeling
+and the ``add`` default produce different shapes). ``torch.stack`` fails on ragged entries,
+so the buffer coerces every done flag to its sample's reward shape first. These CPU tests
+pin that normalization; they are the 1:1 regression for that source change.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+import torch
+
+from igc.modules.igc_experience_buffer import Buffer
+
+
+def test_stack_done_normalizes_mixed_tensor_shapes():
+    """A ``[1]`` done mixed with a scalar ``[]`` done stacks without a ragged error."""
+    reward_batch = torch.tensor([0.0, 0.0])
+    samples = [
+        (None, None, torch.tensor(0.0), None, torch.tensor([1.0])),
+        (None, None, torch.tensor(0.0), None, torch.tensor(0.0)),
+    ]
+
+    done = Buffer._stack_done(samples, reward_batch)
+
+    assert done.shape == reward_batch.shape
+    assert done.reshape(-1).tolist() == [1.0, 0.0]
+
+
+def test_stack_done_broadcasts_scalar_bool_and_zero_dim():
+    """Plain ``bool`` and 0-dim tensor done values broadcast to the reward shape."""
+    reward_batch = torch.zeros(2, 1)
+    samples = [
+        (None, None, torch.zeros(1), None, True),
+        (None, None, torch.zeros(1), None, torch.tensor(1.0)),
+    ]
+
+    done = Buffer._stack_done(samples, reward_batch)
+
+    assert done.shape == (2, 1)
+    assert done.reshape(-1).tolist() == [1.0, 1.0]
+
+
+def test_stack_done_missing_flag_defaults_to_not_done():
+    """A sample added without a done flag contributes a zero (non-terminal) mask."""
+    reward_batch = torch.tensor([0.0])
+    samples = [(None, None, torch.tensor(0.0), None)]
+
+    done = Buffer._stack_done(samples, reward_batch)
+
+    assert done.shape == reward_batch.shape
+    assert done.reshape(-1).tolist() == [0.0]
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_grad_accum_boundary.py
+++ b/tests/modules/test_grad_accum_boundary.py
@@ -16,7 +16,7 @@ import math
 
 import pytest
 
-from igc.modules.llm_train_state_encoder import is_accum_boundary
+from igc.modules.llm_train_state_encoder import is_accum_boundary, reached_max_steps
 
 
 def _boundaries(total, accum):
@@ -56,6 +56,20 @@ def test_final_batch_always_flushes():
     """The last micro-batch is always a boundary so no accumulated gradients are stranded."""
     assert is_accum_boundary(9, 4, 10) is True   # last batch, mid-window
     assert is_accum_boundary(5, 4, 6) is True     # last batch, partial window
+
+
+def test_reached_max_steps_uncapped_when_none_or_nonpositive():
+    """None / 0 / negative max_steps mean no cap, so training never stops on the counter."""
+    assert reached_max_steps(10_000, None) is False
+    assert reached_max_steps(10_000, 0) is False
+    assert reached_max_steps(10_000, -5) is False
+
+
+def test_reached_max_steps_stops_at_the_cap():
+    """With a positive cap, stop once optimizer steps reach it (honors --max_train_steps)."""
+    assert reached_max_steps(49, 50) is False
+    assert reached_max_steps(50, 50) is True
+    assert reached_max_steps(51, 50) is True
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_grad_accum_boundary.py
+++ b/tests/modules/test_grad_accum_boundary.py
@@ -1,0 +1,61 @@
+"""
+Offline regression for the plain-path gradient-accumulation boundary.
+
+Pins that ``is_accum_boundary`` fires every ``accum`` micro-batches AND on the final batch
+of the epoch (so a trailing partial window is flushed, not dropped), yielding exactly
+``ceil(total_batches / accum)`` optimizer steps. This is the logic that makes
+``--gradient_accumulation_steps`` actually honored on the non-accelerator path, where the
+loop previously called optimizer.step() every micro-batch. Pure logic — no torch tensors,
+no GPU, no network.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import math
+
+import pytest
+
+from igc.modules.llm_train_state_encoder import is_accum_boundary
+
+
+def _boundaries(total, accum):
+    """Micro-batch indices at which an optimizer step fires over one epoch."""
+    return [i for i in range(total) if is_accum_boundary(i, accum, total)]
+
+
+def test_accum_one_steps_every_micro_batch():
+    """accum=1 degenerates to stepping on every micro-batch."""
+    assert _boundaries(5, 1) == [0, 1, 2, 3, 4]
+
+
+def test_steps_on_window_and_flushes_partial_tail():
+    """Boundaries land on each full window and always on the final batch."""
+    # 10 batches, accum 4 -> windows end at 3 and 7; final batch 9 flushes the partial.
+    assert _boundaries(10, 4) == [3, 7, 9]
+
+
+def test_no_partial_tail_when_evenly_divisible():
+    """When total is a multiple of accum, the last window IS the final batch (no dup)."""
+    assert _boundaries(8, 4) == [3, 7]
+
+
+@pytest.mark.parametrize("total,accum", [(10, 4), (8, 4), (10, 3), (6, 4), (1, 8), (7, 1)])
+def test_optimizer_step_count_is_ceil(total, accum):
+    """Optimizer steps per epoch == ceil(total_batches / accum) — the effective-batch fix."""
+    assert len(_boundaries(total, accum)) == math.ceil(total / accum)
+
+
+def test_accum_below_one_is_coerced():
+    """accum <= 0 is coerced to 1 (step every batch) rather than dividing by zero."""
+    assert _boundaries(3, 0) == [0, 1, 2]
+    assert _boundaries(3, -5) == [0, 1, 2]
+
+
+def test_final_batch_always_flushes():
+    """The last micro-batch is always a boundary so no accumulated gradients are stranded."""
+    assert is_accum_boundary(9, 4, 10) is True   # last batch, mid-window
+    assert is_accum_boundary(5, 4, 6) is True     # last batch, partial window
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_llm_load_finetuned.py
+++ b/tests/modules/test_llm_load_finetuned.py
@@ -1,0 +1,65 @@
+"""Offline tests for downstream LLM stages loading the trained state encoder.
+
+The goal/parameter/autoencoder stages consume a state encoder checkpoint produced
+by the prior M1 run. These tests use small fakes so the contract is covered with
+no GPU, network, HuggingFace download, or real checkpoint.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+import argparse
+
+import pytest
+
+from igc.modules.llm.igc_llm_module import IgcLanguageModule
+from igc.shared.modules_typing import ModelType
+
+
+class FakeTokenizer:
+    """Tiny tokenizer double that only supports len()."""
+
+    def __len__(self):
+        return 7
+
+
+class FakeDataset:
+    """Dataset double exposing the tokenizer attribute used by the loader."""
+
+    tokenizer = FakeTokenizer()
+
+
+def make_module(llm_stage: str) -> IgcLanguageModule:
+    """Build an IgcLanguageModule around fakes for one downstream stage."""
+    spec = argparse.Namespace(
+        llm=llm_stage,
+        log_level="ERROR",
+        device="cpu",
+    )
+    return IgcLanguageModule(spec, metric_logger=None, ds=FakeDataset())
+
+
+@pytest.mark.parametrize("llm_stage", ["goal", "parameter", "encoder"])
+def test_downstream_stages_load_prior_state_encoder(monkeypatch, llm_stage):
+    """Downstream stages return the fine-tuned state encoder and mark it trained."""
+    module = make_module(llm_stage)
+    state_encoder = object()
+    monkeypatch.setattr(module, "load_finetuned_state_encoder", lambda: state_encoder)
+
+    model, tokenizer, model_state = module.load_finetuned_llm()
+
+    assert model is state_encoder
+    assert tokenizer is module._dataset.tokenizer
+    assert model_state is ModelType.FINETUNED
+
+
+@pytest.mark.parametrize("llm_stage", ["goal", "parameter", "encoder"])
+def test_downstream_stages_fail_fast_without_state_encoder(monkeypatch, llm_stage):
+    """A downstream stage without an M1 checkpoint raises a clear setup error."""
+    module = make_module(llm_stage)
+    monkeypatch.setattr(module, "load_finetuned_state_encoder", lambda: None)
+
+    with pytest.raises(RuntimeError, match=f"train stage m1 .*--llm {llm_stage}"):
+        module.load_finetuned_llm()
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_llm_loader.py
+++ b/tests/modules/test_llm_loader.py
@@ -88,6 +88,51 @@ def test_only_tokenizer_skips_model(monkeypatch):
     assert "model" not in captured
 
 
+def test_only_model_skips_tokenizer_and_padding(monkeypatch):
+    """only_model=True loads no tokenizer and leaves pad config untouched."""
+    captured = _install_fakes(monkeypatch)
+    model, tokenizer = llm_shared.from_pretrained_default("gpt2", only_model=True)
+    assert model is not None and tokenizer is None
+    assert "tok" not in captured
+    assert model.config.pad_token_id is None
+    assert model.config.pad_token is None
+
+
+def test_load_pretrained_default_forwards_loader_flags(monkeypatch):
+    """Fine-tuned load forwards cache/trust/device-map/loading flags to Auto classes."""
+    captured = _install_fakes(monkeypatch)
+    spec = argparse.Namespace(
+        llm_cache_dir="/tmp/igc-hf-cache",
+        trust_remote_code=True,
+        llm_ignore_mismatched_sizes=True,
+        llm_output_loading_info=True,
+        llm_fast_init=False,
+        llm_torch_dtype="auto",
+    )
+    model, tokenizer = llm_shared.load_pretrained_default(
+        spec,
+        "/tmp/igc-model",
+        device_map={"": "cpu"},
+    )
+    assert model is not None and tokenizer is not None
+    assert captured["tok"] == (
+        "/tmp/igc-model",
+        {"cache_dir": "/tmp/igc-hf-cache", "trust_remote_code": True},
+    )
+    assert captured["model"] == (
+        "/tmp/igc-model",
+        {
+            "cache_dir": "/tmp/igc-hf-cache",
+            "trust_remote_code": True,
+            "ignore_mismatched_sizes": True,
+            "output_loading_info": True,
+            "_fast_init": False,
+            "torch_dtype": "auto",
+            "device_map": {"": "cpu"},
+        },
+    )
+
+
 def test_helpers():
     """_model_id / _spec_flag / _resolve_dtype behave for str and Namespace inputs."""
     import torch

--- a/tests/modules/test_load_checkpoint_map_location.py
+++ b/tests/modules/test_load_checkpoint_map_location.py
@@ -1,0 +1,120 @@
+"""Offline regression for device mapping in ``IgcModule.load_checkpoint``.
+
+``load_checkpoint`` computes ``map_to`` (the caller's ``map_location`` or the
+``{'cuda:1': 'cuda:0'}`` default) but historically dropped it on the floor: the
+underlying ``torch.load`` was called without ``map_location``, so a checkpoint
+saved on one device could fail or mis-map when resumed on another (e.g. cuda->cpu).
+
+These tests pin two things on CPU with no GPU required:
+  * ``map_location`` is actually forwarded to ``torch.load`` (spy), including the
+    ``{'cuda:1': 'cuda:0'}`` remap when the caller passes nothing; and
+  * an end-to-end ``map_location='cpu'`` load restores weights onto CPU.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+import logging
+
+import torch
+import torch.nn as nn
+
+from igc.modules.base.igc_base_module import IgcModule
+
+
+def _bypass_module(model, optimizer):
+    """A minimally-populated IgcModule that bypasses the heavy __init__.
+
+    Only the attributes ``load_checkpoint`` touches on the resume path are set.
+    """
+    module = IgcModule.__new__(IgcModule)
+    module._module_checkpoint_dir = "present"  # non-None so we don't early-return
+    module.logger = logging.getLogger("test_load_checkpoint_map_location")
+    module.model = model
+    module.optimizer = optimizer
+    module.scheduler = None
+    module.module_name = "test-module"
+    module.rank = 0
+    return module
+
+
+def _write_checkpoint(path, model, optimizer, epoch=3):
+    torch.save(
+        {
+            "model_state_dict": model.state_dict(),
+            "optimizer_state_dict": optimizer.state_dict(),
+            "epoch": epoch,
+        },
+        path,
+    )
+
+
+def test_load_checkpoint_loads_onto_cpu(tmp_path):
+    """map_location='cpu' loads weights onto CPU without error."""
+    src = nn.Linear(4, 2)
+    src_opt = torch.optim.SGD(src.parameters(), lr=0.1)
+    ckpt = tmp_path / "chk.pt"
+    _write_checkpoint(ckpt, src, src_opt, epoch=3)
+
+    dst = nn.Linear(4, 2)
+    dst_opt = torch.optim.SGD(dst.parameters(), lr=0.1)
+    module = _bypass_module(dst, dst_opt)
+
+    state = module.load_checkpoint(str(ckpt), map_location="cpu")
+
+    assert state.last_epoch == 3
+    for param in dst.parameters():
+        assert param.device.type == "cpu"
+    # weights were actually copied from the checkpoint, not left at init.
+    assert torch.allclose(dst.weight, src.weight)
+    assert torch.allclose(dst.bias, src.bias)
+
+
+def test_load_checkpoint_forwards_map_location(tmp_path, monkeypatch):
+    """The caller's map_location reaches torch.load (regression for the dropped kwarg)."""
+    src = nn.Linear(4, 2)
+    src_opt = torch.optim.SGD(src.parameters(), lr=0.1)
+    ckpt = tmp_path / "chk.pt"
+    _write_checkpoint(ckpt, src, src_opt)
+
+    dst = nn.Linear(4, 2)
+    dst_opt = torch.optim.SGD(dst.parameters(), lr=0.1)
+    module = _bypass_module(dst, dst_opt)
+
+    captured = {}
+    real_load = torch.load
+
+    def spy(f, *args, **kwargs):
+        captured["map_location"] = kwargs.get("map_location")
+        return real_load(f, *args, **kwargs)
+
+    monkeypatch.setattr(torch, "load", spy)
+
+    module.load_checkpoint(str(ckpt), map_location="cpu")
+    assert captured["map_location"] == "cpu"
+
+
+def test_load_checkpoint_default_maps_cuda1_to_cuda0(tmp_path, monkeypatch):
+    """With no map_location, the cuda:1->cuda:0 default remap is forwarded to torch.load."""
+    src = nn.Linear(4, 2)
+    src_opt = torch.optim.SGD(src.parameters(), lr=0.1)
+    ckpt = tmp_path / "chk.pt"
+    _write_checkpoint(ckpt, src, src_opt)
+
+    dst = nn.Linear(4, 2)
+    dst_opt = torch.optim.SGD(dst.parameters(), lr=0.1)
+    module = _bypass_module(dst, dst_opt)
+
+    captured = {}
+    real_load = torch.load
+
+    def spy(f, *args, **kwargs):
+        captured["map_location"] = kwargs.get("map_location")
+        return real_load(f, *args, **kwargs)
+
+    monkeypatch.setattr(torch, "load", spy)
+
+    module.load_checkpoint(str(ckpt))  # map_location defaults to None
+    assert captured["map_location"] == {"cuda:1": "cuda:0"}
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_metric_logger_wandb.py
+++ b/tests/modules/test_metric_logger_wandb.py
@@ -23,7 +23,9 @@ class _FakeWandb:
         self.last_init = None
         self.run = _FakeRun()
 
-    def init(self, project=None, entity=None):
+    def init(self, project=None, entity=None, **kwargs):
+        # Real wandb.init also accepts name/group/job_type/tags/config; accept and ignore
+        # them here so the fake matches how WandbLogger calls wandb.init.
         self.last_init = {"project": project, "entity": entity}
         return self.run
 

--- a/tests/modules/test_peft_lora.py
+++ b/tests/modules/test_peft_lora.py
@@ -55,6 +55,18 @@ def test_default_save_modules_by_backbone():
     assert default_save_modules(model_type="llama") == ["embed_tokens"]
 
 
+def test_default_save_modules_from_model_config():
+    """When no model_type is given, the model config selects the saved embedding."""
+
+    class _Cfg:
+        model_type = "gpt2"
+
+    class _Model:
+        config = _Cfg()
+
+    assert default_save_modules(model=_Model()) == ["wte"]
+
+
 def test_apply_lora_on_tiny_gpt2_makes_few_params_trainable():
     """LoRA on a tiny gpt2 leaves only the adapters trainable by default (<< total)."""
     pytest.importorskip("torch")
@@ -108,6 +120,47 @@ def test_adapter_method_rslora_and_bad_method():
     assert pm.peft_config["default"].use_rslora is True
     with pytest.raises(ValueError):
         apply_lora(_tiny_gpt2(), model_type="gpt2", adapter_method="bogus")
+
+
+def test_apply_lora_explicit_modules_to_save_override_default_embedding():
+    """An explicit modules_to_save list is passed to PEFT instead of the default embedding."""
+    pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+    pytest.importorskip("peft")
+
+    peft_model = apply_lora(
+        _tiny_gpt2(),
+        r=4,
+        model_type="gpt2",
+        modules_to_save=["lm_head"],
+    )
+
+    assert peft_model.peft_config["default"].modules_to_save == ["lm_head"]
+    assert any(
+        "lm_head.modules_to_save" in name and param.requires_grad
+        for name, param in peft_model.named_parameters()
+    )
+    assert not any(
+        "wte.modules_to_save" in name and param.requires_grad
+        for name, param in peft_model.named_parameters()
+    )
+
+
+def test_apply_lora_can_disable_saved_embeddings():
+    """train_embeddings=False leaves modules_to_save unset for adapter-only tuning."""
+    pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+    pytest.importorskip("peft")
+
+    peft_model = apply_lora(
+        _tiny_gpt2(),
+        r=4,
+        model_type="gpt2",
+        train_embeddings=False,
+    )
+
+    assert peft_model.peft_config["default"].modules_to_save is None
+    assert not any("modules_to_save" in name for name, _ in peft_model.named_parameters())
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_q_targets.py
+++ b/tests/modules/test_q_targets.py
@@ -9,6 +9,7 @@ Mus mbayramo@stanford.edu
 """
 import numpy as np
 import torch
+import pytest
 
 from igc.modules.rl.q_targets import q_learning_target, relabel_future
 
@@ -34,6 +35,31 @@ def test_truncation_keeps_bootstrapping():
     next_q = torch.tensor([[2.0, 4.0]])
     target = q_learning_target(reward, done, next_q, gamma=0.5)
     assert torch.isclose(target[0], torch.tensor(2.0))  # 0 + 0.5 * 4
+
+
+@pytest.mark.parametrize(
+    ("gamma", "expected"),
+    [
+        (0.0, torch.tensor([2.0, -1.0])),
+        (1.0, torch.tensor([7.0, -1.0])),
+    ],
+)
+def test_q_learning_target_handles_gamma_extremes(gamma, expected):
+    """Gamma at 0 ignores next_q; gamma at 1 fully bootstraps non-terminals."""
+    reward = torch.tensor([2.0, -1.0])
+    done = torch.tensor([False, True])
+    next_q = torch.tensor([[3.0, 5.0], [20.0, 30.0]])
+    target = q_learning_target(reward, done, next_q, gamma)
+    torch.testing.assert_close(target, expected)
+
+
+def test_q_learning_target_accepts_bool_done_mask():
+    """Boolean terminal masks are converted to reward dtype before arithmetic."""
+    reward = torch.tensor([0.5, 0.5], dtype=torch.float64)
+    done = torch.tensor([False, True])
+    next_q = torch.tensor([[2.0, 3.0], [9.0, 10.0]], dtype=torch.float64)
+    target = q_learning_target(reward, done, next_q, gamma=0.25)
+    torch.testing.assert_close(target, torch.tensor([1.25, 0.5], dtype=torch.float64))
 
 
 def _reward_match(state, goal):
@@ -84,6 +110,45 @@ def test_relabel_future_reward_and_done_consistent():
     (_, r0, d0), (_, r1, d1) = out
     assert float(r0.item()) == 1.0 and float(d0.item()) == 1.0   # goal == achieved
     assert float(r1.item()) == 0.0 and float(d1.item()) == 0.0   # goal != achieved
+
+
+def test_relabel_future_zero_k_returns_no_relabels():
+    """HER k=0 is a no-op and must not call the reward function or RNG."""
+    achieved = torch.ones(1, 2)
+    episode = [(torch.zeros(1, 2), None, None, achieved, None)]
+
+    class _NoCalls:
+        def integers(self, low, high):
+            raise AssertionError("rng should not be called when k=0")
+
+    def reward_fn(state, goal):
+        raise AssertionError("reward_fn should not be called when k=0")
+
+    out = relabel_future(episode, 0, achieved, num_relabeled=0,
+                         reward_fn=reward_fn, rng=_NoCalls())
+    assert out == []
+
+
+def test_relabel_future_at_last_timestep_samples_last_achieved_state():
+    """At the horizon edge, the only valid substituted goal is the last next-state."""
+    achieved = torch.full((1, 2), 9.0)
+    episode = [
+        (torch.zeros(1, 2), None, None, torch.full((1, 2), 3.0), None),
+        (torch.zeros(1, 2), None, None, achieved, None),
+    ]
+
+    class _BoundsCheckingRng:
+        def integers(self, low, high):
+            assert low == 1
+            assert high == 2
+            return 1
+
+    out = relabel_future(episode, 1, achieved, num_relabeled=1,
+                         reward_fn=_reward_match, rng=_BoundsCheckingRng())
+    [(goal, reward, done)] = out
+    torch.testing.assert_close(goal, achieved)
+    torch.testing.assert_close(reward, torch.tensor([1.0]))
+    torch.testing.assert_close(done, torch.tensor([1.0]))
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_q_targets.py
+++ b/tests/modules/test_q_targets.py
@@ -36,6 +36,23 @@ def test_truncation_keeps_bootstrapping():
     assert torch.isclose(target[0], torch.tensor(2.0))  # 0 + 0.5 * 4
 
 
+def test_all_masked_next_state_is_terminal_and_target_stays_finite():
+    """A next state whose legal-action mask leaves every action at -inf (a dead
+    end) is treated as terminal: the target equals reward and stays finite,
+    instead of maxing an all-(-inf) row into a non-finite -inf target."""
+    neg_inf = float("-inf")
+    reward = torch.tensor([1.0, 0.0])
+    done = torch.tensor([0.0, 0.0])
+    # row 0: every action illegal (dead end); row 1: one legal action (value 4)
+    next_q = torch.tensor([[neg_inf, neg_inf], [neg_inf, 4.0]])
+    target = q_learning_target(reward, done, next_q, gamma=0.9)
+    assert torch.isfinite(target).all()
+    # dead-end row 0: no bootstrap -> target == reward == 1.0
+    assert torch.isclose(target[0], torch.tensor(1.0))
+    # row 1 still bootstraps the single legal action: 0 + 0.9 * 4 == 3.6
+    assert torch.isclose(target[1], torch.tensor(3.6))
+
+
 def _reward_match(state, goal):
     """Toy env reward: 1.0 where state equals goal elementwise, else 0.0 (shape [B])."""
     return torch.all(state == goal, dim=1).to(torch.float32)

--- a/tests/modules/test_safe_probe.py
+++ b/tests/modules/test_safe_probe.py
@@ -65,6 +65,18 @@ def test_card_narrows_probes_to_its_tool() -> None:
     assert [a.tool_name for a in probes] == ["Chassis"]
 
 
+def test_card_cannot_raise_default_read_only_ceiling() -> None:
+    """A card for a mutating op cannot offer that op as a default probe."""
+    catalog = FakeCatalog([
+        ToolAction("ComputerSystem", "GET", risk_level=RiskLevel.READ_ONLY),
+        ToolAction("ComputerSystem", "Reset", risk_level=RiskLevel.MUTATING),
+        ToolAction("Chassis", "GET", risk_level=RiskLevel.READ_ONLY),
+    ])
+    card = ToolCard(env_name="redfish", tool_name="ComputerSystem", op="Reset")
+    probes = safe_probe_actions(card, catalog, _OBS)
+    assert [a.op for a in probes] == ["GET"]
+
+
 def test_custom_ceiling_allows_mutating() -> None:
     """An explicit MUTATING ceiling admits mutating probes (but never via a card)."""
     catalog = FakeCatalog([

--- a/tests/modules/test_tool_grounding.py
+++ b/tests/modules/test_tool_grounding.py
@@ -37,6 +37,18 @@ def test_evidence_gate_drops_uncited_error_rules() -> None:
     assert statuses == {409}
 
 
+def test_evidence_gate_can_be_disabled_for_fixture_cards() -> None:
+    """A local fixture can preserve uncited rules when evidence is not required."""
+    card = ToolCard(
+        env_name="redfish", tool_name="ComputerSystem", op="Reset",
+        error_taxonomy=[
+            ErrorRule(match={"status": 503}, error_class=ErrorClass.RETRIABLE, evidence_ids=[]),
+        ],
+    )
+    grounded = ToolCardGrounder(require_evidence=False).ground(card, _spec())
+    assert [r.match for r in grounded.error_taxonomy] == [{"status": 503}]
+
+
 def test_schema_gate_drops_unknown_arg_slots() -> None:
     """An arg slot the catalog never declared is a hallucination and is dropped."""
     card = ToolCard(
@@ -58,6 +70,17 @@ def test_enum_clip_catalog_overrides_teacher() -> None:
     assert grounded.effective_signature["ResetType"]["enum"] == ["On", "ForceOff"]  # Teleport dropped
 
 
+def test_observed_fields_clip_expected_response_claims() -> None:
+    """Expected response fields are limited to fields observed in real bodies."""
+    card = ToolCard(
+        env_name="redfish", tool_name="ComputerSystem", op="Reset",
+        expected_response={"TaskState": "string", "Missing": "string"},
+    )
+    grounded = ToolCardGrounder().ground(card, _spec(), observed_fields={"TaskState"})
+    assert grounded.expected_response == {"TaskState": "string"}
+    assert set(card.expected_response) == {"TaskState", "Missing"}
+
+
 def test_stale_card_is_emptied_and_contradicted() -> None:
     """A card induced against a different op schema is invalidated."""
     card = ToolCard(
@@ -77,6 +100,17 @@ def test_observe_promotes_grounded_on_anticipated_error() -> None:
         error_taxonomy=[ErrorRule(match={"status": 409}, error_class=ErrorClass.PRECONDITION_UNMET, evidence_ids=["t1"])],
     )
     ToolCardGrounder().observe(card, 409, {"error": "pending"})
+    assert card.grounding.status is GroundingStatus.GROUNDED
+    assert card.grounding.n_confirmations == 1
+
+
+def test_observe_confirms_on_complete_expected_response() -> None:
+    """A real 2xx body containing every declared response field confirms the card."""
+    card = ToolCard(
+        env_name="redfish", tool_name="ComputerSystem", op="Reset",
+        expected_response={"TaskState": "string", "Id": "integer"},
+    )
+    ToolCardGrounder().observe(card, 200, {"TaskState": "Running", "Id": 7})
     assert card.grounding.status is GroundingStatus.GROUNDED
     assert card.grounding.n_confirmations == 1
 

--- a/tests/modules/test_tool_teacher.py
+++ b/tests/modules/test_tool_teacher.py
@@ -50,6 +50,72 @@ def test_stub_induces_signature_expected_and_errors() -> None:
     assert card.provenance["source"] == "stub" and card.provenance["k_observed"] == 2
 
 
+def test_stub_keeps_json_shape_types_distinct() -> None:
+    """Observed success bodies preserve JSON shape names, including bool vs int."""
+    card = StubTeacher().induce(
+        "redfish",
+        _spec(),
+        "Reset",
+        [
+            _tr(
+                200,
+                {
+                    "Enabled": True,
+                    "RetryCount": 2,
+                    "Voltage": 12.5,
+                    "Links": ["Systems"],
+                    "Status": {"Health": "OK"},
+                    "Maybe": None,
+                    "Name": "System",
+                },
+            )
+        ],
+    )
+    assert card.expected_response == {
+        "Enabled": "boolean",
+        "RetryCount": "integer",
+        "Voltage": "number",
+        "Links": "array",
+        "Status": "object",
+        "Maybe": "null",
+        "Name": "string",
+    }
+
+
+def test_stub_accumulates_evidence_for_duplicate_error_status() -> None:
+    """Repeated failures of the same status merge into one rule with all evidence ids."""
+    transitions = [
+        _tr(409, {"error": "pending job"}),
+        _tr(409, {"error": "pending firmware apply"}),
+        _tr(412, {"error": "etag required"}),
+    ]
+    card = StubTeacher().induce("redfish", _spec(), "Reset", transitions)
+    assert [rule.match["status"] for rule in card.error_taxonomy] == [409, 412]
+    assert card.error_taxonomy[0].evidence_ids == ["t0", "t1"]
+    assert card.error_taxonomy[1].evidence_ids == ["t2"]
+
+
+def test_stub_reports_empty_card_for_no_relevant_evidence() -> None:
+    """A tool/op with no matching transitions produces no unsupported claims."""
+    card = StubTeacher().induce("redfish", _spec(), "Reset", [_tr(500, {}, op="Other")])
+    assert card.expected_response == {}
+    assert card.error_taxonomy == []
+    assert card.provenance["evidence_ids"] == []
+    assert card.provenance["k_observed"] == 0
+
+
+def test_stub_signature_falls_back_for_non_dict_schema_fragments() -> None:
+    """Non-dict schema fragments are accepted as string slots, not treated as errors."""
+    spec = ToolSpec(
+        "ComputerSystem",
+        ["Reset"],
+        arg_schema={"Reset": {"ResetType": "string"}},
+        risk_level=RiskLevel.MUTATING,
+    )
+    card = StubTeacher().induce("redfish", spec, "Reset", [_tr(204, {"TaskState": "x"})])
+    assert card.effective_signature == {"ResetType": {"type": "string"}}
+
+
 def test_stub_pulls_enum_from_actioninfo() -> None:
     """ActionInfo enums populate the induced signature (catalog is the enum source)."""
     card = StubTeacher().induce(

--- a/tests/modules/test_train_goal_termination.py
+++ b/tests/modules/test_train_goal_termination.py
@@ -1,0 +1,90 @@
+"""Offline regression for goal-rollout termination in ``IgcAgentTrainer.train_goal``.
+
+``VectorizedRestApiEnv.step`` returns ``done`` (goal reached or horizon) as its third
+value. The rollout must end as soon as any env reports the episode is over; a regression
+where ``done`` was unpacked into an unused name let the loop always run to
+``max_episode_len`` and replay past-terminal transitions. These tests drive the rollout
+with tiny CPU stubs (no model, no real env) and assert the step count matches the env's
+own terminal signal.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+import torch
+
+from igc.modules.igc_train_agent import IgcAgentTrainer
+
+
+class _FakeEnv:
+    """Minimal single-env stub: reports ``done`` after a fixed number of steps."""
+
+    def __init__(self, state_dim: int, done_after: int):
+        self.num_envs = 1
+        self._state = torch.zeros(1, state_dim)
+        self._done_after = done_after
+        self.step_calls = 0
+
+    def reset(self, goal=None, goal_type=None):
+        return self._state.clone(), [{}]
+
+    def add_goal_state(self, _state):
+        return None
+
+    def encode_batched_rest_api_method(self, _method, num_envs):
+        return torch.zeros(num_envs, 2)
+
+    def concat_batch_rest_api_method(self, api_one_hot, method_one_hot):
+        return torch.cat([api_one_hot, method_one_hot], dim=1)
+
+    def step(self, _action):
+        self.step_calls += 1
+        is_done = self.step_calls >= self._done_after
+        done = torch.tensor([is_done])
+        terminated = torch.tensor([is_done])
+        rewards = torch.zeros(1)
+        info = [{"goal_reached": torch.tensor(False)}]
+        return self._state.clone(), rewards, done, terminated, info
+
+
+class _FakeDataset:
+    """Supplies a fixed one-hot action batch for the epsilon-random branch."""
+
+    def __init__(self, api_dim: int):
+        self._api_dim = api_dim
+
+    def sample_batch_of_rest_api(self, num_envs):
+        return None, None, torch.zeros(num_envs, self._api_dim)
+
+
+def _make_trainer(state_dim: int, max_episode_len: int, done_after: int):
+    """Build a trainer with train_goal's dependencies stubbed (bypasses __init__)."""
+    trainer = IgcAgentTrainer.__new__(IgcAgentTrainer)
+    trainer.env = _FakeEnv(state_dim, done_after)
+    trainer.dataset = _FakeDataset(api_dim=3)
+    trainer.current_goal = {"state": torch.zeros(1, state_dim)}
+    trainer.max_episode_len = max_episode_len
+    return trainer
+
+
+def test_rollout_stops_on_env_done():
+    """A first-step env terminal ends the rollout immediately, not at max_episode_len."""
+    trainer = _make_trainer(state_dim=4, max_episode_len=10, done_after=1)
+    trainer.train_goal(epsilon=1.0)
+    assert trainer.env.step_calls == 1
+
+
+def test_rollout_stops_midway_when_env_terminates():
+    """The rollout ends on the step the env first reports done (before the horizon)."""
+    trainer = _make_trainer(state_dim=4, max_episode_len=10, done_after=3)
+    trainer.train_goal(epsilon=1.0)
+    assert trainer.env.step_calls == 3
+
+
+def test_rollout_truncates_at_max_episode_len():
+    """With no env terminal, the horizon guard still caps the rollout length."""
+    trainer = _make_trainer(state_dim=4, max_episode_len=5, done_after=999)
+    trainer.train_goal(epsilon=1.0)
+    assert trainer.env.step_calls == 5
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/modules/train/test_launch.py
+++ b/tests/modules/train/test_launch.py
@@ -8,8 +8,11 @@ sharding. Data/output dirs are intentionally NOT baked in. Pure stdlib.
 Author:
 Mus mbayramo@stanford.edu
 """
+import json
 
-from igc.modules.train.launch import profile_to_argv
+import pytest
+
+from igc.modules.train.launch import main, profile_to_argv
 from igc.modules.train.profiles import resolve_profile
 
 
@@ -54,6 +57,42 @@ def test_override_flows_into_argv():
     """A resolved override (e.g. batch_size) is reflected in the argv."""
     argv = profile_to_argv(resolve_profile("m1_7b_lora", batch_size=16))
     assert _val(argv, "--per_device_train_batch_size") == "16"
+
+
+def test_main_print_argv_applies_typed_set_overrides(capsys):
+    """CLI --set overrides are coerced before printing the igc_main argv."""
+    rc = main([
+        "--profile", "m1_3b_lora",
+        "--set", "batch_size=12",
+        "--set", "lr=2e-4",
+        "--set", "max_steps=25",
+        "--print-argv",
+    ])
+    argv = capsys.readouterr().out.strip().split()
+
+    assert rc == 0
+    assert _val(argv, "--per_device_train_batch_size") == "12"
+    assert _val(argv, "--llm_learning_rate") == "0.0002"
+    assert _val(argv, "--max_train_steps") == "25"
+    assert "--num_train_epochs" not in argv
+
+
+def test_main_prints_public_safe_profile_json(capsys):
+    """Without --print-argv, CLI output is a resolved profile JSON payload."""
+    rc = main(["--profile", "m1_7b_full_zero3", "--set", "num_workers=2"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["profile"] == "m1_7b_full_zero3"
+    assert payload["num_workers"] == 2
+    assert payload["adapter"]["method"] == "full_finetune"
+    assert "json_data_dir" not in payload and "output_dir" not in payload
+
+
+def test_main_rejects_unknown_set_override():
+    """A typo in --set fails loudly instead of silently changing the command."""
+    with pytest.raises(ValueError, match="unknown profile override"):
+        main(["--profile", "m1_3b_lora", "--set", "btch_size=16"])
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/modules/train/test_profiles.py
+++ b/tests/modules/train/test_profiles.py
@@ -17,13 +17,76 @@ from igc.modules.train.profiles import (
     resolve_profile,
 )
 
-_SIX = ["m1_gpt2_smoke", "m1_3b_lora", "m1_7b_lora", "m1_7b_rslora_r32", "m1_3b_full", "m1_7b_full_zero3"]
+_SIX = [
+    "m1_gpt2_smoke",
+    "m1_3b_lora",
+    "m1_7b_lora",
+    "m1_7b_rslora_r32",
+    "m1_3b_full",
+    "m1_7b_full_zero3",
+]
+
+_PROFILE_CASES = [
+    ("m1_gpt2_smoke", "gpt2", False, 8, 1, 5e-5, "none", 256, "no", 50),
+    (
+        "m1_3b_lora", "Qwen/Qwen2.5-3B-Instruct", True, 8, 2,
+        1e-4, "none", 1024, "bf16", None,
+    ),
+    (
+        "m1_7b_lora", "Qwen/Qwen2.5-7B-Instruct", True, 8, 4,
+        1e-4, "none", 1024, "bf16", None,
+    ),
+    (
+        "m1_7b_rslora_r32", "Qwen/Qwen2.5-7B-Instruct", True, 8, 4,
+        1e-4, "none", 1024, "bf16", None,
+    ),
+    (
+        "m1_3b_full", "Qwen/Qwen2.5-3B-Instruct", False, 4, 8,
+        2e-5, "zero3", 1024, "bf16", None,
+    ),
+    (
+        "m1_7b_full_zero3", "Qwen/Qwen2.5-7B-Instruct", False, 2, 16,
+        1e-5, "zero3", 1024, "bf16", None,
+    ),
+]
 
 
 def test_all_six_profiles_registered():
     """Every named profile from the plan is present."""
     names = profile_names()
-    assert set(_SIX) <= set(names)
+    assert names == _SIX
+
+
+@pytest.mark.parametrize(
+    (
+        "name", "model", "use_peft", "batch_size", "grad_accum", "lr",
+        "sharding", "seq_len", "precision", "max_steps",
+    ),
+    _PROFILE_CASES,
+)
+def test_profile_matrix_matches_plan_contract(
+    name,
+    model,
+    use_peft,
+    batch_size,
+    grad_accum,
+    lr,
+    sharding,
+    seq_len,
+    precision,
+    max_steps,
+):
+    """Each named profile keeps the executable launch contract pinned."""
+    p = resolve_profile(name)
+    assert p.model == model
+    assert p.use_peft is use_peft
+    assert p.batch_size == batch_size
+    assert p.grad_accum == grad_accum
+    assert p.lr == lr
+    assert p.sharding == sharding
+    assert p.seq_len == seq_len
+    assert p.precision == precision
+    assert p.max_steps == max_steps
 
 
 def test_7b_rslora_matches_plan_spec():
@@ -64,12 +127,42 @@ def test_resolve_applies_overrides_and_rejects_typos():
         resolve_profile("does_not_exist")
 
 
+def test_resolve_override_does_not_mutate_registered_profile():
+    """Overrides return a copy and leave the registered profile unchanged."""
+    base = resolve_profile("m1_3b_lora")
+    changed = resolve_profile("m1_3b_lora", batch_size=16, lr=2e-4, max_steps=200)
+    again = resolve_profile("m1_3b_lora")
+    assert changed.batch_size == 16 and changed.lr == 2e-4 and changed.max_steps == 200
+    assert again is base
+    assert again.batch_size == 8 and again.lr == 1e-4 and again.max_steps is None
+
+
+def test_peft_false_override_disables_lora_kwargs_even_with_adapter():
+    """A use_peft=False override makes a profile behave as a full fine-tune."""
+    p = resolve_profile("m1_3b_lora", use_peft=False)
+    assert p.adapter is not None
+    assert p.describe()["adapter"]["method"] == "full_finetune"
+    with pytest.raises(ValueError):
+        apply_lora_kwargs(p)
+
+
 def test_adapter_init_maps():
     """Adapter init names map to PEFT init_lora_weights values."""
     assert AdapterSpec(init="pissa").init_lora_weights() == "pissa"
+    assert AdapterSpec(init="eva").init_lora_weights() == "eva"
+    assert AdapterSpec(init="loftq").init_lora_weights() == "loftq"
     assert AdapterSpec(init="default").init_lora_weights() is True
     with pytest.raises(ValueError):
         AdapterSpec(init="nonsense").init_lora_weights()
+
+
+def test_apply_lora_kwargs_preserves_custom_adapter_targets():
+    """Custom adapter init and target modules pass through as PEFT kwargs."""
+    adapter = AdapterSpec(init="loftq", target_modules=("x_proj",))
+    p = resolve_profile("m1_3b_lora", adapter=adapter)
+    kw = apply_lora_kwargs(p)
+    assert kw["init_lora_weights"] == "loftq"
+    assert kw["target_modules"] == ["x_proj"]
 
 
 def test_describe_is_flat_log_safe_dict():

--- a/tests/modules/train/test_report.py
+++ b/tests/modules/train/test_report.py
@@ -11,6 +11,8 @@ Mus mbayramo@stanford.edu
 
 from pathlib import Path
 
+import pytest
+
 from igc.modules.train.report import ResultBundle, RunManifest, capture_environment, compare
 
 
@@ -104,6 +106,71 @@ def test_enriched_manifest_round_trips(tmp_path: Path) -> None:
     assert back.manifest.dataset["source_mix"]["synthetic"] == 1191
     assert back.manifest.training["epochs_done"] == 3
     assert back.manifest.warnings and back.manifest.environment.get("python")
+
+
+@pytest.mark.parametrize(
+    ("field", "other"),
+    [
+        ("model", "Qwen/Qwen2.5-3B-Instruct"),
+        ("tokenizer", "other-tokenizer"),
+        ("data_manifest", "ds-v2"),
+        ("eval_split", "held-out-b"),
+        ("max_steps", 400),
+        ("seq_len", 2048),
+    ],
+)
+def test_fairness_check_names_each_changed_field(field: str, other) -> None:
+    """Each apples-to-apples manifest field is flagged when it differs."""
+    base = _bundle("lora", 16, {"recall@1": 0.6})
+    changed = _bundle("rslora", 32, {"recall@1": 0.7})
+    setattr(changed.manifest, field, other)
+
+    rep = compare([base, changed])
+    assert any(issue.startswith(f"{field} differs") for issue in rep.fairness_issues)
+
+
+def test_from_dict_defaults_missing_optional_collections() -> None:
+    """Partial JSON from an older report still loads with safe defaults."""
+    bundle = ResultBundle.from_dict({
+        "manifest": {
+            "run_id": "legacy-r1",
+            "profile": "m1_3b_lora",
+            "model": "Qwen/Qwen2.5-3B-Instruct",
+        },
+        "metrics": {"recall@1": 0.5},
+    })
+
+    assert bundle.plots_dir == ""
+    assert bundle.best_examples == []
+    assert bundle.worst_examples == []
+    assert bundle.known_blockers == []
+    assert bundle.manifest.environment == {}
+
+
+def test_duplicate_arm_labels_remain_visible_in_report() -> None:
+    """Duplicate arm labels stay visible instead of hiding that two bundles collided."""
+    first = _bundle("lora", 16, {"recall@1": 0.6})
+    second = _bundle("lora", 16, {"recall@1": 0.7}, split="held-out-b")
+    rep = compare([first, second], baseline="lora")
+
+    assert rep.arms == ["lora-r16", "lora-r16"]
+    assert rep.baseline == "lora-r16"
+    assert "lora-r16" in rep.table
+    assert rep.table["lora-r16"]["recall@1"] == 0.7
+    assert any("eval_split differs" in issue for issue in rep.fairness_issues)
+
+
+def test_markdown_renders_missing_metrics_and_baseline() -> None:
+    """Markdown shows missing metrics and labels the selected baseline row."""
+    rep = compare([
+        _bundle("lora", 16, {"recall@1": 0.6}),
+        _bundle("dora", 16, {"probe_macro_f1": 0.8}),
+    ], baseline="lora")
+
+    markdown = rep.to_markdown()
+    assert "lora-r16 *(baseline)*" in markdown
+    assert "| dora-r16 | 0.8 | — |" in markdown
+    assert "Deltas vs. baseline `lora-r16`" in markdown
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/shared/test_accelerator_sharding.py
+++ b/tests/shared/test_accelerator_sharding.py
@@ -9,6 +9,8 @@ Mus mbayramo@stanford.edu
 """
 import argparse
 
+import pytest
+
 from igc.shared.shared_accelerator import sharding_config
 
 
@@ -60,6 +62,22 @@ def test_unsharded_run_keeps_user_precision():
     """A precision set on an unsharded run is honored (not overridden to bf16)."""
     c = sharding_config(_ns(sharding="none", mixed_precision="fp16"))
     assert c["sharded"] is False and c["mixed_precision"] == "fp16"
+
+
+def test_unknown_sharding_mode_raises():
+    """An unsupported mode (bypassing the CLI ``choices`` guard) fails fast, not silently.
+
+    Without the guard ``zero4`` would map to ``sharded=True, zero_stage=None`` and build a
+    broken DeepSpeed plugin at runtime; the guard rejects it with the offending value named.
+    """
+    with pytest.raises(ValueError, match="zero4"):
+        sharding_config(_ns(sharding="zero4"))
+
+
+def test_missing_sharding_attr_defaults_to_none():
+    """A Namespace without ``sharding`` at all defaults to the valid 'none' (no raise)."""
+    c = sharding_config(argparse.Namespace())
+    assert c["sharded"] is False and c["sharding"] == "none"
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/shared/test_accelerator_sharding.py
+++ b/tests/shared/test_accelerator_sharding.py
@@ -8,10 +8,12 @@ Author:
 Mus mbayramo@stanford.edu
 """
 import argparse
+import sys
+import types
 
 import pytest
 
-from igc.shared.shared_accelerator import sharding_config
+from igc.shared.shared_accelerator import build_accelerator, sharding_config
 
 
 def _ns(**kw):
@@ -19,6 +21,33 @@ def _ns(**kw):
     kw.setdefault("mixed_precision", None)
     kw.setdefault("gradient_accumulation_steps", 1)
     return argparse.Namespace(**kw)
+
+
+def _fake_accelerate(monkeypatch):
+    """Install a tiny accelerate surface so builder tests stay CPU/offline."""
+
+    class FakeAccelerator:
+        calls = []
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.calls.append(kwargs)
+
+    class FakeDeepSpeedPlugin:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class FakeFSDPPlugin:
+        pass
+
+    accelerate = types.ModuleType("accelerate")
+    accelerate_utils = types.ModuleType("accelerate.utils")
+    accelerate.Accelerator = FakeAccelerator
+    accelerate_utils.DeepSpeedPlugin = FakeDeepSpeedPlugin
+    accelerate_utils.FullyShardedDataParallelPlugin = FakeFSDPPlugin
+    monkeypatch.setitem(sys.modules, "accelerate", accelerate)
+    monkeypatch.setitem(sys.modules, "accelerate.utils", accelerate_utils)
+    return FakeAccelerator, FakeDeepSpeedPlugin, FakeFSDPPlugin
 
 
 def test_none_is_unsharded_ddp():
@@ -78,6 +107,62 @@ def test_missing_sharding_attr_defaults_to_none():
     """A Namespace without ``sharding`` at all defaults to the valid 'none' (no raise)."""
     c = sharding_config(argparse.Namespace())
     assert c["sharded"] is False and c["sharding"] == "none"
+
+
+def test_build_accelerator_unsharded_forwards_safe_runtime_args(monkeypatch):
+    """Unsharded build forwards device placement, precision, and grad accumulation."""
+    fake_accelerator, _, _ = _fake_accelerate(monkeypatch)
+
+    accelerator = build_accelerator(
+        _ns(
+            sharding="none",
+            device_placement=False,
+            mixed_precision="fp16",
+            gradient_accumulation_steps=4,
+        )
+    )
+
+    assert isinstance(accelerator, fake_accelerator)
+    assert fake_accelerator.calls == [
+        {
+            "device_placement": False,
+            "mixed_precision": "fp16",
+            "gradient_accumulation_steps": 4,
+        }
+    ]
+
+
+def test_build_accelerator_zero3_offload_uses_deepspeed_plugin(monkeypatch):
+    """zero3_offload builds a CPU-offload DeepSpeed plugin and lets it place models."""
+    fake_accelerator, fake_deepspeed, _ = _fake_accelerate(monkeypatch)
+
+    build_accelerator(_ns(sharding="zero3_offload", gradient_accumulation_steps=3))
+
+    kwargs = fake_accelerator.calls[-1]
+    plugin = kwargs["deepspeed_plugin"]
+    assert isinstance(plugin, fake_deepspeed)
+    assert "device_placement" not in kwargs
+    assert kwargs["mixed_precision"] == "bf16"
+    assert kwargs["gradient_accumulation_steps"] == 3
+    assert plugin.kwargs == {
+        "zero_stage": 3,
+        "offload_optimizer_device": "cpu",
+        "offload_param_device": "cpu",
+        "gradient_accumulation_steps": 3,
+    }
+
+
+def test_build_accelerator_fsdp_uses_fsdp_plugin(monkeypatch):
+    """fsdp builds the FSDP plugin without constructing a DeepSpeed plugin."""
+    fake_accelerator, _, fake_fsdp = _fake_accelerate(monkeypatch)
+
+    build_accelerator(_ns(sharding="fsdp", mixed_precision="fp8"))
+
+    kwargs = fake_accelerator.calls[-1]
+    assert isinstance(kwargs["fsdp_plugin"], fake_fsdp)
+    assert "deepspeed_plugin" not in kwargs
+    assert "device_placement" not in kwargs
+    assert kwargs["mixed_precision"] == "fp8"
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/shared/test_arg_parser_action_repr.py
+++ b/tests/shared/test_arg_parser_action_repr.py
@@ -10,6 +10,8 @@ Mus mbayramo@stanford.edu
 """
 import sys
 
+import pytest
+
 from igc.shared.shared_arg_parser import shared_arg_parser
 
 
@@ -33,6 +35,12 @@ def test_action_repr_pointer_selectable(monkeypatch):
     assert args.action_repr == "pointer"
 
 
+def test_action_repr_rejects_unknown_mode(monkeypatch):
+    """--action_repr rejects unimplemented modes instead of silently accepting them."""
+    with pytest.raises(SystemExit):
+        _parse(monkeypatch, ["--action_repr", "tool"])
+
+
 def test_raw_data_dir_is_defined(monkeypatch):
     """--raw_data_dir exists with a sensible default (fixes the AttributeError)."""
     args = _parse(monkeypatch, [])
@@ -52,14 +60,84 @@ def test_model_type_is_free_form(monkeypatch):
     assert args.model_type == "meta-llama/Meta-Llama-3-8B"
 
 
+def test_large_model_loader_flags_parse(monkeypatch):
+    """Large-backbone loader flags are available without importing a model."""
+    defaults = _parse(monkeypatch, [])
+    assert defaults.trust_remote_code is False
+    assert defaults.llm_torch_dtype is None
+
+    args = _parse(
+        monkeypatch,
+        [
+            "--model_type",
+            "/models/DeepSeek-V4-Flash",
+            "--trust_remote_code",
+            "--llm_torch_dtype",
+            "bfloat16",
+        ],
+    )
+    assert args.model_type == "/models/DeepSeek-V4-Flash"
+    assert args.trust_remote_code is True
+    assert args.llm_torch_dtype == "bfloat16"
+
+
+def test_large_model_dtype_rejects_unknown_value(monkeypatch):
+    """--llm_torch_dtype stays constrained to supported loader values."""
+    with pytest.raises(SystemExit):
+        _parse(monkeypatch, ["--llm_torch_dtype", "int8"])
+
+
 def test_peft_flags(monkeypatch):
     """--use_peft defaults off; LoRA hyperparams have sane defaults and parse."""
     defaults = _parse(monkeypatch, [])
     assert defaults.use_peft is False
-    assert defaults.lora_r == 16 and defaults.lora_alpha == 32 and defaults.lora_target_modules is None
+    assert defaults.lora_r == 16
+    assert defaults.lora_alpha == 32
+    assert defaults.lora_target_modules is None
     on = _parse(monkeypatch, ["--use_peft", "--lora_r", "8", "--lora_target_modules", "q_proj", "v_proj"])
     assert on.use_peft is True and on.lora_r == 8
     assert on.lora_target_modules == ["q_proj", "v_proj"]
+
+
+def test_sharding_and_accelerator_flags_parse(monkeypatch):
+    """Sharding and accelerator flags parse without importing DeepSpeed or Accelerate."""
+    args = _parse(
+        monkeypatch,
+        [
+            "--sharding",
+            "zero3",
+            "--mixed_precision",
+            "bf16",
+            "--use_accelerator",
+        ],
+    )
+    assert args.sharding == "zero3"
+    assert args.mixed_precision == "bf16"
+    assert args.use_accelerator is True
+    assert args.device is None
+
+
+def test_redfish_connection_flags_parse_without_live_mode(monkeypatch):
+    """Redfish connection flags parse but do not imply live execution."""
+    args = _parse(
+        monkeypatch,
+        [
+            "--redfish-ip",
+            "https://example.invalid",
+            "--redfish-port",
+            "8443",
+            "--insecure",
+            "--is-http",
+            "--x-auth",
+            "placeholder-token",
+        ],
+    )
+    assert args.live is False
+    assert args.redfish_ip == "https://example.invalid"
+    assert args.redfish_port == 8443
+    assert args.insecure is True
+    assert args.is_http is True
+    assert args.x_auth == "placeholder-token"
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/test_conftest_stub_encoder.py
+++ b/tests/test_conftest_stub_encoder.py
@@ -1,0 +1,52 @@
+"""Tests for the shared ``StubEncoder`` fixtures in ``tests/conftest.py``.
+
+These guard the encoder contract that other offline tests rely on: a
+deterministic, CPU-only encoder with the expected output shape that records the
+observations it is handed.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import torch
+
+
+def test_stub_encoder_output_shape_and_dtype(stub_encoder):
+    """encode() returns a float32 tensor of the advertised emb_shape."""
+    out = stub_encoder.encode("/redfish/v1")
+    assert out.shape == stub_encoder.emb_shape
+    assert out.dtype == torch.float32
+
+
+def test_stub_encoder_is_deterministic(stub_encoder):
+    """Equal observations encode to equal tensors (no randomness/I/O)."""
+    first = stub_encoder.encode("same-observation")
+    second = stub_encoder.encode("same-observation")
+    assert torch.equal(first, second)
+
+
+def test_stub_encoder_distinguishes_inputs(stub_encoder):
+    """Different observations map to different embeddings."""
+    a = stub_encoder.encode("observation-a")
+    b = stub_encoder.encode("observation-b")
+    assert not torch.equal(a, b)
+
+
+def test_stub_encoder_records_calls(stub_encoder):
+    """Every encoded observation is appended to calls in order."""
+    stub_encoder.encode("first")
+    stub_encoder.encode("second")
+    assert stub_encoder.calls == ["first", "second"]
+
+
+def test_stub_encoder_cls_fixture_constructs_with_model_and_tokenizer(stub_encoder_cls):
+    """The class fixture builds with (model, tokenizer) like the real encoder."""
+    sentinel_model = object()
+    sentinel_tok = object()
+    encoder = stub_encoder_cls(model=sentinel_model, tokenizer=sentinel_tok)
+    assert encoder.model is sentinel_model
+    assert encoder.tokenizer is sentinel_tok
+    assert encoder.calls == []
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/test_dataset_tokenizer_model_type.py
+++ b/tests/test_dataset_tokenizer_model_type.py
@@ -1,0 +1,120 @@
+"""Offline regression tests for JSONDataset tokenizer selection.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from pathlib import Path
+
+import pytest
+
+from igc.ds import redfish_dataset
+from igc.ds.redfish_dataset import JSONDataset
+
+
+class FakeTokenizer:
+    """Tiny tokenizer double with the methods JSONDataset uses at construction."""
+
+    eos_token = "<eos>"
+    eos_token_id = 2
+
+    def __init__(self, name_or_path: str, *, pad_token=None, pad_token_id=None):
+        self.name_or_path = name_or_path
+        self.pad_token = pad_token
+        self.pad_token_id = pad_token_id
+        self.added_tokens = []
+        self.special_token_maps = []
+        self.vocab_size = 100
+
+    def add_tokens(self, tokens, special_tokens: bool = False):
+        """Record added tokens and return how many would have been added."""
+        self.added_tokens.append((tuple(tokens), special_tokens))
+        return len(tokens)
+
+    def __len__(self):
+        """Return a stable fake vocabulary size."""
+        return self.vocab_size
+
+    def add_special_tokens(self, special_tokens_dict):
+        """Record special-token maps and return the number of mapped tokens."""
+        self.special_token_maps.append(special_tokens_dict)
+        return len(special_tokens_dict.get("additional_special_tokens", ()))
+
+    def save_pretrained(self, tokenizer_dir: str):
+        """Create the tokenizer directory, matching the HuggingFace save contract needed here."""
+        Path(tokenizer_dir).mkdir(parents=True, exist_ok=True)
+        return (tokenizer_dir,)
+
+
+def test_default_tokenize_builds_backbone_tokenizer_without_gpt2_overwrite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-GPT2 default_tokenize path drives AutoTokenizer and is not replaced by GPT2."""
+    model_id = "vendor/non-gpt2-backbone"
+    auto_calls = []
+
+    class FakeAutoTokenizer:
+        @staticmethod
+        def from_pretrained(name_or_path):
+            auto_calls.append(str(name_or_path))
+            pad_token = "<pad>" if Path(str(name_or_path)).name == "tokenizer" else None
+            pad_token_id = 0 if pad_token is not None else None
+            return FakeTokenizer(
+                str(name_or_path),
+                pad_token=pad_token,
+                pad_token_id=pad_token_id,
+            )
+
+    class FailingGPT2Tokenizer:
+        @staticmethod
+        def from_pretrained(name_or_path):
+            raise AssertionError(f"unexpected GPT2 fallback for {name_or_path}")
+
+    monkeypatch.setattr(redfish_dataset, "AutoTokenizer", FakeAutoTokenizer)
+    monkeypatch.setattr(redfish_dataset, "GPT2Tokenizer", FailingGPT2Tokenizer)
+    monkeypatch.setattr(JSONDataset, "_build_tokenizer", lambda self: None)
+
+    dataset = JSONDataset(
+        dataset_dir=str(tmp_path / "dataset"),
+        raw_json_directory_path=str(tmp_path / "raw-json"),
+        default_tokenize=model_id,
+        skip_download=True,
+        skip_creation=True,
+    )
+
+    assert auto_calls[0] == model_id
+    assert auto_calls[1] == dataset.tokenizer_dir()
+    assert dataset._default_tokenize_name == model_id
+    assert dataset.tokenizer.name_or_path == dataset.tokenizer_dir()
+    assert dataset.tokenizer.pad_token == "<pad>"
+
+
+def test_injected_tokenizer_skips_backbone_factory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit tokenizer remains authoritative and avoids Auto/GPT2 factories."""
+    tokenizer = FakeTokenizer("provided-tokenizer", pad_token="<pad>", pad_token_id=0)
+
+    class FailingTokenizerFactory:
+        @staticmethod
+        def from_pretrained(name_or_path):
+            raise AssertionError(f"unexpected tokenizer factory call for {name_or_path}")
+
+    monkeypatch.setattr(redfish_dataset, "AutoTokenizer", FailingTokenizerFactory)
+    monkeypatch.setattr(redfish_dataset, "GPT2Tokenizer", FailingTokenizerFactory)
+
+    dataset = JSONDataset(
+        dataset_dir=str(tmp_path / "dataset"),
+        raw_json_directory_path=str(tmp_path / "raw-json"),
+        default_tokenize="vendor/non-gpt2-backbone",
+        tokenizer=tokenizer,
+        skip_download=True,
+        skip_creation=True,
+    )
+
+    assert dataset.tokenizer is tokenizer
+    assert dataset._dataset_file_name.endswith("processed_dataset_provided-tokenizer.pt")
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/test_save_spec_redaction.py
+++ b/tests/test_save_spec_redaction.py
@@ -9,7 +9,25 @@ Mus mbayramo@stanford.edu
 import argparse
 import json
 
+import pytest
+
 from igc_main import _is_sensitive, save_spec
+
+
+@pytest.mark.parametrize(
+    "key",
+    (
+        "IDRAC_PASSWORD",
+        "HUGGINGFACE_TOKEN",
+        "OPENAI_API_KEY",
+        "WANDB_APIKEY",
+        "client_secret",
+        "x_auth",
+    ),
+)
+def test_is_sensitive_accepts_common_secret_spellings(key):
+    """Common token/key/password spellings are treated as credential-bearing keys."""
+    assert _is_sensitive(key)
 
 
 def test_is_sensitive_flags_credentials_only():
@@ -35,6 +53,34 @@ def test_save_spec_redacts_password_keeps_nonsecrets(tmp_path):
     assert written["model_type"] == "gpt2"
     blob = json.dumps(written)
     assert "hunter2" not in blob and "tok-abc" not in blob
+
+
+def test_save_spec_redacts_secret_patterns_across_sections(tmp_path):
+    """Secret-like args in any parser section are masked before parameters.json is written."""
+    cluster = argparse.ArgumentParser()
+    cluster.add_argument("--idrac-password", default="idrac-pass")
+    cluster.add_argument("--huggingface-token", default="hf-token")
+    cluster.add_argument("--target-node", default="slot13")
+
+    tracking = argparse.ArgumentParser()
+    tracking.add_argument("--wandb-api-key", dest="WANDB_APIKEY", default="wandb-key")
+    tracking.add_argument("--client-secret", default="client-secret")
+    tracking.add_argument("--metric-report", default="wandb")
+
+    cmd = argparse.Namespace(output_dir=str(tmp_path))
+    save_spec(cmd, [("cluster", cluster), ("tracking", tracking)])
+
+    written = json.loads((tmp_path / "parameters.json").read_text())
+    assert written["cluster"]["idrac_password"] == "***REDACTED***"
+    assert written["cluster"]["huggingface_token"] == "***REDACTED***"
+    assert written["cluster"]["target_node"] == "slot13"
+    assert written["tracking"]["WANDB_APIKEY"] == "***REDACTED***"
+    assert written["tracking"]["client_secret"] == "***REDACTED***"
+    assert written["tracking"]["metric_report"] == "wandb"
+
+    blob = json.dumps(written)
+    for raw_secret in ("idrac-pass", "hf-token", "wandb-key", "client-secret"):
+        assert raw_secret not in blob
 
 
 def test_save_spec_leaves_empty_password_untouched(tmp_path):

--- a/train_llm.sh
+++ b/train_llm.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 python trainer.py --train llm --num_train_epochs 10 --llm latent --llm_log_level info --log_level info
-
 python trainer.py --train llm --num_train_epochs 10 --llm encoder --llm_log_level info --log_level info
 
 


### PR DESCRIPTION
## Summary

Brings the recent feature series to main: a provenance-tagged data-source layer for the training pipeline, offline extraction of Redfish argument value spaces for the stage-2 argument decoder, a batch of RL/training correctness fixes, and a broad expansion of the offline CPU test suite.

### Data-source layer (`igc/ds/sources`)
- `SourceAdapter` / `SourceRecord` / `TrustLevel` contract: every record carries where it came from and how much it can be trusted (real > replay > sim tiers).
- `RedfishFixtureSource`: offline adapter over captured per-resource JSON (`~/.json_responses/<host>/` layout and the vendor fixture corpora), keyed on canonical `@odata.id`.
- `SourceMix` + `DataManifest`: deterministic trust-tier train/eval split (hash-based, reproducible) wired into `RunManifest` for fair-comparison checks.
- `TrainingExample` normalizer and JSONL corpus reader/writer (`corpus_io`).

### Redfish enum-space extraction (`redfish_enum_space.py`, new)
- Classifies captured resources by `@odata.type` and extracts per-slot argument value spaces from BIOS attribute registries, `#ActionInfo` bodies, inline `@Redfish.AllowableValues` annotations, and `#BootOption` references.
- `EnumSpaceIndex` folds a record stream into the `arg_schema` fragments the stage-2 argument decoder consumes (round-trip pinned in tests). ActionInfo takes precedence over inline annotations; read-only attributes never enter PATCH schemas.
- Validated against the three vendor fixture corpora plus a live capture tree: 2,030 records, zero parse skips, 380 patchable slots (97 categorical), 9 action parameters, 24 boot references.
- Design note: `docs/REDFISH_ENUM_SPACES.md`.

### RL / training correctness
- DQN target: treat an all-illegal next state as terminal; stop goal rollouts on env terminal rather than max episode length.
- Replay buffer: coerce ragged done flags before stacking.
- Checkpoint loader: fix inverted `best_accuracy` sentinel and honor `map_location`.
- Train loop: honor `--max_train_steps`, drop per-step `empty_cache`, honor grad-accum, pin H2D transfers; reject unknown `--sharding` modes.

### Tests and docs
- Offline edge-case coverage across the argument decoder, action codec, replay buffer, loaders, parsers, tool teacher/grounding, PEFT save modules, and the REST mock env; shared `StubEncoder` fixtures; a CPU training pass for the state-encoder LLM.
- Training runbook, math-gate and training-optimization docs, module docstring cleanups.
- `idrac_ctl` submodule bump (boot-state + bios-snapshot commands, exporter fix).

## Test plan
- Offline gate: `pytest tests -q` (CPU-only, no network/GPU/downloads) — 357 passed; the 13 remaining failures are pre-existing legacy dataset/module tests that also fail on the base commit.
- `tests/ds`: 57 passed. `ruff check` clean on changed files.