### PR TITLE
Gather sharded state dicts collectively before checkpoint saves

### DIFF
--- a/igc/modules/base/igc_base_module.py
+++ b/igc/modules/base/igc_base_module.py
@@ -567,6 +567,7 @@ class IgcModule(IgcBaseState):
             initial_lr: Optional[float] = None,
             is_best_accuracy: Optional[bool] = False,
             batch_idx: Optional[int] = None,
+            model_state_dict: Optional[Dict] = None,
     ) -> str:
         """
         Save model checkpoint.
@@ -601,7 +602,10 @@ class IgcModule(IgcBaseState):
         _optimizer = optimizer if optimizer is not None else self.optimizer
 
         checkpoint = {
-            'model_state_dict': _model.state_dict(),
+            # a caller that already gathered the full state dict (sharded runs use
+            # accelerator.get_state_dict, a collective) passes it here; calling
+            # state_dict() on a sharded model from rank 0 alone deadlocks.
+            'model_state_dict': model_state_dict if model_state_dict is not None else _model.state_dict(),
             'epoch': epoch,
             'is_trained': True,
         }

--- a/igc/modules/llm_train_state_encoder.py
+++ b/igc/modules/llm_train_state_encoder.py
@@ -23,6 +23,7 @@ from transformers import PreTrainedModel, PreTrainedTokenizer
 from igc.modules.base.igc_llm_base_module import LlmModule
 from igc.modules.base.igc_metric_logger import MetricLogger
 from igc.modules.shared.llm_shared import safe_resize_token_embeddings
+from igc.shared.shared_accelerator import broadcast_flag
 from igc.shared.shared_torch_builder import TorchBuilder
 
 from igc.ds.redfish_masked_dataset import (
@@ -638,9 +639,18 @@ class LlmEmbeddingsTrainer(LlmModule):
             epochs_done = epoch + 1
 
             # save best checkpoint
+            is_best_accuracy = validation_accuracy > self._best_validation_metric
+            should_save = is_best_accuracy or (epoch + 1) % self._save_freq == 0
+            gathered_state = None
+            if self.is_accelerator and self._module_checkpoint_dir is not None:
+                # rank 0's verdict must be uniform, and the state-dict gather is a
+                # COLLECTIVE under ZeRO-3/FSDP — every rank participates or the
+                # fleet deadlocks / rank 0 writes shards.
+                should_save = broadcast_flag(self.accelerator, should_save)
+                if should_save:
+                    gathered_state = self.accelerator.get_state_dict(self.model)
             if self.is_rank_zero():
-                is_best_accuracy = validation_accuracy > self._best_validation_metric
-                if is_best_accuracy or (epoch + 1) % self._save_freq == 0:
+                if should_save:
                     self._best_validation_metric = validation_accuracy
                     if self._module_checkpoint_dir is not None:
                         if self.is_accelerator:
@@ -651,6 +661,7 @@ class LlmEmbeddingsTrainer(LlmModule):
                                 self._module_checkpoint_dir,
                                 epoch + 1,
                                 model=model,
+                                model_state_dict=gathered_state,
                                 optimizer=opt,
                                 scheduler=shed,
                                 last_accuracy=validation_accuracy,

--- a/igc/shared/shared_accelerator.py
+++ b/igc/shared/shared_accelerator.py
@@ -131,4 +131,24 @@ def build_accelerator(cmd: argparse.Namespace):
     return accelerator
 
 
+def broadcast_flag(accelerator, flag: bool) -> bool:
+    """Make a rank-0 boolean decision uniform across ranks.
+
+    Collective checkpoint operations (e.g. ``get_state_dict`` gathers under
+    ZeRO-3/FSDP) require every rank to take the same branch; a rank-local
+    verdict (like a validation-accuracy comparison) deadlocks the fleet when
+    ranks disagree. Single-process accelerators pass the flag through.
+
+    :param accelerator: the built ``accelerate.Accelerator``.
+    :param flag: this rank's local decision.
+    :return: rank 0's decision, uniform on every rank.
+    """
+    if getattr(accelerator, "num_processes", 1) <= 1:
+        return flag
+    import torch
+    from accelerate.utils import broadcast
+    verdict = torch.tensor([1 if flag else 0], device=accelerator.device)
+    return bool(broadcast(verdict, from_process=0).item())
+
+
 # Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_sharded_save.py
+++ b/tests/modules/test_sharded_save.py
@@ -1,0 +1,68 @@
+"""Offline regressions for sharded-run checkpointing support.
+
+Under ZeRO-3/FSDP a rank-0-only ``unwrap_model().state_dict()`` deadlocks (the
+gather is collective) or writes shards. The trainer now gathers via
+``accelerator.get_state_dict`` on every rank behind a rank-0 verdict made
+uniform by ``broadcast_flag``, and ``IgcModule.save_checkpoint`` accepts the
+pre-gathered ``model_state_dict`` instead of re-calling ``state_dict()``.
+CPU-only; single-process behavior plus the saver override are pinned here —
+the true multi-rank path runs on the cluster rung (gpu-marked).
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import argparse
+
+import loguru
+import torch
+
+from igc.modules.base.igc_base_module import IgcModule
+from igc.shared.shared_accelerator import broadcast_flag
+
+
+class _SingleProcessAccelerator:
+    num_processes = 1
+
+
+def test_broadcast_flag_single_process_is_identity():
+    """With one process there is nothing to synchronize."""
+    accelerator = _SingleProcessAccelerator()
+    assert broadcast_flag(accelerator, True) is True
+    assert broadcast_flag(accelerator, False) is False
+
+
+def _module(tmp_path):
+    module = IgcModule.__new__(IgcModule)
+    module.rank = 0
+    module.module_name = "tmod"
+    module.logger = loguru.logger
+    module.model = torch.nn.Linear(2, 2)
+    module.optimizer = None
+    module.scheduler = None
+    module._trainer_args = argparse.Namespace(seed=1, output_dir=str(tmp_path))
+    return module
+
+
+def test_save_checkpoint_uses_pregathered_state_dict(tmp_path):
+    """A provided model_state_dict is saved verbatim, not model.state_dict()."""
+    module = _module(tmp_path)
+    gathered = {"weight": torch.ones(2, 2), "bias": torch.zeros(2)}
+
+    path = module.save_checkpoint(
+        str(tmp_path), epoch=1, model_state_dict=gathered
+    )
+    checkpoint = torch.load(path, weights_only=True)
+
+    assert torch.equal(checkpoint["model_state_dict"]["weight"], torch.ones(2, 2))
+
+
+def test_save_checkpoint_falls_back_to_model_state(tmp_path):
+    """Without the override the model's own state dict is saved (plain path)."""
+    module = _module(tmp_path)
+    path = module.save_checkpoint(str(tmp_path), epoch=1)
+    checkpoint = torch.load(path, weights_only=True)
+    assert set(checkpoint["model_state_dict"]) == {"weight", "bias"}
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
Fixes the gaps-audit blocker: sharded (ZeRO-3/FSDP) runs saved checkpoints via a rank-0-only unwrap+state_dict, which deadlocks (collective gather) or writes shards — every m1_*_full sharded profile would hang at its first save. The save verdict is now made uniform across ranks (broadcast_flag; rank-0 decides), the full state dict is gathered collectively via accelerator.get_state_dict, and IgcModule.save_checkpoint accepts the pre-gathered dict. Single-process behavior unchanged (broadcast_flag is identity; gather is accelerate's plain unwrap path).

Offline gate: 472 passed, 11 deselected (+3 regressions). The true multi-rank round-trip is the R4 cluster rung (gpu-marked). Ruff: 0 new findings (2 pre-existing F523 untouched).