### PR TITLE
Bump submodule to redfish_ctl and ingest the new multi-vendor walk corpora

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 
 [submodule "idrac_ctl"]
     path = idrac_ctl
-    url = git@github.com:spyroot/idrac_ctl.git
+    url = git@github.com:spyroot/redfish_ctl.git

--- a/igc_ctl.py
+++ b/igc_ctl.py
@@ -20,15 +20,16 @@ import warnings
 import requests
 import urllib3
 
-from idrac_ctl import IDracManager, CustomArgumentDefaultsHelpFormatter, ApiRequestType
-from idrac_ctl.idrac_ctl.cmd_exceptions import AuthenticationFailed
-from idrac_ctl.idrac_ctl.idrac_main import console_error_printer
+# redfish_ctl is the renamed idrac_ctl; install with: pip install "redfish_ctl>=1.1.4"
+from redfish_ctl import IDracManager, CustomArgumentDefaultsHelpFormatter, ApiRequestType
+from redfish_ctl.cmd_exceptions import AuthenticationFailed
+from redfish_ctl.redfish_main import console_error_printer
 
 try:
     from urllib3.exceptions import InsecureRequestWarning
 
-    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-except ImportError as ir:
+    urllib3.disable_warnings(InsecureRequestWarning)
+except ImportError:
     warnings.warn("Failed import urllib3")
 
 logging.basicConfig(format='%(asctime)s,%(msecs)03d %(levelname)-8s '


### PR DESCRIPTION
## What

Two commits:

1. **Submodule bump + repoint.** The data-collection tool was renamed `idrac_ctl` → `redfish_ctl` (github.com/spyroot/redfish_ctl, PyPI `redfish-ctl`) and generalized to a full multi-vendor Redfish implementation. `.gitmodules` now points at the renamed repo (submodule path stays `idrac_ctl/` — igc code reads fixture corpora under it) and the pin fast-forwards 246 commits on the same lineage.
2. **`igc_ctl.py` import fix.** The double-nested `idrac_ctl.idrac_ctl.*` module paths no longer exist upstream (`idrac_ctl` is now a thin alias package); import from the canonical `redfish_ctl` package instead. Also clears two pre-existing lint findings in the touched file (net: 3 findings → 1).

## Contract verification

The binding discovery contract is unchanged: `redfish_ctl/discovery/cmd_discovery.py` still writes `rest_api_map.npy` holding exactly `url_file_mapping` + `allowed_methods_mapping`, which `igc/ds/ds_rest_trajectories.py` loads. All replacement imports were resolved against the new pin with the project interpreter before committing.

## New data this brings

The full GB300 crawl corpus (four per-host walk directories, ~2,000 resources, with `rest_api_map.npy` discovery maps stored via **git LFS**), two real Supermicro X10 host walks (129 + 64 resources, with maps), a generic DMTF corpus (86), and grown iLO (167) / Dell (48) fixtures.

Ingest proof through the `igc.ds.sources` pipeline on this branch:
- **4,010 raw records emitted, 0 unparsable**, across 10 sources
- **2,834 records carry `allowed_methods` attached from the real `.npy` maps** — first offline end-to-end exercise of the discovery contract
- 2,160 URL-deduped (the GB300 corpus bundles walks also shipped as standalone fixture dirs; dedup collapses them correctly) → 1,839 train / 321 eval (trust-tier split)
- Known follow-up: cross-vendor URL collisions (e.g. `/redfish/v1` present on every vendor) also dedup — the mixer's dedup key should become `(source, url)`; tracked on the board.

**Consumers need `git lfs` installed** to materialize the `.npy` maps and the corpus tarball (verified working here); the JSON corpora are regular git objects and work without it.

## Gate

Offline suite on this branch: **484 passed, 0 failed** (11 gpu/live deselected). `ruff` on the touched file: findings reduced 3 → 1 (remaining one pre-exists on main).