### PR TITLE
Add GB300 job hygiene: disk preflight, publish hook, NCCL smoke, HF token

### DIFF
--- a/igc/shared/shared_main.py
+++ b/igc/shared/shared_main.py
@@ -19,6 +19,11 @@ def shared_main(
     args, parser_groups = shared_arg_parser()
     args.local_rank = int(os.environ.get('LOCAL_RANK', -1))
 
+    # The team docs standardize on HUGGINGFACE_TOKEN, but huggingface_hub reads
+    # HF_TOKEN — map it once (value never logged) so gated-model downloads work.
+    if os.environ.get("HUGGINGFACE_TOKEN") and not os.environ.get("HF_TOKEN"):
+        os.environ["HF_TOKEN"] = os.environ["HUGGINGFACE_TOKEN"]
+
     # "auto" is the parser default and never a valid torch.device string; resolve
     # it (and an unset device) to a concrete device before any module calls
     # torch.device(args.device). Under accelerate launch/torchrun (LOCAL_RANK set)

--- a/scripts/nccl_smoke.py
+++ b/scripts/nccl_smoke.py
@@ -1,0 +1,88 @@
+"""NCCL all-reduce microbench — the entry gate for any multi-GPU rung.
+
+The GB300 fabric has a documented history of NVLink flakiness, so a 4-GPU
+training job must not be the first thing to exercise collective comms. Run
+this first (30 seconds, R4 rung of docs/SMOKE_LADDER.md):
+
+    NCCL_NVLS_ENABLE=0 torchrun --nproc_per_node 4 scripts/nccl_smoke.py
+
+Each rank all-reduces a tensor repeatedly and rank 0 prints the effective
+bus bandwidth; any fabric fault surfaces here as a hang or NCCL error in
+seconds instead of hours into training. Pure helpers below are offline-
+unit-tested; the collective path needs GPUs and torchrun.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import argparse
+import os
+import time
+
+
+def tensor_megabytes(numel: int, bytes_per_element: int = 4) -> float:
+    """Size of the reduced tensor in MiB.
+
+    :param numel: number of elements.
+    :param bytes_per_element: element width (fp32 default).
+    :return: size in MiB.
+    """
+    return numel * bytes_per_element / (1024 ** 2)
+
+
+def busbw_gbps(numel: int, iters: int, seconds: float, world_size: int) -> float:
+    """Effective all-reduce bus bandwidth in GB/s (ring algorithm accounting).
+
+    :param numel: elements per all-reduce.
+    :param iters: number of all-reduce calls timed.
+    :param seconds: total wall time for the timed calls.
+    :param world_size: participating ranks.
+    :return: bus bandwidth in GB/s (0.0 when inputs are degenerate).
+    """
+    if seconds <= 0 or world_size <= 1 or iters <= 0:
+        return 0.0
+    bytes_moved = numel * 4 * iters * 2 * (world_size - 1) / world_size
+    return bytes_moved / seconds / 1e9
+
+
+def main() -> int:
+    """Run the collective loop under torchrun; print rank-0 bandwidth."""
+    parser = argparse.ArgumentParser(description="NCCL all-reduce microbench")
+    parser.add_argument("--numel", type=int, default=64 * 1024 * 1024,
+                        help="elements per all-reduce (fp32; default 256 MiB).")
+    parser.add_argument("--iters", type=int, default=20, help="timed iterations.")
+    parser.add_argument("--warmup", type=int, default=3, help="untimed iterations.")
+    args = parser.parse_args()
+
+    import torch
+    import torch.distributed as dist
+
+    dist.init_process_group("nccl")
+    rank = dist.get_rank()
+    world = dist.get_world_size()
+    torch.cuda.set_device(int(os.environ.get("LOCAL_RANK", rank)))
+    payload = torch.ones(args.numel, dtype=torch.float32, device="cuda")
+
+    for _ in range(args.warmup):
+        dist.all_reduce(payload)
+    torch.cuda.synchronize()
+
+    start = time.perf_counter()
+    for _ in range(args.iters):
+        dist.all_reduce(payload)
+    torch.cuda.synchronize()
+    elapsed = time.perf_counter() - start
+
+    if rank == 0:
+        print(f"nccl_smoke OK: world={world} "
+              f"size={tensor_megabytes(args.numel):.0f}MiB iters={args.iters} "
+              f"busbw={busbw_gbps(args.numel, args.iters, elapsed, world):.1f} GB/s")
+    dist.destroy_process_group()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/scripts/train_igc.sbatch
+++ b/scripts/train_igc.sbatch
@@ -28,6 +28,15 @@
 
 set -euo pipefail
 
+# Disk preflight: a run that starts on a nearly-full node-local NVMe dies mid-training
+# (HF pulls + dataset + checkpoints). Fail fast, with an explicit override knob.
+IGC_MIN_FREE_GB="${IGC_MIN_FREE_GB:-100}"
+AVAIL_GB="$(df -BG --output=avail "${HOME}" 2>/dev/null | tail -1 | tr -dc '0-9' || echo 0)"
+if [[ "${AVAIL_GB}" -lt "${IGC_MIN_FREE_GB}" ]]; then
+    echo "BLOCKER: only ${AVAIL_GB}G free under \$HOME (< IGC_MIN_FREE_GB=${IGC_MIN_FREE_GB}G) — clean up or lower the floor deliberately." >&2
+    exit 1
+fi
+
 # 1-GPU first: the NVLink fabric is flaky under multi-GPU (disable SHARP/multicast).
 export NCCL_NVLS_ENABLE=0
 export PYTHONUNBUFFERED=1
@@ -106,3 +115,13 @@ srun --container-image="${NGC_IMAGE}" \
             ${EXTRA_ARGS} \
             --log_level info --llm_log_level info
      '
+
+# End-of-job publish: node-local NVMe is not durable storage — when IGC_WEIGHTS_DEST is
+# set (e.g. a path under the shared /models filesystem), copy the run's artifacts off
+# the node with a sha256 manifest. Opt-in: publish_checkpoint.sh requires the dest.
+if [[ -n "${IGC_WEIGHTS_DEST:-}" ]]; then
+    "${IGC_DIR}/scripts/publish_checkpoint.sh" "${IGC_DIR}/experiments/${IGC_RUN}" \
+        || echo "WARNING: checkpoint publish failed — weights remain ONLY on this node" >&2
+else
+    echo "NOTE: IGC_WEIGHTS_DEST unset — weights stay on node-local NVMe (set it to publish, e.g. a /models path)." >&2
+fi

--- a/tests/shared/test_gb300_ops.py
+++ b/tests/shared/test_gb300_ops.py
@@ -1,0 +1,76 @@
+"""Offline tests for the GB300 ops helpers.
+
+Covers the pure pieces of the operational path: the HF token mapping in
+``shared_main`` (docs standardize on ``HUGGINGFACE_TOKEN`` but
+``huggingface_hub`` reads ``HF_TOKEN``; values are never asserted into logs),
+and the nccl_smoke bandwidth/size arithmetic (the collective loop itself is a
+cluster-rung tool). CPU-only, no network.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import importlib.util
+import os
+import pathlib
+import sys
+
+import pytest
+import torch  # noqa: F401 — ensures the heavy import happens before shared_main
+
+from igc.shared.shared_main import shared_main
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[2] / "scripts"
+
+
+def _load_nccl_smoke():
+    spec = importlib.util.spec_from_file_location("nccl_smoke", _SCRIPTS / "nccl_smoke.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_shared_main(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "argv", ["igc_main.py", "--output_dir", str(tmp_path)])
+    return shared_main(is_cuda_empty_cache=False)
+
+
+def test_huggingface_token_mapped_to_hf_token(monkeypatch, tmp_path):
+    """HUGGINGFACE_TOKEN is mirrored into HF_TOKEN for huggingface_hub."""
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.setenv("HUGGINGFACE_TOKEN", "sentinel-token")
+    _run_shared_main(monkeypatch, tmp_path)
+    assert os.environ.get("HF_TOKEN") == "sentinel-token"
+
+
+def test_existing_hf_token_not_clobbered(monkeypatch, tmp_path):
+    """An explicitly-set HF_TOKEN wins over the legacy variable."""
+    monkeypatch.setenv("HF_TOKEN", "explicit")
+    monkeypatch.setenv("HUGGINGFACE_TOKEN", "legacy")
+    _run_shared_main(monkeypatch, tmp_path)
+    assert os.environ["HF_TOKEN"] == "explicit"
+
+
+def test_busbw_ring_accounting():
+    """Bus bandwidth follows the ring all-reduce byte accounting."""
+    smoke = _load_nccl_smoke()
+    # 1e9 bytes moved in 1s -> 1 GB/s: pick numel so bytes==1e9 for world=2, iters=1
+    # bytes = numel*4*1*2*(2-1)/2 = numel*4  -> numel = 2.5e8
+    assert smoke.busbw_gbps(250_000_000, 1, 1.0, 2) == pytest.approx(1.0)
+
+
+def test_busbw_degenerate_inputs_are_zero():
+    """Zero time, one rank, or zero iters never divide by zero."""
+    smoke = _load_nccl_smoke()
+    assert smoke.busbw_gbps(10, 1, 0.0, 4) == 0.0
+    assert smoke.busbw_gbps(10, 1, 1.0, 1) == 0.0
+    assert smoke.busbw_gbps(10, 0, 1.0, 4) == 0.0
+
+
+def test_tensor_megabytes():
+    """Size helper reports fp32 MiB."""
+    smoke = _load_nccl_smoke()
+    assert smoke.tensor_megabytes(64 * 1024 * 1024) == pytest.approx(256.0)
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
Closes the remaining ops gaps before cluster rungs: fail-fast disk preflight in the sbatch (IGC_MIN_FREE_GB), opt-in end-of-job artifact publishing via IGC_WEIGHTS_DEST (e.g. a shared /models path; previously weights were stranded on node-local NVMe with publish_checkpoint.sh uncalled), the R4-gating NCCL all-reduce microbench, and HUGGINGFACE_TOKEN -> HF_TOKEN mapping (huggingface_hub reads the latter; token values never logged).

Also verified-and-documented: the audit's 'checkpoints accumulate forever' claim was wrong — save_checkpoint cycles num_check_points_to_keep filenames in place (probe: 7 epochs, keep=3 -> exactly 3 files), so no rotation change ships.

Offline gate: 489 passed, 11 deselected (+5 tests: token mapping x2, busbw ring accounting + degenerate guards, size helper). Ruff clean; sbatch syntax-checked.