### PR TITLE
Tolerate non-host subdirectories when loading captures

### DIFF
--- a/igc/ds/ds_rest_trajectories.py
+++ b/igc/ds/ds_rest_trajectories.py
@@ -177,15 +177,29 @@ class RestTrajectory(AbstractLogger):
         sub_directory = [f for f in os.listdir(self.rest_new_prefix)
                          if os.path.isdir(os.path.join(self.rest_new_prefix, f))]
 
+        loaded = []
         for s in sub_directory:
             dir_path = os.path.join(self.rest_new_prefix, s)
+            # capture roots also hold non-host dirs (orig/, post/, pre/) and hosts whose
+            # crawl produced no map; the pipeline must tolerate partial captures, so a
+            # subdirectory without a flat rest_api_map .npy is skipped, not fatal.
+            if not any(f.endswith('.npy') for f in os.listdir(dir_path)):
+                self.logger.warning(
+                    f"Skipping {dir_path}: no rest_api_map .npy at its top level.")
+                continue
             merged_url_file_mapping, merged_allowed_methods_mapping = RestTrajectory.load_url_file_mapping(dir_path)
             self._rest_map_data[s] = {
                 "rest_api_map": merged_url_file_mapping,
                 "merged_allowed_methods_mapping": merged_allowed_methods_mapping
             }
+            loaded.append(s)
 
-        for s in sub_directory:
+        if not loaded:
+            raise ValueError(
+                f"No host capture directory under {self.rest_new_prefix} contains a "
+                f"rest_api_map .npy — nothing to build from.")
+
+        for s in loaded:
             self.remap_respond_location(s)
 
         self._hosts = sub_directory

--- a/tests/ds/test_capture_load_tolerance.py
+++ b/tests/ds/test_capture_load_tolerance.py
@@ -1,0 +1,62 @@
+"""Offline regression: capture loading tolerates non-host subdirectories.
+
+``RestTrajectory.load`` iterates every subdirectory of the capture root, but
+real capture roots also hold ``orig/``/``post/``/``pre/`` (nested copies, no
+top-level ``.npy``) and hosts whose crawl produced no map — the first such
+directory previously raised and killed every on-node dataset rebuild. Loading
+must skip them with a warning, keep the hosts that do carry maps, and only
+fail when NO host has a map at all. Uses tiny synthetic ``.npy`` maps.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+from igc.ds.ds_rest_trajectories import RestTrajectory
+
+
+def _host_dir(root, name):
+    """A minimal host capture dir: one response file + its .npy map."""
+    host = root / name
+    host.mkdir(parents=True)
+    response = host / "redfish_v1.json"
+    response.write_text(json.dumps({"@odata.id": "/redfish/v1"}))
+    np.save(
+        host / "rest_api_map.npy",
+        {
+            "url_file_mapping": {"/redfish/v1": str(response)},
+            "allowed_methods_mapping": {"/redfish/v1": ["GET"]},
+        },
+    )
+    return host
+
+
+def test_non_host_subdirs_are_skipped(tmp_path):
+    """orig/-style nested dirs and empty dirs don't abort the load."""
+    _host_dir(tmp_path, "172.0.0.1")
+    (tmp_path / "orig" / "172.0.0.1").mkdir(parents=True)  # nested, no flat .npy
+    (tmp_path / "post").mkdir()  # empty
+
+    trajectory = RestTrajectory(str(tmp_path), str(tmp_path / "orig"))
+    trajectory.load()
+
+    mapping, methods = trajectory.merged_view()
+    assert "/redfish/v1" in mapping
+    assert methods["/redfish/v1"] == ["GET"]
+
+
+def test_all_subdirs_mapless_raises(tmp_path):
+    """A capture root with no usable host at all still fails loudly."""
+    (tmp_path / "orig").mkdir()
+    (tmp_path / "post").mkdir()
+
+    trajectory = RestTrajectory(str(tmp_path), str(tmp_path / "orig"))
+    with pytest.raises(ValueError, match="No host capture directory"):
+        trajectory.load()
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
First real-cluster finding: the R2 on-node dataset rebuild (docker, slot3) died with 'No mapping files found' because RestTrajectory.load hard-fails on any capture subdirectory lacking a flat rest_api_map .npy — and real capture roots contain orig/post/pre copies plus hosts without maps. Local runs never hit this (prebuilt caches bypass the build). Mapless subdirs now skip with a warning; the load raises only when NO host carries a map. Two regressions with synthetic .npy maps (mixed layout loads; all-mapless raises). The .npy key contract is untouched.

Offline gate: 491 passed.