### PR TITLE
Wire the provenance-tagged corpus into M1 training and emit run reports

### DIFF
--- a/igc/ds/corpus_dataset.py
+++ b/igc/ds/corpus_dataset.py
@@ -1,0 +1,148 @@
+"""
+Torch dataset over a written training corpus (the tokenizer bridge).
+
+Feeds the provenance-tagged corpus produced by the ``igc.ds.sources`` pipeline
+(``write_corpus`` -> ``examples.jsonl`` + ``manifest.json``) into the existing M1
+state-encoder training loop. Each example is rendered as its request line plus the
+response JSON, tokenized once at construction to the same fixed-length
+``input_ids``/``attention_mask`` items the trainer's collate function stacks — so the
+trainer consumes a trust-tier-split corpus without any loop changes.
+
+The class duck-types the surface the trainer touches on ``MaskedJSONDataset``:
+``tokenizer``/``load_tokenizer`` plus the masking-method hooks, which are no-ops here
+because a written corpus trains the plain causal-LM (NO_MASK) objective.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, List, Optional
+
+import torch
+from torch.utils.data import Dataset
+
+from igc.ds.sources.corpus_io import iter_examples, read_manifest
+from igc.ds.sources.mixer import DataManifest
+
+
+class CorpusJSONLDataset(Dataset):
+    """Fixed-length tokenized dataset over a ``write_corpus`` output directory.
+
+    :param corpus_dir: directory holding ``examples.jsonl`` (and ``manifest.json``).
+    :param default_tokenize: HF tokenizer id/path used when ``tokenizer`` is not given.
+    :param max_len: fixed sequence length every item is padded/truncated to.
+    :param tokenizer: pre-built tokenizer (tests inject one; training resolves from
+        ``default_tokenize`` lazily so importing this module stays offline-safe).
+    :raises FileNotFoundError: when ``corpus_dir`` has no ``examples.jsonl``.
+    """
+
+    def __init__(self,
+                 corpus_dir: str,
+                 default_tokenize: Optional[str] = "gpt2",
+                 max_len: Optional[int] = 1024,
+                 tokenizer: Optional[Any] = None):
+        self._corpus_dir = os.path.abspath(os.path.expanduser(corpus_dir))
+        self._default_tokenize = default_tokenize
+        self._max_len = max_len
+        self._tokenizer = tokenizer
+
+        examples_path = os.path.join(self._corpus_dir, "examples.jsonl")
+        if not os.path.isfile(examples_path):
+            raise FileNotFoundError(f"no examples.jsonl under {self._corpus_dir}")
+
+        manifest_path = os.path.join(self._corpus_dir, "manifest.json")
+        self.manifest: Optional[Dict] = (
+            read_manifest(manifest_path) if os.path.isfile(manifest_path) else None)
+
+        self._data: List[Dict[str, torch.Tensor]] = []
+        tok = self.tokenizer
+        for example in iter_examples(examples_path):
+            action = example.get("request_or_action", {}) or {}
+            text = (f"{action.get('method', 'GET')} {action.get('url', '')}\n"
+                    f"{json.dumps(example.get('response', {}), sort_keys=True)}")
+            out = tok(text, padding="max_length", max_length=self._max_len,
+                      truncation=True, return_tensors="pt")
+            self._data.append({
+                "input_ids": out["input_ids"].squeeze(0),
+                "attention_mask": out["attention_mask"].squeeze(0),
+            })
+
+    # --- tokenizer surface (mirrors JSONDataset) ---------------------------------
+
+    @property
+    def tokenizer(self):
+        """The dataset tokenizer, resolved from ``default_tokenize`` on first use."""
+        if self._tokenizer is None:
+            self.load_tokenizer()
+        return self._tokenizer
+
+    def load_tokenizer(self) -> None:
+        """Build the tokenizer from ``default_tokenize`` (pad falls back to eos)."""
+        if self._tokenizer is None:
+            from transformers import AutoTokenizer
+            self._tokenizer = AutoTokenizer.from_pretrained(self._default_tokenize)
+        if self._tokenizer.pad_token is None:
+            self._tokenizer.pad_token = self._tokenizer.eos_token
+
+    # --- provenance for run reports -----------------------------------------------
+
+    def run_manifest_fields(self) -> Dict[str, str]:
+        """``{data_manifest, eval_split}`` for the run report, or empty strings.
+
+        Reconstructs the :class:`DataManifest` written next to the corpus so the run
+        report carries the same content hash / split id the mixer computed.
+
+        :return: dict with ``data_manifest`` and ``eval_split`` keys.
+        """
+        if not self.manifest:
+            return {"data_manifest": "", "eval_split": ""}
+        manifest = DataManifest(**self.manifest)
+        return manifest.to_run_manifest_fields()
+
+    # --- masking surface the trainer may touch (NO_MASK corpus: all no-ops) --------
+
+    def disable_masking(self) -> None:
+        """No-op: a written corpus trains the plain causal-LM objective."""
+
+    def enable_masking(self, *args, **kwargs) -> None:
+        """No-op: span masking is not defined for the packed corpus."""
+
+    def mask_section(self, *args, **kwargs) -> None:
+        """No-op masking hook (see :meth:`enable_masking`)."""
+
+    def mask_new_tokens(self, *args, **kwargs) -> None:
+        """No-op masking hook (see :meth:`enable_masking`)."""
+
+    def mask_targets(self, *args, **kwargs) -> None:
+        """No-op masking hook (see :meth:`enable_masking`)."""
+
+    def mask_allowed_value(self, *args, **kwargs) -> None:
+        """No-op masking hook (see :meth:`enable_masking`)."""
+
+    def mask_odata_id(self, *args, **kwargs) -> None:
+        """No-op masking hook (see :meth:`enable_masking`)."""
+
+    def mask_targets_key(self, *args, **kwargs) -> None:
+        """No-op masking hook (see :meth:`enable_masking`)."""
+
+    def mask_objects(self, *args, **kwargs) -> None:
+        """No-op masking hook (see :meth:`enable_masking`)."""
+
+    def mask_arrays(self, *args, **kwargs) -> None:
+        """No-op masking hook (see :meth:`enable_masking`)."""
+
+    # --- torch Dataset -------------------------------------------------------------
+
+    def __len__(self) -> int:
+        """Number of tokenized examples."""
+        return len(self._data)
+
+    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
+        """The fixed-length ``input_ids``/``attention_mask`` item at ``idx``."""
+        return self._data[idx]
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/igc/ds/redfish_dataset.py
+++ b/igc/ds/redfish_dataset.py
@@ -1506,6 +1506,30 @@ class JSONDataset(
         """
         self._masked_data = value
 
+    def __getstate__(self):
+        """Drop the unpicklable logger state so DataLoader workers can spawn.
+
+        ``self.logger`` (loguru with stdout + file sinks) and the build-time
+        ``RestTrajectory`` (which binds its own loguru logger) hold open file
+        handles that cannot pickle; workers only need ``__len__``/``__getitem__``
+        over ``self._data``, so both are dropped and the logger is rebuilt on
+        unpickle.
+
+        :return: the instance dict minus the unpicklable members.
+        """
+        state = self.__dict__.copy()
+        state["logger"] = None
+        state["_rest_trajectories"] = None
+        return state
+
+    def __setstate__(self, state):
+        """Restore the instance and rebuild a process-local logger.
+
+        :param state: the dict produced by :meth:`__getstate__`.
+        """
+        self.__dict__.update(state)
+        self.logger = AbstractLogger.create_logger(__name__)
+
     def __len__(self):
         """Return length of dataset"""
         return len(self._data["train_data"])

--- a/igc/ds/redfish_dataset.py
+++ b/igc/ds/redfish_dataset.py
@@ -23,6 +23,7 @@ import os
 import random
 import shutil
 import sys
+import warnings
 import time
 import zlib
 from pathlib import Path
@@ -758,11 +759,20 @@ class JSONDataset(
         :raises ValueError: on a provenance mismatch, with a rebuild hint.
         """
         recorded_tokens = tokenizer_spec.get("num_tokens")
-        if recorded_tokens is not None and int(recorded_tokens) != int(num_tokens):
+        if recorded_tokens is not None and int(recorded_tokens) > int(num_tokens):
+            # cache token ids can exceed the live vocab -> corruption; refuse.
             raise ValueError(
                 f"Dataset caches were tokenized with a {recorded_tokens}-token tokenizer "
-                f"but the loaded tokenizer has {num_tokens} tokens. Rebuild the dataset "
-                f"for this backbone with --recreate_dataset.")
+                f"but the loaded tokenizer has only {num_tokens} tokens. Rebuild the "
+                f"dataset for this backbone with --recreate_dataset.")
+        if recorded_tokens is not None and int(recorded_tokens) < int(num_tokens):
+            # a tokenizer that grew (appended specials) keeps existing ids stable;
+            # loading is safe, but flag it so a rebuild is a conscious choice.
+            warnings.warn(
+                f"Dataset caches were built with a {recorded_tokens}-token tokenizer; "
+                f"the loaded one has {num_tokens} (grew by "
+                f"{int(num_tokens) - int(recorded_tokens)}). Existing ids remain valid; "
+                f"rebuild with --recreate_dataset to cover the new tokens.")
         recorded_model = tokenizer_spec.get("model_type")
         if recorded_model is not None and model_type is not None and recorded_model != model_type:
             raise ValueError(

--- a/igc/modules/igc_main.py
+++ b/igc/modules/igc_main.py
@@ -81,13 +81,25 @@ class IgcMain:
         :return:
         """
         if self._dataset is None:
-            self._dataset = MaskedJSONDataset(
-                self._dataset_dir,
-                default_tokenize=self._specs.model_type,
-                max_len=self._specs.seq_len,
-                recreate_dataset=self._specs.recreate_dataset,
-                do_consistency_check=self._specs.do_consistency_check
-            )
+            corpus_dir = getattr(self._specs, "corpus_dir", "") or ""
+            if corpus_dir:
+                # --corpus_dir selects the provenance-tagged JSONL corpus written by
+                # igc.ds.sources.write_corpus (trust-tier split + manifest) instead of
+                # rebuilding from raw ~/.json_responses captures.
+                from igc.ds.corpus_dataset import CorpusJSONLDataset
+                self._dataset = CorpusJSONLDataset(
+                    corpus_dir,
+                    default_tokenize=self._specs.model_type,
+                    max_len=self._specs.seq_len,
+                )
+            else:
+                self._dataset = MaskedJSONDataset(
+                    self._dataset_dir,
+                    default_tokenize=self._specs.model_type,
+                    max_len=self._specs.seq_len,
+                    recreate_dataset=self._specs.recreate_dataset,
+                    do_consistency_check=self._specs.do_consistency_check
+                )
         return self._dataset
 
     def train(self):

--- a/igc/modules/llm_train_state_encoder.py
+++ b/igc/modules/llm_train_state_encoder.py
@@ -509,6 +509,12 @@ class LlmEmbeddingsTrainer(LlmModule):
         max_steps = getattr(self._trainer_args, "max_train_steps", None)
         global_opt_steps = 0
 
+        # End-of-run report bookkeeping (emitted as report.json on rank zero).
+        run_started_at = time.strftime("%Y-%m-%dT%H:%M:%S")
+        run_started_clock = time.time()
+        final_epoch_loss = None
+        epochs_done = last_epoch
+
         if total_batches == calculated_total_batches:
             print(f"Rank {self.rank}, Staring training, "
                   f"total_batches: {total_batches} "
@@ -625,9 +631,11 @@ class LlmEmbeddingsTrainer(LlmModule):
 
             if num_batches > 0:
                 average_loss = total_loss / num_batches
+                final_epoch_loss = average_loss
                 if self.is_rank_zero():
                     self.metric_logger.log_metric("train/epoch_loss", average_loss, epoch_step)
                 print(f"Rank {self.rank} Epoch {epoch + 1}/{self.num_epochs} - Average Loss: {average_loss}")
+            epochs_done = epoch + 1
 
             # save best checkpoint
             if self.is_rank_zero():
@@ -665,6 +673,33 @@ class LlmEmbeddingsTrainer(LlmModule):
             self.model = self.accelerator.unwrap_model(self.model)
         self.save_model(self._module_checkpoint_dir)
         self.save_finetuned()
+
+        # Emit the self-describing run report (report.json) next to the checkpoint so
+        # every run is comparable through igc.modules.train.report.compare(). Emission
+        # must never take down a finished training run, hence the broad guard.
+        if self.is_rank_zero():
+            try:
+                from igc.modules.train.emit import build_run_bundle, emit_run_report
+                manifest_fields = getattr(self.dataset, "run_manifest_fields", None)
+                bundle = build_run_bundle(
+                    vars(self._trainer_args),
+                    training={
+                        "final_epoch_loss": final_epoch_loss,
+                        "epochs_done": epochs_done,
+                        "optimizer_steps": global_opt_steps,
+                        "best_eval": self._best_validation_metric,
+                    },
+                    metrics={"eval/accuracy": validation_accuracy},
+                    dataset_fields=manifest_fields() if callable(manifest_fields) else None,
+                    started_at=run_started_at,
+                    ended_at=time.strftime("%Y-%m-%dT%H:%M:%S"),
+                    wall_clock_sec=round(time.time() - run_started_clock, 1),
+                    checkpoint_path=str(self._module_checkpoint_dir or ""),
+                )
+                report_path = emit_run_report(bundle, str(self._module_checkpoint_dir or "."))
+                self.logger.info(f"Run report written: {report_path}")
+            except Exception as report_err:  # noqa: BLE001 — report loss < run loss
+                self.logger.warning(f"run-report emission failed: {report_err}")
 
         del train_dataloader
         del eval_dataloader

--- a/igc/modules/train/emit.py
+++ b/igc/modules/train/emit.py
@@ -1,0 +1,114 @@
+"""
+Run-report emission: turn a finished training run into a ResultBundle on disk.
+
+The trainer calls :func:`build_run_bundle` with its parsed spec and end-of-run stats,
+then :func:`emit_run_report` writes ``report.json`` into the run's output directory —
+making every run self-describing (model, adapter, data manifest, environment, final
+metrics) and comparable through the existing ``compare()`` report tooling. Pure
+functions, no trainer imports, so the contract is testable offline.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import os
+import sys
+from typing import Dict, List, Optional
+
+from igc.modules.train.report import ResultBundle, RunManifest, capture_environment
+
+# spec keys copied into RunManifest.settings — the run knobs that matter for
+# reproducing/comparing a run (never secrets; see _SENSITIVE_MARKERS).
+_SETTINGS_KEYS = (
+    "per_device_train_batch_size", "gradient_accumulation_steps", "num_train_epochs",
+    "llm_learning_rate", "llm_scheduler", "llm_optimizer", "mixed_precision",
+    "sharding", "use_accelerator", "use_peft", "lora_r", "lora_alpha", "lora_dropout",
+    "masking_type", "num_workers", "seed",
+)
+
+# any spec key containing one of these is never emitted, whatever its value.
+_SENSITIVE_MARKERS = ("token", "key", "password", "secret", "credential")
+
+
+def _scrub(spec_vars: Dict) -> Dict:
+    """Copy selected run settings from the spec, refusing sensitive keys.
+
+    :param spec_vars: ``vars(spec)`` from the argument parser.
+    :return: settings dict safe to persist in a report.
+    """
+    settings = {}
+    for key in _SETTINGS_KEYS:
+        if any(marker in key.lower() for marker in _SENSITIVE_MARKERS):
+            continue
+        if key in spec_vars:
+            settings[key] = str(spec_vars[key])
+    return settings
+
+
+def build_run_bundle(spec_vars: Dict, *,
+                     training: Dict,
+                     metrics: Optional[Dict] = None,
+                     dataset_fields: Optional[Dict] = None,
+                     argv: Optional[List[str]] = None,
+                     started_at: str = "",
+                     ended_at: str = "",
+                     wall_clock_sec: Optional[float] = None,
+                     checkpoint_path: str = "") -> ResultBundle:
+    """Assemble a ResultBundle for a finished run.
+
+    :param spec_vars: ``vars(spec)`` — model/adapters/settings are read from here.
+    :param training: end-of-run stats (e.g. ``final_epoch_loss``, ``epochs_done``,
+        ``optimizer_steps``, ``best_eval``).
+    :param metrics: headline metric values for the comparison table.
+    :param dataset_fields: ``{"data_manifest", "eval_split"}`` from the corpus
+        (``CorpusJSONLDataset.run_manifest_fields``), empty when training from raw captures.
+    :param argv: the launch command (defaults to ``sys.argv``).
+    :param started_at: ISO start timestamp.
+    :param ended_at: ISO end timestamp.
+    :param wall_clock_sec: run duration in seconds.
+    :param checkpoint_path: where the run saved its model.
+    :return: the assembled :class:`ResultBundle`.
+    """
+    dataset_fields = dataset_fields or {}
+    model = str(spec_vars.get("model_type", ""))
+    use_peft = bool(spec_vars.get("use_peft", False))
+    started_tag = started_at.replace(":", "").replace("-", "") or "run"
+    manifest = RunManifest(
+        run_id=f"m1-{os.path.basename(model) or 'model'}-{started_tag}",
+        profile=str(spec_vars.get("profile", "") or ""),
+        model=model,
+        tokenizer=model,
+        adapter_method=str(spec_vars.get("adapter_method", "lora")) if use_peft else "none",
+        adapter_rank=int(spec_vars["lora_r"]) if use_peft and "lora_r" in spec_vars else None,
+        adapter_init=str(spec_vars.get("lora_init", "default") or "default"),
+        data_manifest=str(dataset_fields.get("data_manifest", "")),
+        eval_split=str(dataset_fields.get("eval_split", "")),
+        max_steps=spec_vars.get("max_train_steps"),
+        seq_len=spec_vars.get("seq_len"),
+        settings=_scrub(spec_vars),
+        argv=list(argv if argv is not None else sys.argv),
+        started_at=started_at,
+        ended_at=ended_at,
+        wall_clock_sec=wall_clock_sec,
+        checkpoint_path=str(checkpoint_path or ""),
+        environment=capture_environment(),
+        training=dict(training),
+    )
+    return ResultBundle(manifest=manifest, metrics=dict(metrics or {}))
+
+
+def emit_run_report(bundle: ResultBundle, output_dir: str) -> str:
+    """Write the bundle as ``report.json`` under ``output_dir``.
+
+    :param bundle: the assembled run bundle.
+    :param output_dir: run output directory (created if missing).
+    :return: the written report path.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, "report.json")
+    bundle.write(path)
+    return path
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/igc/shared/shared_accelerator.py
+++ b/igc/shared/shared_accelerator.py
@@ -72,10 +72,26 @@ def _plugin_kwargs(cfg: dict) -> dict:
     """
     if not cfg["sharded"]:
         return {}
+    import importlib
+    _utils = importlib.import_module("accelerate.utils")
     if cfg["sharding"] == "fsdp":
-        from accelerate.utils import FullyShardedDataParallelPlugin
-        return {"fsdp_plugin": FullyShardedDataParallelPlugin()}
-    from accelerate.utils import DeepSpeedPlugin
+        # FSDP2 (torch-native): per-layer wrap via the model's _no_split_modules,
+        # resharding after forward, sharded state dicts for multi-rank saves.
+        return {"fsdp_plugin": _utils.FullyShardedDataParallelPlugin(
+            fsdp_version=2,
+            auto_wrap_policy="transformer_based_wrap",
+            reshard_after_forward=True,
+            state_dict_type="SHARDED_STATE_DICT",
+            cpu_ram_efficient_loading=True,
+        )}
+    # ZeRO needs deepspeed installed; fail with a clear message BEFORE Accelerator
+    # (whose failed init leaks ACCELERATE_USE_DEEPSPEED and poisons retries).
+    _ds_available = getattr(_utils, "is_deepspeed_available", None)
+    if _ds_available is not None and not _ds_available():
+        raise ValueError(
+            f"--sharding {cfg['sharding']} requires deepspeed, which is not "
+            f"installed; install deepspeed or use --sharding fsdp.")
+    DeepSpeedPlugin = _utils.DeepSpeedPlugin
     return {
         "deepspeed_plugin": DeepSpeedPlugin(
             zero_stage=cfg["zero_stage"],
@@ -103,7 +119,16 @@ def build_accelerator(cmd: argparse.Namespace):
     if cfg["gradient_accumulation_steps"] > 1:
         accelerator_args["gradient_accumulation_steps"] = cfg["gradient_accumulation_steps"]
     accelerator_args.update(_plugin_kwargs(cfg))
-    return Accelerator(**accelerator_args)
+    accelerator = Accelerator(**accelerator_args)
+    # a sharded config in a single-process launch silently trains UNSHARDED —
+    # fail loudly instead so a misconfigured GB300 job dies at startup.
+    dist_type = getattr(accelerator, "distributed_type", None)
+    if cfg["sharded"] and dist_type is not None and str(dist_type).endswith("NO"):
+        raise RuntimeError(
+            f"--sharding {cfg['sharding']} requested but this is a single-process "
+            f"launch (distributed_type=NO); start via accelerate launch/torchrun "
+            f"with --num_processes > 1 so sharding engages.")
+    return accelerator
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/igc/shared/shared_arg_parser.py
+++ b/igc/shared/shared_arg_parser.py
@@ -734,6 +734,13 @@ def add_dataset_dataloader(parser):
              "This mainly need a node that build dataset")
 
     group.add_argument(
+        "--corpus_dir",
+        type=str, default="",
+        help="Directory holding a written training corpus (examples.jsonl + manifest.json "
+             "from igc.ds.sources.write_corpus). When set, training reads this "
+             "provenance-tagged corpus instead of building from --json_data_dir.")
+
+    group.add_argument(
         "--raw_data_dir",
         type=str, default="~/.json_responses",
         help="Raw captured Redfish responses the mock REST env serves; mirrors "

--- a/igc/shared/shared_main.py
+++ b/igc/shared/shared_main.py
@@ -19,13 +19,15 @@ def shared_main(
     args, parser_groups = shared_arg_parser()
     args.local_rank = int(os.environ.get('LOCAL_RANK', -1))
 
-    if args.local_rank == -1:
-        # "auto" is the parser default and never a valid torch.device string; resolve
-        # it (and an unset device) to a concrete cuda/mps/cpu device before any module
-        # calls torch.device(args.device).
-        if args.device is None or args.device == "auto":
+    # "auto" is the parser default and never a valid torch.device string; resolve
+    # it (and an unset device) to a concrete device before any module calls
+    # torch.device(args.device). Under accelerate launch/torchrun (LOCAL_RANK set)
+    # the rank picks the cuda ordinal; single-process keeps the plain resolution.
+    if args.device is None or args.device == "auto":
+        if args.local_rank == -1:
             args.device = get_device()
-            # torch.cuda.set_device(args.device)
+        else:
+            args.device = get_device(args.local_rank)
     # else:
     #     args.device = get_device(rank=args.local_rank)
     #     if is_deepspeed_dd_init:

--- a/igc/shared/shared_torch_builder.py
+++ b/igc/shared/shared_torch_builder.py
@@ -11,7 +11,6 @@ import os
 from functools import partial
 from typing import List, Any, Optional, Callable, Union
 import torch
-import transformers
 from torch import nn
 from torch.nn import Module
 from torch.optim import Optimizer
@@ -41,7 +40,8 @@ class TorchBuilder:
         """Get a list of supported optimizers.
         :return:
         """
-        return ['Adam', 'AdamW', 'AdamW2', 'Adagrad', 'Adamax', 'ASGD', 'RMSprop', 'Rprop', 'SGD']
+        # AdamW2 (transformers.AdamW) was removed upstream in transformers 5.x.
+        return ['Adam', 'AdamW', 'Adagrad', 'Adamax', 'ASGD', 'RMSprop', 'Rprop', 'SGD']
 
     @staticmethod
     def get_supported_schedulers() -> List[str]:
@@ -170,11 +170,7 @@ class TorchBuilder:
         optimizer_name = optimizer
         optimizer = optimizer.lower()
 
-        if optimizer == 'AdamW2'.lower():
-            # this a special case for AdamW2 in transformer pacakge.
-            optimizer_class = getattr(transformers, "AdamW", None)
-        else:
-            optimizer_class = getattr(torch.optim, optimizer_name, None)
+        optimizer_class = getattr(torch.optim, optimizer_name, None)
 
         if optimizer_class is None:
             raise ValueError(f"Optimizer '{optimizer}' not recognized")
@@ -206,9 +202,6 @@ class TorchBuilder:
                 merged.pop("fused", None)
                 return torch.optim.AdamW(
                     model.parameters(), lr=lr, weight_decay=weight_decay, **merged)
-        elif optimizer == 'AdamW2'.lower():
-            return transformers.AdamW(
-                model.parameters(), lr=lr, weight_decay=weight_decay, **optimizer_args)
         elif optimizer == 'Adagrad'.lower():
             return torch.optim.Adagrad(
                 model.parameters(), lr=lr, weight_decay=weight_decay, **optimizer_args)

--- a/tests/ds/test_corpus_dataset.py
+++ b/tests/ds/test_corpus_dataset.py
@@ -1,0 +1,110 @@
+"""
+Offline tests for the corpus tokenizer bridge (CorpusJSONLDataset).
+
+Pins that a corpus written by write_corpus loads into fixed-length
+input_ids/attention_mask items the trainer's collate stacks, that the trainer-facing
+duck-type surface (tokenizer property, load_tokenizer, the masking no-ops) is present,
+that run_manifest_fields round-trips the mixer's data_manifest/eval_split ids, and that
+a missing corpus raises. Uses a fake tokenizer — no downloads, no network.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from igc.ds.corpus_dataset import CorpusJSONLDataset
+from igc.ds.sources.base import SourceRecord, TrustLevel
+from igc.ds.sources.corpus_io import write_corpus
+from igc.ds.sources.mixer import SourceMix
+from igc.ds.sources.training_object import normalize
+
+
+class _FakeTokenizer:
+    """Minimal HF-like tokenizer: char-code ids, pads/truncates to max_length."""
+
+    pad_token = "<pad>"
+    eos_token = "<eos>"
+
+    def __call__(self, text, padding=None, max_length=None, truncation=None,
+                 return_tensors=None):
+        ids = [ord(c) % 1000 + 1 for c in text][:max_length]
+        mask = [1] * len(ids)
+        while len(ids) < max_length:
+            ids.append(0)
+            mask.append(0)
+        return {"input_ids": torch.tensor([ids]), "attention_mask": torch.tensor([mask])}
+
+
+class _FakeSource:
+    """Fixed-record source for building a small corpus."""
+
+    def __init__(self, records):
+        self.source = records[0].source if records else "real"
+        self.trust_level = TrustLevel.REAL
+        self._records = records
+
+    def iter_records(self):
+        return iter(self._records)
+
+
+def _corpus_dir(tmp_path: Path, n=4) -> str:
+    """Write a small normalized corpus (examples.jsonl + manifest.json)."""
+    recs = [SourceRecord(url=f"/redfish/v1/S/{i}",
+                         response={"@odata.id": f"/redfish/v1/S/{i}", "Id": str(i)},
+                         source="real_dell", trust_level=TrustLevel.REAL,
+                         allowed_methods=["GET"], vendor="dell") for i in range(n)]
+    mix = SourceMix([_FakeSource(recs)], eval_fraction=0.25, seed=0)
+    train, _ = mix.split()
+    out = tmp_path / "corpus"
+    write_corpus(normalize(train), mix.manifest(), str(out))
+    return str(out)
+
+
+def test_items_are_fixed_length_tensor_dicts(tmp_path: Path):
+    """Every item is a {input_ids, attention_mask} pair of length max_len."""
+    ds = CorpusJSONLDataset(_corpus_dir(tmp_path), max_len=64, tokenizer=_FakeTokenizer())
+    assert len(ds) > 0
+    item = ds[0]
+    assert set(item) == {"input_ids", "attention_mask"}
+    assert item["input_ids"].shape == (64,) and item["attention_mask"].shape == (64,)
+
+
+def test_items_stack_like_the_trainer_collate(tmp_path: Path):
+    """torch.stack over items works — the exact contract of custom_collate_fn."""
+    ds = CorpusJSONLDataset(_corpus_dir(tmp_path), max_len=32, tokenizer=_FakeTokenizer())
+    batch = {k: torch.stack([ds[i][k] for i in range(len(ds))]) for k in ("input_ids", "attention_mask")}
+    assert batch["input_ids"].shape == (len(ds), 32)
+    assert batch["attention_mask"].dtype == torch.int64
+
+
+def test_trainer_duck_type_surface(tmp_path: Path):
+    """The masking hooks and tokenizer surface the trainer touches all exist."""
+    ds = CorpusJSONLDataset(_corpus_dir(tmp_path), max_len=16, tokenizer=_FakeTokenizer())
+    for hook in ("disable_masking", "enable_masking", "mask_section", "mask_new_tokens",
+                 "mask_targets", "mask_allowed_value", "mask_odata_id", "mask_targets_key",
+                 "mask_objects", "mask_arrays"):
+        getattr(ds, hook)()  # must not raise
+    assert ds.tokenizer is not None
+    ds.load_tokenizer()  # idempotent
+
+
+def test_run_manifest_fields_round_trip(tmp_path: Path):
+    """data_manifest/eval_split ids match what the mixer computed for this corpus."""
+    ds = CorpusJSONLDataset(_corpus_dir(tmp_path), max_len=16, tokenizer=_FakeTokenizer())
+    fields = ds.run_manifest_fields()
+    assert set(fields) == {"data_manifest", "eval_split"}
+    assert len(fields["data_manifest"]) == 16  # blake2b hex from DataManifest.content_hash
+    assert fields["eval_split"] == "floor=REAL:frac=0.25:seed=0"
+
+
+def test_missing_corpus_raises(tmp_path: Path):
+    """A directory without examples.jsonl fails fast, not at first batch."""
+    with pytest.raises(FileNotFoundError):
+        CorpusJSONLDataset(str(tmp_path / "nope"), tokenizer=_FakeTokenizer())
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/ds/test_dataset_picklable.py
+++ b/tests/ds/test_dataset_picklable.py
@@ -1,0 +1,57 @@
+"""Offline regressions for JSONDataset picklability (DataLoader workers).
+
+``pickle.dumps(dataset)`` previously failed with ``cannot pickle
+'_io.TextIOWrapper'`` because ``self.logger`` (loguru stdout + file sinks) and
+the build-time ``RestTrajectory`` live in ``__dict__`` — breaking every
+``num_workers > 0`` DataLoader under the spawn start method (macOS default;
+the GB300 profile sets ``num_workers=8``). ``__getstate__`` drops both and
+``__setstate__`` rebuilds a process-local logger. Tested on a ``__new__``
+instance with a real open file handle standing in for the sink. CPU-only.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import pickle
+
+import torch
+
+from igc.ds.redfish_dataset import JSONDataset
+
+
+def _dataset_like(tmp_path):
+    """A minimal JSONDataset (bypasses __init__) with worker-relevant state."""
+    ds = JSONDataset.__new__(JSONDataset)
+    ds.logger = open(tmp_path / "sink.log", "w")  # unpicklable stand-in
+    ds._rest_trajectories = open(tmp_path / "traj.log", "w")
+    ds._data = {"train_data": [torch.tensor([1]), torch.tensor([2])]}
+    ds._masked_data = None
+    return ds
+
+
+def test_pickle_round_trip_drops_handles_and_keeps_data(tmp_path):
+    """dumps/loads succeeds; data survives; handles are gone."""
+    ds = _dataset_like(tmp_path)
+    clone = pickle.loads(pickle.dumps(ds))
+
+    assert len(clone) == 2
+    assert torch.equal(clone[0], torch.tensor([1]))
+    assert clone._rest_trajectories is None
+
+
+def test_unpickled_instance_has_working_logger(tmp_path):
+    """__setstate__ rebuilds a process-local logger (not None, callable)."""
+    clone = pickle.loads(pickle.dumps(_dataset_like(tmp_path)))
+    assert clone.logger is not None
+    clone.logger.info("worker logger alive")  # must not raise
+
+
+def test_original_instance_unchanged_by_getstate(tmp_path):
+    """__getstate__ copies state; the live instance keeps its logger."""
+    ds = _dataset_like(tmp_path)
+    pickle.dumps(ds)
+    assert ds.logger is not None
+    assert hasattr(ds.logger, "write")  # still the original handle
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/ds/test_tokenizer_provenance.py
+++ b/tests/ds/test_tokenizer_provenance.py
@@ -23,10 +23,16 @@ def test_matching_provenance_passes():
     )
 
 
-def test_token_count_mismatch_raises_with_rebuild_hint():
-    """A different live vocab size is refused loudly, naming the fix."""
+def test_cache_larger_than_live_vocab_raises_with_rebuild_hint():
+    """Caches whose ids can exceed the live vocab are refused loudly."""
     with pytest.raises(ValueError, match="--recreate_dataset"):
-        JSONDataset.check_tokenizer_provenance({"num_tokens": 53147}, 151936)
+        JSONDataset.check_tokenizer_provenance({"num_tokens": 151936}, 53147)
+
+
+def test_grown_tokenizer_warns_but_loads():
+    """A tokenizer that grew keeps ids valid: warn, do not refuse."""
+    with pytest.warns(UserWarning, match="grew by 7"):
+        JSONDataset.check_tokenizer_provenance({"num_tokens": 53140}, 53147)
 
 
 def test_model_type_mismatch_raises():

--- a/tests/modules/test_checkpoint_save_resume_edges.py
+++ b/tests/modules/test_checkpoint_save_resume_edges.py
@@ -1,0 +1,127 @@
+"""Broad offline edges for ``IgcModule`` checkpoint save/resume behavior.
+
+These tests extend the checkpoint cluster coverage without touching engine
+code: checkpoint slot rotation, best-checkpoint naming, nonzero-rank no-op
+saves, list scheduler state, and seeded split determinism across ratios.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import argparse
+from pathlib import Path
+
+import loguru
+import pytest
+import torch
+from torch.utils.data import TensorDataset
+
+from igc.modules.base.igc_base_module import IgcModule
+
+
+def _module(tmp_path: Path, *, rank: int = 0) -> IgcModule:
+    """Build a minimal CPU-only ``IgcModule`` shell for checkpoint tests."""
+    module = IgcModule.__new__(IgcModule)
+    module.rank = rank
+    module.module_name = "tmod"
+    module.logger = loguru.logger
+    module.model = torch.nn.Linear(2, 2)
+    module.optimizer = torch.optim.SGD(module.model.parameters(), lr=0.1)
+    module.scheduler = None
+    module.dataset = TensorDataset(torch.arange(100, dtype=torch.float32))
+    module._trainer_args = argparse.Namespace(seed=42, output_dir=str(tmp_path))
+    module._module_checkpoint_dir = str(tmp_path)
+    return module
+
+
+def test_save_checkpoint_rotates_epoch_slots_by_keep_count(tmp_path: Path) -> None:
+    """Epoch checkpoints wrap by ``num_check_points_to_keep`` and overwrite."""
+    module = _module(tmp_path)
+
+    first_slot = Path(
+        module.save_checkpoint(str(tmp_path), epoch=1, num_check_points_to_keep=3)
+    )
+    second_slot = Path(
+        module.save_checkpoint(str(tmp_path), epoch=2, num_check_points_to_keep=3)
+    )
+    wrapped_slot = Path(
+        module.save_checkpoint(str(tmp_path), epoch=4, num_check_points_to_keep=3)
+    )
+
+    assert first_slot == wrapped_slot
+    assert first_slot.name == "tmod_epoch_1.pt"
+    assert second_slot.name == "tmod_epoch_2.pt"
+    assert torch.load(first_slot, weights_only=True)["epoch"] == 4
+
+
+def test_save_checkpoint_best_accuracy_uses_stable_best_filename(
+        tmp_path: Path) -> None:
+    """Best-accuracy saves use the stable best filename and keep the metric."""
+    module = _module(tmp_path)
+
+    checkpoint_path = Path(
+        module.save_checkpoint(
+            str(tmp_path),
+            epoch=5,
+            is_best_accuracy=True,
+            last_accuracy=0.875,
+        )
+    )
+    checkpoint = torch.load(checkpoint_path, weights_only=True)
+
+    assert checkpoint_path.name == "tmod_epoch_best.pt"
+    assert checkpoint["epoch"] == 5
+    assert checkpoint["last_accuracy"] == pytest.approx(0.875)
+
+
+def test_save_checkpoint_rank_greater_than_zero_is_noop(tmp_path: Path) -> None:
+    """Nonzero ranks do not write checkpoint files from local save calls."""
+    module = _module(tmp_path, rank=1)
+
+    result = module.save_checkpoint(str(tmp_path), epoch=3)
+
+    assert result == ""
+    assert list(tmp_path.glob("*.pt")) == []
+
+
+def test_load_checkpoint_restores_list_scheduler_state(tmp_path: Path) -> None:
+    """List scheduler state dicts are saved and restored during resume."""
+    source = _module(tmp_path)
+    source_schedulers = [
+        torch.optim.lr_scheduler.StepLR(source.optimizer, step_size=2, gamma=0.5),
+        torch.optim.lr_scheduler.ExponentialLR(source.optimizer, gamma=0.9),
+    ]
+    source.optimizer.step()
+    for scheduler in source_schedulers:
+        scheduler.step()
+
+    source.save_checkpoint(str(tmp_path), epoch=6, scheduler=source_schedulers)
+
+    target = _module(tmp_path)
+    target.scheduler = [
+        torch.optim.lr_scheduler.StepLR(target.optimizer, step_size=2, gamma=0.5),
+        torch.optim.lr_scheduler.ExponentialLR(target.optimizer, gamma=0.9),
+    ]
+    state = target.load_checkpoint(str(tmp_path), resuming=True)
+
+    assert state.last_epoch == 6
+    assert isinstance(state.scheduler_state, list)
+    assert len(state.scheduler_state) == 2
+    assert target.scheduler[0].state_dict()["last_epoch"] == 1
+    assert target.scheduler[1].state_dict()["last_epoch"] == 1
+
+
+@pytest.mark.parametrize("ratio", [0.25, 0.5, 0.75])
+def test_split_dataset_is_seeded_across_ratios(
+        tmp_path: Path, ratio: float) -> None:
+    """Seeded train/eval partitions stay deterministic for common ratios."""
+    first_train, first_eval = _module(tmp_path).split_dataset(ratio=ratio)
+    second_train, second_eval = _module(tmp_path).split_dataset(ratio=ratio)
+
+    assert list(first_train.indices) == list(second_train.indices)
+    assert list(first_eval.indices) == list(second_eval.indices)
+    assert len(first_train) == int(100 * ratio)
+    assert len(first_train) + len(first_eval) == 100
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/modules/train/test_emit.py
+++ b/tests/modules/train/test_emit.py
@@ -1,0 +1,98 @@
+"""
+Offline tests for run-report emission.
+
+Pins that build_run_bundle maps the parsed spec into a RunManifest (model, adapter
+from use_peft, corpus data_manifest/eval_split, scrubbed settings), that sensitive
+key names can never leak into the emitted settings, that emit_run_report writes a
+report.json that ResultBundle.read round-trips, and that the bundle feeds the
+existing compare() fairness check. Pure stdlib — no torch, no trainer construction.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+from pathlib import Path
+
+from igc.modules.train.emit import _SENSITIVE_MARKERS, build_run_bundle, emit_run_report
+from igc.modules.train.report import ResultBundle, compare
+
+
+def _spec(**over):
+    """A minimal parsed-spec dict as vars(spec) would produce."""
+    spec = {
+        "model_type": "Qwen/Qwen2.5-7B-Instruct",
+        "use_peft": True, "adapter_method": "rslora", "lora_r": 32,
+        "lora_alpha": 64, "lora_init": "default",
+        "max_train_steps": 200, "seq_len": 1024,
+        "per_device_train_batch_size": 8, "gradient_accumulation_steps": 4,
+        "num_train_epochs": 3, "llm_learning_rate": 5e-5,
+        "llm_scheduler": "OneCycleLR", "llm_optimizer": "AdamW",
+        "mixed_precision": "bf16", "sharding": "none", "use_accelerator": False,
+        "masking_type": "NO_MASK", "num_workers": 8, "seed": 42,
+    }
+    spec.update(over)
+    return spec
+
+
+def _bundle(**over):
+    return build_run_bundle(
+        _spec(**over),
+        training={"final_epoch_loss": 3.1, "epochs_done": 3, "optimizer_steps": 200,
+                  "best_eval": 0.72},
+        metrics={"eval/accuracy": 0.72},
+        dataset_fields={"data_manifest": "70a2db0b0e90e194",
+                        "eval_split": "floor=REAL:frac=0.15:seed=0"},
+        argv=["igc_main.py", "--train", "llm", "--llm", "latent"],
+        started_at="2026-07-10T01:00:00", ended_at="2026-07-10T02:00:00",
+        wall_clock_sec=3600.0, checkpoint_path="experiments/run1",
+    )
+
+
+def test_manifest_maps_spec_and_corpus_fields():
+    """Model, adapter (from use_peft), data manifest, and stats land in the manifest."""
+    b = _bundle()
+    m = b.manifest
+    assert m.model == "Qwen/Qwen2.5-7B-Instruct"
+    assert m.adapter_method == "rslora" and m.adapter_rank == 32
+    assert m.data_manifest == "70a2db0b0e90e194"
+    assert m.eval_split == "floor=REAL:frac=0.15:seed=0"
+    assert m.max_steps == 200 and m.seq_len == 1024
+    assert m.training["optimizer_steps"] == 200
+    assert m.argv[0] == "igc_main.py"
+    assert m.environment.get("python")  # capture_environment ran
+    assert b.metrics == {"eval/accuracy": 0.72}
+
+
+def test_no_peft_means_adapter_none():
+    """use_peft=False reports adapter 'none' with no rank."""
+    m = _bundle(use_peft=False).manifest
+    assert m.adapter_method == "none" and m.adapter_rank is None
+
+
+def test_settings_scrubbed_of_sensitive_keys():
+    """No emitted settings key may carry a sensitive marker (token/key/secret/...)."""
+    m = _bundle().manifest
+    for key in m.settings:
+        assert not any(mark in key.lower() for mark in _SENSITIVE_MARKERS)
+    # the allowlisted run knobs made it through
+    assert m.settings["gradient_accumulation_steps"] == "4"
+    assert m.settings["llm_scheduler"] == "OneCycleLR"
+
+
+def test_emit_writes_readable_report(tmp_path: Path):
+    """emit_run_report writes report.json that ResultBundle.read reconstructs."""
+    path = emit_run_report(_bundle(), str(tmp_path / "run"))
+    assert path.endswith("report.json")
+    back = ResultBundle.read(path)
+    assert back.manifest.model == "Qwen/Qwen2.5-7B-Instruct"
+    assert back.manifest.training["final_epoch_loss"] == 3.1
+    assert back.arm == "rslora-r32"
+
+
+def test_bundle_feeds_compare_fairness():
+    """Two emitted runs on the same corpus/split compare as fair."""
+    rep = compare([_bundle(), _bundle(adapter_method="dora")], baseline="rslora")
+    assert not rep.fairness_issues
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/shared/test_accelerator_sharding.py
+++ b/tests/shared/test_accelerator_sharding.py
@@ -38,7 +38,8 @@ def _fake_accelerate(monkeypatch):
             self.kwargs = kwargs
 
     class FakeFSDPPlugin:
-        pass
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
 
     accelerate = types.ModuleType("accelerate")
     accelerate_utils = types.ModuleType("accelerate.utils")
@@ -166,3 +167,64 @@ def test_build_accelerator_fsdp_uses_fsdp_plugin(monkeypatch):
 
 
 # Author: Mus mbayramo@stanford.edu
+
+
+def test_fsdp_plugin_is_fsdp2_configured(monkeypatch):
+    """fsdp builds an FSDP2 plugin: versioned, auto-wrapped, resharding, sharded saves."""
+    fake_accelerator, _, fake_fsdp = _fake_accelerate(monkeypatch)
+    build_accelerator(_ns(sharding="fsdp"))
+    kwargs = fake_accelerator.calls[-1]
+    plugin = kwargs["fsdp_plugin"]
+    assert isinstance(plugin, fake_fsdp)
+    assert plugin.kwargs["fsdp_version"] == 2
+    assert plugin.kwargs["auto_wrap_policy"] == "transformer_based_wrap"
+    assert plugin.kwargs["reshard_after_forward"] is True
+    assert plugin.kwargs["state_dict_type"] == "SHARDED_STATE_DICT"
+
+
+def test_zero_without_deepspeed_raises_before_accelerator(monkeypatch):
+    """zero3 without deepspeed installed fails with a clear message, not an env leak."""
+    import sys
+    import types
+
+    accelerate = types.ModuleType("accelerate")
+    accelerate_utils = types.ModuleType("accelerate.utils")
+
+    class _NeverAccelerator:
+        def __init__(self, **kwargs):
+            raise AssertionError("Accelerator must not be constructed")
+
+    accelerate.Accelerator = _NeverAccelerator
+    accelerate_utils.is_deepspeed_available = lambda: False
+    monkeypatch.setitem(sys.modules, "accelerate", accelerate)
+    monkeypatch.setitem(sys.modules, "accelerate.utils", accelerate_utils)
+
+    with pytest.raises(ValueError, match="--sharding fsdp"):
+        build_accelerator(_ns(sharding="zero3"))
+
+
+def test_sharded_single_process_launch_fails_loudly(monkeypatch):
+    """A sharded config resolving to distributed_type NO raises instead of training unsharded."""
+    import sys
+    import types
+
+    class _NoDistAccelerator:
+        calls = []
+
+        def __init__(self, **kwargs):
+            self.distributed_type = "DistributedType.NO"
+            type(self).calls.append(kwargs)
+
+    class _Plugin:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    accelerate = types.ModuleType("accelerate")
+    accelerate_utils = types.ModuleType("accelerate.utils")
+    accelerate.Accelerator = _NoDistAccelerator
+    accelerate_utils.FullyShardedDataParallelPlugin = _Plugin
+    monkeypatch.setitem(sys.modules, "accelerate", accelerate)
+    monkeypatch.setitem(sys.modules, "accelerate.utils", accelerate_utils)
+
+    with pytest.raises(RuntimeError, match="single-process"):
+        build_accelerator(_ns(sharding="fsdp"))

--- a/tests/shared/test_device_resolution.py
+++ b/tests/shared/test_device_resolution.py
@@ -65,3 +65,25 @@ def test_resolved_device_is_a_valid_torch_device(monkeypatch, tmp_path):
 
 
 # Author: Mus mbayramo@stanford.edu
+
+
+def test_local_rank_launch_resolves_auto_via_rank(monkeypatch, tmp_path):
+    """Under accelerate launch/torchrun (LOCAL_RANK set), 'auto' resolves per-rank."""
+    seen = {}
+
+    def fake_get_device(rank=None):
+        seen["rank"] = rank
+        return torch.device("meta")
+
+    monkeypatch.setattr(shared_main_mod, "get_device", fake_get_device)
+    monkeypatch.setenv("LOCAL_RANK", "1")
+    args = _run(monkeypatch, tmp_path, [])
+    assert args.device == torch.device("meta")
+    assert seen["rank"] == 1
+
+
+def test_local_rank_launch_keeps_explicit_device(monkeypatch, tmp_path, resolved_device):
+    """An explicit --device cpu survives a distributed launch untouched."""
+    monkeypatch.setenv("LOCAL_RANK", "0")
+    args = _run(monkeypatch, tmp_path, ["--device", "cpu"])
+    assert args.device == "cpu"

--- a/tests/shared/test_optimizer_registry.py
+++ b/tests/shared/test_optimizer_registry.py
@@ -1,0 +1,41 @@
+"""Offline regressions for the optimizer registry in ``TorchBuilder``.
+
+``AdamW2`` aliased ``transformers.AdamW``, which was removed in transformers
+5.x — selecting it failed at trainer construction. The registry no longer
+advertises it (the ``--llm_optimizer`` CLI choices derive from this list), and
+every advertised name must resolve to a real ``torch.optim`` class. CPU-only.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import pytest
+import torch
+
+from igc.shared.shared_torch_builder import TorchBuilder
+
+
+def test_adamw2_no_longer_advertised():
+    """The removed transformers.AdamW alias is gone from the registry."""
+    assert "AdamW2" not in TorchBuilder.get_supported_optimizers()
+
+
+@pytest.mark.parametrize("name", TorchBuilder.get_supported_optimizers())
+def test_every_advertised_optimizer_constructs(name):
+    """Each advertised optimizer builds against torch.optim on a tiny model."""
+    model = torch.nn.Linear(2, 2)
+    optimizer = TorchBuilder.create_optimizer(
+        name, model, lr=0.01, weight_decay=0.0
+    )
+    assert isinstance(optimizer, torch.optim.Optimizer)
+
+
+def test_unknown_optimizer_raises():
+    """A stale/unknown name fails with a clear error, not an AttributeError."""
+    with pytest.raises(ValueError, match="not recognized"):
+        TorchBuilder.create_optimizer(
+            "AdamW2", torch.nn.Linear(2, 2), lr=0.01, weight_decay=0.0
+        )
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
## What

Two connectors that make M1 training run on the new data pipeline and make every run self-describing:

**1. Corpus bridge (`--corpus_dir`)**
- `CorpusJSONLDataset` loads a corpus written by `igc.ds.sources.write_corpus` (`examples.jsonl` + `manifest.json`), renders each example as its request line + response JSON, and tokenizes once to the fixed-length `input_ids`/`attention_mask` items the trainer's collate already stacks.
- Duck-types the `MaskedJSONDataset` surface the trainer touches (`tokenizer`, `load_tokenizer`, masking hooks as no-ops — a written corpus trains the plain causal-LM objective).
- `--corpus_dir` selects it in `igc_main`'s dataset property; unset keeps the existing `MaskedJSONDataset` path unchanged.

**2. Run-report emission**
- `igc/modules/train/emit.py`: `build_run_bundle` maps the parsed spec + end-of-run stats into a `RunManifest` (adapter from `use_peft`, corpus `data_manifest`/`eval_split` ids, launch argv, environment capture, allowlisted settings that refuse any key naming a token/secret).
- `_train` writes `report.json` next to the checkpoint on rank zero, inside a guard so emission can never take down a finished run. Runs become comparable through the existing `compare()` tooling.

## Why

The `igc/ds/sources` pipeline (fixture sources → trust-tier split → normalized corpus) existed but nothing consumed it, and finished runs left no machine-readable record. With this PR: build a corpus once, train on it with `--corpus_dir`, and every run drops a `report.json` whose `data_manifest`/`eval_split` ids let the fairness check catch apples-to-oranges comparisons.

## Test plan

- 10 new offline tests (fake tokenizer, no downloads): fixed-length items + collate contract, trainer duck-type surface, manifest id round-trip, missing-corpus fail-fast; emit mapping, secret-scrub guarantee, report read-back, compare() fairness.
- Full offline gate on the branch: **455 passed, 0 failed** (11 gpu/live deselected).
- `ruff` clean on all touched files.