### PR TITLE
Add the fleet-health preflight gate and the smoke ladder runbook

### DIFF
--- a/docs/SMOKE_LADDER.md
+++ b/docs/SMOKE_LADDER.md
@@ -1,0 +1,52 @@
+# Smoke ladder — from offline gate to a full GB300 run
+
+Each rung is a gate: a run may not move up until the rung below passes. The ladder exists
+because the expensive failures (broken resume, corrupt sharded checkpoints, a mis-matched
+tokenizer) are cheap to catch low and ruinous to discover hours into a cluster job.
+
+Conventions: the offline gate is plain `pytest -q` from the repo root (configured by
+`pytest.ini`, which registers and excludes the `gpu`/`slow`/`download`/`dataset`/`live`
+markers). Cluster steps read the fleet dashboard address from `NV72_FLEET_DASHBOARD_URL`
+(an internal URL kept out of this repo; see the team's ops notes) and are gated by
+`scripts/preflight_nv72.sh`, which pipes `/api/v1/state` through the offline-tested
+checker in `igc/shared/nv72_preflight.py`.
+
+## R0 — offline gate (every change)
+
+```bash
+pytest -q          # must be green; ruff check on touched files
+```
+
+## R1 — CPU mini-train (before any GPU time)
+
+A 20-step M1 run on the tiny dataset (`--device cpu`, `--num_workers 2`). Gates:
+loss decreases; a checkpoint is written; **the run resumes from its own checkpoint**
+(kill it, restart, confirm the epoch advances instead of restarting at zero).
+
+## R2 — 1 GPU, gpt2 smoke profile
+
+`m1_gpt2_smoke` via `scripts/run_profile.sh` on one GB300. Gates: fleet preflight passes;
+the W&B run appears (single run — not one per rank); `kill -USR1` produces a resumable
+checkpoint; throughput is recorded.
+
+## R3 — 1 GPU, modern backbone (LoRA)
+
+The `m1_local` profile (weights dir from `IGC_MODEL_DIR`) or a Qwen2.5 profile, 50 steps,
+**on a dataset rebuilt for that backbone** (`--recreate_dataset`; the tokenizer-provenance
+guard in the dataset loader refuses mismatched caches). Gates: the vocabulary assertion
+passes (no `safe_resize` refusal); loss decreases; checkpoint round-trips.
+
+## R4 — 4 GPU, FSDP2 sharded
+
+`accelerate launch --num_processes 4` with `--sharding fsdp`. Run `NCCL_NVLS_ENABLE=0`
+per the fabric caution in the ops notes. Gates: an NCCL all-reduce microbench completes
+first; the sharded run saves AND reloads a checkpoint (the collective-gather path);
+single-process launches of a sharded config must fail loudly (by design).
+
+## R5 — full run
+
+Only after R4: the real profile, full step budget, checkpoint rotation on, end-of-job
+weight publishing to shared storage, disk-space preflight green.
+
+Author:
+Mus mbayramo@stanford.edu

--- a/igc/shared/nv72_preflight.py
+++ b/igc/shared/nv72_preflight.py
@@ -1,0 +1,90 @@
+"""Fleet-health preflight evaluation for GB300 training jobs.
+
+TEAM_GUIDE makes checking the NV72 fleet dashboard a hard blocker before any
+GB300 work: RoCE degraded, the shared ``/models`` mount missing, or a required
+model endpoint absent means "stop and report a BLOCKER", never "submit anyway".
+This module holds the pure decision logic — it never talks to the network.
+``scripts/preflight_nv72.sh`` (which owns the curl against
+``$NV72_FLEET_DASHBOARD_URL``, defined in the caller's environment) pipes the
+``/api/v1/state`` JSON into :func:`main`; tests feed fixture payloads straight
+into :func:`evaluate_state` per TEAM_GUIDE's offline-testing mandate.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import argparse
+import json
+import sys
+from typing import List, Optional, Tuple
+
+
+def evaluate_state(
+        state: dict,
+        require_endpoint: Optional[str] = None,
+) -> Tuple[bool, List[str]]:
+    """Decide whether the fleet is healthy enough to submit a GB300 job.
+
+    :param state: the parsed ``/api/v1/state`` payload (or a test fixture).
+    :param require_endpoint: optionally require a serving model endpoint group
+        (e.g. ``"flash"`` or ``"pro"``) to be non-empty.
+    :return: ``(ok, reasons)`` — ``reasons`` lists every blocker found.
+    """
+    reasons: List[str] = []
+    summaries = state.get("summaries") or {}
+
+    roce = summaries.get("roce") or {}
+    if not roce:
+        reasons.append("state has no summaries.roce section (dashboard degraded?)")
+    elif roce.get("rdma_active") != roce.get("nodes"):
+        reasons.append(
+            f"RoCE degraded: rdma_active {roce.get('rdma_active')}/{roce.get('nodes')}")
+
+    mount = summaries.get("models_mount") or {}
+    if not mount:
+        reasons.append("state has no summaries.models_mount section")
+    elif mount.get("mounted") != mount.get("nodes"):
+        reasons.append(
+            f"/models mount degraded: mounted {mount.get('mounted')}/{mount.get('nodes')}")
+
+    if require_endpoint is not None:
+        endpoints = (state.get("model_endpoints") or {}).get(require_endpoint) or []
+        if not endpoints:
+            reasons.append(
+                f"required model endpoint group {require_endpoint!r} has no serving instance")
+
+    return (not reasons, reasons)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Read the state JSON from stdin and print the verdict.
+
+    :param argv: CLI args (``--require-endpoint flash|pro``).
+    :return: process exit code — 0 healthy, 1 blocked, 2 unreadable input.
+    """
+    parser = argparse.ArgumentParser(description="NV72 fleet preflight verdict.")
+    parser.add_argument(
+        "--require-endpoint", default=None,
+        help="also require this model endpoint group (e.g. flash, pro) to be serving.")
+    args = parser.parse_args(argv)
+
+    try:
+        state = json.load(sys.stdin)
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        print(f"BLOCKER: fleet state unreadable ({e}) — is the dashboard up?")
+        return 2
+
+    ok, reasons = evaluate_state(state, require_endpoint=args.require_endpoint)
+    if ok:
+        print("fleet preflight OK")
+        return 0
+    for reason in reasons:
+        print(f"BLOCKER: {reason}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/scripts/preflight_nv72.sh
+++ b/scripts/preflight_nv72.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# preflight_nv72.sh — mandatory fleet-health gate before any GB300 job.
+#
+# TEAM_GUIDE's blocker rule: check the NV72 fleet dashboard before GB300 work;
+# an unavailable API or unhealthy state (RoCE down, /models unmounted, required
+# model endpoint absent) is a hard stop. The dashboard address comes ONLY from
+# the environment — never hardcoded (internal endpoint policy):
+#
+#   export NV72_FLEET_DASHBOARD_URL=...   # from your ops notes / TEAM_GUIDE
+#   ./scripts/preflight_nv72.sh                       # infra health only
+#   ./scripts/preflight_nv72.sh --require-endpoint pro  # also require Pro serving
+#
+# Decision logic lives in igc/shared/nv72_preflight.py (offline-unit-tested);
+# this wrapper only owns the curl.
+set -euo pipefail
+
+: "${NV72_FLEET_DASHBOARD_URL:?set NV72_FLEET_DASHBOARD_URL (internal dashboard base URL) before GB300 work}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+if ! STATE_JSON=$(curl -fsS --max-time "${NV72_PREFLIGHT_TIMEOUT:-10}" \
+        "${NV72_FLEET_DASHBOARD_URL}/api/v1/state"); then
+    echo "BLOCKER: fleet dashboard unreachable at \$NV72_FLEET_DASHBOARD_URL/api/v1/state" >&2
+    exit 1
+fi
+
+printf '%s' "${STATE_JSON}" | PYTHONPATH="${HERE}" "${PYTHON_BIN}" -m igc.shared.nv72_preflight "$@"

--- a/scripts/submit_train.sh
+++ b/scripts/submit_train.sh
@@ -24,6 +24,18 @@ case "${STAGE}" in
     *) echo "ERROR: stage '${STAGE}' is not one of m1|m2|m3|m3p|m6|all" >&2; exit 2 ;;
 esac
 
+# Fleet-health gate (TEAM_GUIDE blocker rule): never submit against an unhealthy fleet.
+# Requires NV72_FLEET_DASHBOARD_URL in the environment; IGC_SKIP_PREFLIGHT=1 is the
+# explicit, logged escape hatch for operator judgment calls.
+if [[ "${IGC_SKIP_PREFLIGHT:-0}" != "1" ]]; then
+    "${HERE}/scripts/preflight_nv72.sh" || {
+        echo "BLOCKER: fleet preflight failed — fix the fleet or set IGC_SKIP_PREFLIGHT=1 deliberately." >&2
+        exit 1
+    }
+else
+    echo "WARNING: IGC_SKIP_PREFLIGHT=1 — submitting without the fleet-health gate." >&2
+fi
+
 command -v sbatch >/dev/null || { echo "ERROR: sbatch not found — run this from a GB300 node (ssh nvidia@172.25.230.40)." >&2; exit 1; }
 [ -f "${SBATCH_FILE}" ] || { echo "ERROR: ${SBATCH_FILE} not found." >&2; exit 1; }
 

--- a/tests/shared/test_nv72_preflight.py
+++ b/tests/shared/test_nv72_preflight.py
@@ -1,0 +1,76 @@
+"""Offline tests for the NV72 fleet preflight decision logic.
+
+TEAM_GUIDE mandates that unit tests never call the live dashboard: the
+``/api/v1/state`` payload is mocked as small fixture dicts and the pre-flight
+verdict logic is asserted against them. Pins the blocker rules — RoCE
+degradation, ``/models`` mount degradation, a missing required model endpoint,
+and a malformed/empty state all block; a healthy fleet passes.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+from igc.shared.nv72_preflight import evaluate_state
+
+
+def _healthy_state(**overrides):
+    """A minimal healthy /api/v1/state fixture."""
+    state = {
+        "summaries": {
+            "roce": {"rdma_active": 18, "nodes": 18},
+            "models_mount": {"mounted": 18, "nodes": 18},
+        },
+        "model_endpoints": {
+            "flash": [{"model": "m", "url": "u", "role": "fast_worker"}],
+            "pro": [],
+        },
+    }
+    state.update(overrides)
+    return state
+
+
+def test_healthy_fleet_passes():
+    """All-green summaries with no endpoint requirement pass."""
+    ok, reasons = evaluate_state(_healthy_state())
+    assert ok and reasons == []
+
+
+def test_roce_degradation_blocks():
+    """rdma_active < nodes is a blocker naming the counts."""
+    state = _healthy_state()
+    state["summaries"]["roce"] = {"rdma_active": 16, "nodes": 18}
+    ok, reasons = evaluate_state(state)
+    assert not ok
+    assert any("RoCE" in r and "16/18" in r for r in reasons)
+
+
+def test_models_mount_degradation_blocks():
+    """An unmounted /models node is a blocker."""
+    state = _healthy_state()
+    state["summaries"]["models_mount"] = {"mounted": 17, "nodes": 18}
+    ok, reasons = evaluate_state(state)
+    assert not ok
+    assert any("/models" in r for r in reasons)
+
+
+def test_required_endpoint_absent_blocks():
+    """Requiring a scaled-down endpoint group blocks with its name."""
+    ok, reasons = evaluate_state(_healthy_state(), require_endpoint="pro")
+    assert not ok
+    assert any("'pro'" in r for r in reasons)
+
+
+def test_required_endpoint_present_passes():
+    """Requiring a serving group passes."""
+    ok, reasons = evaluate_state(_healthy_state(), require_endpoint="flash")
+    assert ok
+
+
+def test_empty_state_blocks_on_missing_sections():
+    """A degraded dashboard payload (no summaries) is itself a blocker."""
+    ok, reasons = evaluate_state({})
+    assert not ok
+    assert len(reasons) == 2  # roce + models_mount sections missing
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
Implements the team guide's mandatory pre-GB300 fleet check (previously unimplemented): offline-tested decision logic (RoCE, /models mount, optional required endpoint), a thin curl wrapper reading NV72_FLEET_DASHBOARD_URL from the environment only (no internal address committed), and a hard submit gate in submit_train.sh with an explicit escape hatch. docs/SMOKE_LADDER.md records the R0-R5 ladder (offline gate -> CPU mini-train -> 1-GPU smoke -> modern-backbone LoRA -> 4-GPU FSDP2 -> full run) with per-rung gates.

Offline gate: 484 passed, 11 deselected (+6 mocked-payload tests per the guide's testing mandate). Ruff clean.