### PR TITLE
Replace the 2023 env freeze with a real dependency manifest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,144 +1,39 @@
-_libgcc_mutex==0.1
-_openmp_mutex==5.1
-absl-py==1.4.0
-asttokens==2.2.1
-astunparse==1.6.3
-backcall==0.2.0
-box2d-py==2.3.8
-bzip2==1.0.8
-ca-certificates==2023.01.10
-cachetools==5.3.0
-certifi==2023.5.7
-cffi==1.15.1
-charset-normalizer==3.1.0
-cloudpickle==2.2.1
-contourpy==1.0.7
-crc32c==2.3.post0
-cs224r==0.1.0
-cycler==0.11.0
-decorator==4.4.2
-executing==1.2.0
-filelock==3.12.0
-fonttools==4.39.3
-fsspec==2023.5.0
-glfw==2.5.9
-google-auth-oauthlib==1.0.0
-google-auth==2.17.3
-grpcio==1.54.0
-gym-notices==0.0.8
+# igc runtime dependencies.
+# Floors track the validated dev environment (torch 2.12 / transformers 5.12 / numpy 1.26);
+# setup.py filters comment and blank lines when reading this file.
+
+# core ML stack
+torch>=2.6,<2.13
+transformers>=5.0,<6
+accelerate>=1.14,<2
+peft>=0.19,<1
+numpy>=1.26,<2
+
+# RL environments. gym stays only until igc/envs migrates to gymnasium
+# (rest_gym_base / rest_gym_env / rest_gym_batch_env still import gym).
+gymnasium>=1.0,<2
 gym==0.26.2
-idna==3.4
-imageio-ffmpeg==0.4.8
-imageio==2.28.1
-intel-openmp==2023.1.0
-ipdb==0.13.13
-ipython==8.13.2
-jax==0.4.8
-jaxlib==0.4.7+cuda12.cudnn88
-jedi==0.18.2
-jinja2==3.1.2
-kiwisolver==1.4.4
-libffi==3.4.2
-libgcc-ng==11.2.0
-libgomp==11.2.0
-libstdcxx-ng==11.2.0
-libuuid==1.41.5
-markdown==3.4.3
-markupsafe==2.1.2
-matplotlib-inline==0.1.6
-matplotlib==3.7.1
-mkl==2023.1.0
-ml-dtypes==0.1.0
-moviepy==1.0.3
-mpmath==1.3.0
-mujoco==2.3.5
-mypy-extensions==1.0.0
-ncurses==6.4
-networkx==3.1
-numpy==1.24.3
-oauthlib==3.2.2
-opencv==4.7.0
-openssl==1.1.1t
-opt-einsum==3.3.0
-packaging==23.1
-parso==0.8.3
-pexpect==4.8.0
-pickleshare==0.7.5
-pillow==9.5.0
-pip==23.0.1
-prettytable==3.7.0
-proglog==0.1.10
-prompt-toolkit==3.0.38
-protobuf==4.23.0
-ptyprocess==0.7.0
-pure-eval==0.2.2
-pyasn1-modules==0.3.0
-pyasn1==0.5.0
-pycparser==2.21
-pyglet==2.0.7
-pygments==2.15.1
-pyopengl==3.1.6
-pyparsing==3.0.9
-pyre-extensions==0.0.29
-python-dateutil==2.8.2
-python==3.10.11
-pyvirtualdisplay==3.0
-pyyaml==6.0
-readline==8.2
-requests-oauthlib==1.3.1
-requests==2.30.0
-rsa==4.9
-scipy==1.10.1
-setuptools==67.7.2
-six==1.16.0
-soundfile==0.12.1
-sqlite==3.41.2
-stack-data==0.6.2
-sympy==1.12rc1
-tbb==2021.9.0
-tensorboard-data-server==0.7.0
-tensorboard==2.13.0
-tensorboardx==2.6
-tk==8.6.12
-tomli==2.0.1
-torch==2.1.0a0+git622e582
-torchaudio==2.1.0a0+51cc1cb
-torchvision==0.16.0a0+b1333dd
-tqdm==4.65.0
-traitlets==5.9.0
-typing-extensions==4.5.0
-typing-inspect==0.8.0
-# tzdata==2023c
-urllib3==2.0.2
-vtk==9.2.6
-wcwidth==0.2.6
-werkzeug==2.3.4
-wheel==0.38.4
-xformers==0.0.20+6425fd0.d20230509
-xz==5.4.2
-zlib==1.2.13
+gym-notices==0.0.8
 
-# this for redfish sim
-Flask
-aniso8601
-itsdangerous
-Jinja2
-MarkupSafe
-pytz
-requests
-six
-Werkzeug
-StringGenerator
-flask_restful
-urllib3
-flask_httpauth
-
-# hugging face
-transformers
-deepspeed
-accelerate
-
-# for cuda printing
-tabulate
-nltk
+# HuggingFace ecosystem
+huggingface_hub>=1.0
+tokenizers
+safetensors
+evaluate>=0.4
 rouge_score
+scikit-learn
+
+# runtime utilities (mock REST env, metrics, logging)
+requests>=2.31
+tensorboard
+loguru
+tabulate
+tqdm
+pynvml
+
+# data collection (redfish_ctl discovery crawl driven by collector.sh)
+redfish_ctl>=1.1.4
+
+# NOTE: deepspeed is intentionally absent — it is a cluster-only optional extra
+# (pip install .[deepspeed]); --sharding zero* raises a clear message without it
+# and --sharding fsdp needs no extra dependency.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,11 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 with open('requirements.txt') as f:
-    requirements = f.read().splitlines()
+    # keep only real requirement lines: comments and blanks are documentation.
+    requirements = [
+        line.strip() for line in f
+        if line.strip() and not line.strip().startswith('#')
+    ]
 
 setup_info = dict(
     name='igc',
@@ -17,17 +21,18 @@ setup_info = dict(
     long_description_content_type='text/markdown',
     packages=['igc'] + ['igc.' + pkg for pkg in find_packages('igc')],
     license="MIT",
-    python_requires='>=3.10',
+    # <3.13 until shared_torch_utils drops distutils.LooseVersion.
+    python_requires='>=3.10,<3.13',
     install_requires=requirements,
-    # entry_points={
-    #     'console_scripts': [
-    #         'idrac_ctl = idrac_ctl.idrac_main:idrac_main_ctl',
-    #     ]
-    # },
     extras_require={
         "dev": [
-            "pytest >= 3.7"
-        ]
+            "pytest>=7",
+            "ruff",
+        ],
+        # cluster-only: ZeRO sharding; fsdp needs no extra dependency.
+        "deepspeed": [
+            "deepspeed>=0.14",
+        ],
     },
 )
 setup(**setup_info)

--- a/tests/test_requirements_parse.py
+++ b/tests/test_requirements_parse.py
@@ -1,0 +1,52 @@
+"""Offline sanity for the dependency manifest.
+
+The previous requirements.txt was a 2023 conda-env freeze (conda-only packages,
+unresolvable local `+git` builds, duplicate pins) that setup.py ingested
+verbatim, comments included — so ``pip install .`` could never resolve. These
+pin the new contract: every non-comment line parses as a valid PEP 508
+requirement, no duplicates, the validated stack floors are present, and
+setup.py's filter drops comments and blanks. CPU-only, no network.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+from pathlib import Path
+
+from packaging.requirements import Requirement
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _requirement_lines():
+    lines = (_ROOT / "requirements.txt").read_text().splitlines()
+    return [ln.strip() for ln in lines if ln.strip() and not ln.strip().startswith("#")]
+
+
+def test_every_line_is_a_valid_requirement():
+    """Each non-comment line parses as a PEP 508 requirement."""
+    for line in _requirement_lines():
+        Requirement(line)  # raises InvalidRequirement on garbage
+
+
+def test_no_duplicate_packages():
+    """No package is pinned twice (the old freeze had six duplicates)."""
+    names = [Requirement(ln).name.lower() for ln in _requirement_lines()]
+    assert len(names) == len(set(names))
+
+
+def test_core_stack_floors_present():
+    """The validated core stack is declared with floors."""
+    reqs = {Requirement(ln).name.lower(): ln for ln in _requirement_lines()}
+    for pkg in ("torch", "transformers", "accelerate", "peft", "numpy", "gymnasium"):
+        assert pkg in reqs, f"{pkg} missing from requirements.txt"
+        assert any(op in reqs[pkg] for op in (">=", "==")), f"{pkg} has no floor"
+
+
+def test_deepspeed_stays_an_extra():
+    """deepspeed must not be a core requirement (cluster-only extra)."""
+    names = {Requirement(ln).name.lower() for ln in _requirement_lines()}
+    assert "deepspeed" not in names
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
requirements.txt was an unresolvable 2023 conda pip-freeze ingested verbatim (comments included) by setup.py. This declares the validated stack with floors (torch>=2.6, transformers>=5, accelerate>=1.14, peft>=0.19, numpy>=1.26, gymnasium alongside gym until the env migration completes), keeps deepspeed as a cluster-only extra, filters comment/blank lines in setup.py, and caps python_requires at <3.13 until the distutils.LooseVersion use is removed.

Offline gate: 463 passed, 11 deselected. New tests: requirements parse as PEP 508, no duplicates, core floors present, deepspeed stays an extra.