### PR TITLE
Fix capture-tolerance test fixture to the real ctor contract

### DIFF
--- a/tests/ds/test_capture_load_tolerance.py
+++ b/tests/ds/test_capture_load_tolerance.py
@@ -41,7 +41,9 @@ def test_non_host_subdirs_are_skipped(tmp_path):
     (tmp_path / "orig" / "172.0.0.1").mkdir(parents=True)  # nested, no flat .npy
     (tmp_path / "post").mkdir()  # empty
 
-    trajectory = RestTrajectory(str(tmp_path), str(tmp_path / "orig"))
+    # ctor contract: load() iterates rest_new_prefix (the SECOND arg — the
+    # datasets/orig-style map root); raw_json_dir only anchors response remapping.
+    trajectory = RestTrajectory(str(tmp_path), str(tmp_path))
     trajectory.load()
 
     mapping, methods = trajectory.merged_view()
@@ -54,7 +56,7 @@ def test_all_subdirs_mapless_raises(tmp_path):
     (tmp_path / "orig").mkdir()
     (tmp_path / "post").mkdir()
 
-    trajectory = RestTrajectory(str(tmp_path), str(tmp_path / "orig"))
+    trajectory = RestTrajectory(str(tmp_path), str(tmp_path))
     with pytest.raises(ValueError, match="No host capture directory"):
         trajectory.load()
 


### PR DESCRIPTION
Fix-forward for PR #17, which I merged with this test red (a piped pytest hid the exit code — my gating error, now run with pipefail). The source tolerance fix was correct; the fixture passed host dirs in raw_json_dir while load() iterates rest_new_prefix (second arg). Offline gate: 491 passed, exit-code enforced.