### PR TITLE
Align env step tuples with the terminated/truncated contract

### DIFF
--- a/igc/envs/rest_gym_batch_env.py
+++ b/igc/envs/rest_gym_batch_env.py
@@ -243,8 +243,8 @@ class VectorizedRestApiEnv(VectorEnv, RestApiBaseEnv):
                 self.rewards[i] = -0.2
             else:
                 self.rewards[i] = -0.5
+                # dead-end error state: real terminal
                 self.dones[i] = True
-                self.terminateds[i] = False
 
             # add response to list
             self.responses.append(response)
@@ -252,8 +252,7 @@ class VectorizedRestApiEnv(VectorEnv, RestApiBaseEnv):
             if self.step_count >= self.max_steps:
                 if not self.dones[i]:
                     self.rewards[i] = -1.0
-
-                self.dones[i] = True
+                # time-limit is a truncation, not a terminal state
                 self.terminateds[i] = True
 
     def step_wait(
@@ -262,8 +261,8 @@ class VectorizedRestApiEnv(VectorEnv, RestApiBaseEnv):
         """
         Wait for the asynchronous actions to complete and return the results.
 
-        :return: Tuple containing the observations,
-                 rewards, done flags, terminated flags, and info dictionaries.
+        :return: Tuple of observations, rewards, terminated flags (goal or
+                 dead-end), truncated flags (time-limit), and info dictionaries.
         """
         observations = []
         info = [{}] * self.num_envs
@@ -279,9 +278,9 @@ class VectorizedRestApiEnv(VectorEnv, RestApiBaseEnv):
                 )
                 _responses += 1
 
-        done = torch.tensor(self.dones, dtype=torch.bool)
-        done_mask = torch.logical_not(done)
-        terminated = torch.tensor(self.terminateds, dtype=torch.bool)
+        terminated = torch.tensor(self.dones, dtype=torch.bool)
+        truncated = torch.tensor(self.terminateds, dtype=torch.bool)
+        active_mask = torch.logical_not(terminated | truncated)
 
         if len(observations) == 0:
             _observations = self.last_observation
@@ -290,28 +289,23 @@ class VectorizedRestApiEnv(VectorEnv, RestApiBaseEnv):
 
         rewards = torch.tensor(self.rewards, dtype=torch.float32)
         goal_reached = self.check_goal(_observations)
-        goal_reached_mask = torch.logical_and(goal_reached, done_mask)
+        goal_reached_mask = torch.logical_and(goal_reached, active_mask)
         rewards[goal_reached_mask] = 1.0
-        done[goal_reached_mask] = True
-        terminated[goal_reached_mask] = False
-
-        if self.step_count >= self.max_steps:
-            done.fill_(True)
-            terminated.fill_(True)
+        terminated[goal_reached_mask] = True
 
         info = [{'goal_reached': gr} for gr in goal_reached]
         self.last_observation = _observations
 
-        for i, done_val in enumerate(done.tolist()):
-            if not self.dones[i] and done_val:
-                self.dones[i] = done_val
-
         for i, terminated_val in enumerate(terminated.tolist()):
-            if not self.terminateds[i] and terminated_val:
-                self.terminateds[i] = terminated_val
+            if not self.dones[i] and terminated_val:
+                self.dones[i] = terminated_val
+
+        for i, truncated_val in enumerate(truncated.tolist()):
+            if not self.terminateds[i] and truncated_val:
+                self.terminateds[i] = truncated_val
 
         self.rewards = [0.0] * self._num_envs
-        return _observations, rewards, done, terminated, info
+        return _observations, rewards, terminated, truncated, info
 
     def simulate_goal_reached(self, batch_id: int):
         """Simulate that particular trajectory in batch reached a goal state.

--- a/igc/envs/rest_gym_env.py
+++ b/igc/envs/rest_gym_env.py
@@ -252,15 +252,17 @@ class RestApiEnv(gym.Env):
         self.step_count += 1
         info = {}
 
-        done = False
+        # standard gymnasium contract: terminated = real terminal state (goal or
+        # dead-end), truncated = time-limit. Previously position 3 conflated both
+        # and position 4 meant truncation — the exact inversion q_targets warns about.
         terminated = False
+        truncated = False
 
         if self.step_count >= self.max_steps:
-            done = True
-            terminated = True
+            truncated = True
             reward = -1.0
 
-        if not done:
+        if not truncated:
             self.extract_action_method(action)
             rest_api_one_hot, method_one_hot = RestApiEnv.extract_action_method(action)
             method = RestApiEnv.one_hot_to_method_string(method_one_hot)
@@ -277,19 +279,18 @@ class RestApiEnv(gym.Env):
                 # agent execute goal action
                 if self.is_goal_reached(action, response):
                     reward = 1.0
-                    done = True
+                    terminated = True
                     self.last_observation = self.encoder.encode(response.json())
                 elif 200 <= response.status_code <= 300:
                     print(f"status code {response.status_code}")
                     self.last_observation = self.encoder.encode(response.json())
                     reward = 0.1
-                    done = False
                     # Update the current observation with the successful observation
                 elif response.status_code == 500:
                     print(f"status code {response.status_code}")
                     reward = -0.5
-                    done = True
-                    terminated = False
+                    # a dead-end error state is a real terminal, not a truncation
+                    terminated = True
                     observation = self._mock_rest.generate_error_response()
                     self.last_observation = self.encoder.encode(observation)
                 else:
@@ -305,7 +306,7 @@ class RestApiEnv(gym.Env):
         #     reward = -0.1
 
         reward = np.clip(reward, -1.0, 1.0)
-        return self.last_observation, reward, done, terminated, info
+        return self.last_observation, reward, terminated, truncated, info
 
     def reset(
             self,

--- a/igc/modules/igc_train_agent.py
+++ b/igc/modules/igc_train_agent.py
@@ -231,13 +231,13 @@ class IgcAgentTrainer(RlBaseModule):
         rewards_per_trajectory = []
 
         i = 0
-        # VectorizedRestApiEnv.step returns ``done`` (goal reached or horizon truncation)
-        # as its third value. Stop the rollout as soon as any env reports the episode is
-        # over; previously ``terminated`` was never updated and the loop always ran to
-        # ``max_episode_len``, replaying past-terminal transitions under the same goal.
-        done = [False] * self.env.num_envs
+        # standard contract: position 3 = terminated (goal/dead-end), position 4 =
+        # truncated (time-limit). The rollout stops on either; replay bootstrapping
+        # distinguishes them downstream (q_targets masks on terminal-only dones).
+        terminated = torch.zeros(self.env.num_envs, dtype=torch.bool)
+        truncated = torch.zeros(self.env.num_envs, dtype=torch.bool)
 
-        while not any(done) and i < self.max_episode_len:
+        while not bool((terminated | truncated).any()) and i < self.max_episode_len:
 
             goal_state = self.current_goal["state"]
             state_flat = _state.view(_state.size(0), -1)
@@ -273,7 +273,7 @@ class IgcAgentTrainer(RlBaseModule):
 
                 concatenated_vector = torch.cat([rest_api_one_hot, rest_api_method_one_hot], dim=1)
 
-            next_state, rewards, done, terminated, info = self.env.step(concatenated_vector)
+            next_state, rewards, terminated, truncated, info = self.env.step(concatenated_vector)
             next_state_flat = next_state.view(next_state.size(0), -1).detach().cpu()
             episode_experience.append(
                 (state_flat, concatenated_vector, rewards, next_state_flat, goal_state_flat)

--- a/tests/envs/test_rest_gym_env_reset_step.py
+++ b/tests/envs/test_rest_gym_env_reset_step.py
@@ -135,12 +135,12 @@ def test_step_get_known_resource_returns_success_observation(rest_env: RestApiEn
     _, info = rest_env.reset()
     action = _action(rest_env._discovered_rest_api, SYSTEM_URI, "GET")
 
-    observation, reward, done, terminated, step_info = rest_env.step(action)
+    observation, reward, terminated, truncated, step_info = rest_env.step(action)
 
     assert info == {"goal": None}
     assert reward == pytest.approx(0.1)
-    assert done is False
     assert terminated is False
+    assert truncated is False
     assert step_info == {}
     assert rest_env.step_count == 1
     assert torch.equal(observation, rest_env.encoder.encode(json.dumps(SYSTEM_PAYLOAD)))
@@ -153,12 +153,12 @@ def test_step_http_500_returns_terminal_error_observation(rest_env: RestApiEnv):
     rest_env.mock_server().set_simulate_http_500_error(True)
     action = _action(rest_env._discovered_rest_api, SYSTEM_URI, "GET")
 
-    observation, reward, done, terminated, info = rest_env.step(action)
+    observation, reward, terminated, truncated, info = rest_env.step(action)
 
     error_json = MockServer.generate_error_response()
     assert reward == pytest.approx(-0.5)
-    assert done is True
-    assert terminated is False
+    assert terminated is True  # dead-end error is a real terminal
+    assert truncated is False
     assert info == {}
     assert torch.equal(observation, rest_env.encoder.encode(error_json))
     assert torch.equal(rest_env.last_observation, observation)
@@ -171,3 +171,16 @@ def test_reset_rejects_fixed_state_goal_with_wrong_shape(rest_env: RestApiEnv):
 
 
 # Author: Mus mbayramo@stanford.edu
+
+
+def test_step_limit_truncates_without_terminating(rest_env: RestApiEnv):
+    """Hitting max_steps truncates (time-limit) and never marks terminal."""
+    rest_env.reset()
+    action = _action(rest_env._discovered_rest_api, SYSTEM_URI, "GET")
+    rest_env.step_count = rest_env.max_steps - 1
+
+    _, reward, terminated, truncated, _ = rest_env.step(action)
+
+    assert truncated is True
+    assert terminated is False
+    assert reward == pytest.approx(-1.0)

--- a/tests/modules/test_train_goal_termination.py
+++ b/tests/modules/test_train_goal_termination.py
@@ -39,11 +39,11 @@ class _FakeEnv:
     def step(self, _action):
         self.step_calls += 1
         is_done = self.step_calls >= self._done_after
-        done = torch.tensor([is_done])
         terminated = torch.tensor([is_done])
+        truncated = torch.tensor([False])
         rewards = torch.zeros(1)
         info = [{"goal_reached": torch.tensor(False)}]
-        return self._state.clone(), rewards, done, terminated, info
+        return self._state.clone(), rewards, terminated, truncated, info
 
 
 class _FakeDataset:


### PR DESCRIPTION
Fixes the audit-flagged semantic inversion: both envs returned done (terminal OR time-limit) in position 3 and 'terminated' (actually truncation) in position 4. Standard contract now: terminated = goal reached or dead-end error; truncated = time-limit. The vectorized env tracks both per sub-env (goal detection only applies to still-active envs), the trainer rollout stops on either flag, and the pinning tests were updated to the new contract with a new truncation regression.

Offline gate: 469 passed, 11 deselected. Ruff: 0 new findings.