### PR TITLE
Integrate six Codex worker test branches

### DIFF
--- a/tests/ds/test_source_mixer_edges.py
+++ b/tests/ds/test_source_mixer_edges.py
@@ -1,0 +1,121 @@
+"""Additional edge coverage for trust-tier-aware source mixing."""
+
+from igc.ds.sources import mixer as mixer_module
+from igc.ds.sources.base import SourceAdapter, SourceRecord, TrustLevel
+from igc.ds.sources.mixer import SourceMix
+
+
+class _Source(SourceAdapter):
+    """SourceAdapter test double backed by an in-memory record list."""
+
+    def __init__(self, source, trust_level, records):
+        super().__init__(module_name=f"edge-source[{source}]")
+        self.source = source
+        self.trust_level = trust_level
+        self._records = records
+
+    def iter_records(self):
+        return iter(self._records)
+
+
+def _record(url, source, trust_level):
+    return SourceRecord(
+        url=url,
+        response={"@odata.id": url},
+        source=source,
+        trust_level=trust_level,
+    )
+
+
+def _source(source, trust_level, urls):
+    return _Source(
+        source,
+        trust_level,
+        [_record(url, source, trust_level) for url in urls],
+    )
+
+
+def test_single_record_below_eval_floor_always_trains():
+    """A lone low-trust record is not held out even at eval_fraction=1.0."""
+    mix = SourceMix(
+        [_source("sim", TrustLevel.SIM_GENERIC, ["/redfish/v1/sim-only"])],
+        eval_fraction=1.0,
+        eval_trust_floor=TrustLevel.REAL,
+    )
+
+    train, held_out = mix.split()
+
+    assert [record.url for record in train] == ["/redfish/v1/sim-only"]
+    assert held_out == []
+
+
+def test_eval_threshold_is_strictly_less_than_fraction(monkeypatch):
+    """A hash equal to the fraction stays in train; below it is held out."""
+    hash_by_url = {
+        "/redfish/v1/exact": 0.5,
+        "/redfish/v1/below": 0.499,
+        "/redfish/v1/above": 0.501,
+    }
+    monkeypatch.setattr(
+        mixer_module,
+        "unit_hash",
+        lambda key, seed: hash_by_url[key],
+    )
+    mix = SourceMix(
+        [_source("real", TrustLevel.REAL, list(hash_by_url))],
+        eval_fraction=0.5,
+        seed=123,
+    )
+
+    train, held_out = mix.split()
+
+    assert [record.url for record in train] == [
+        "/redfish/v1/exact",
+        "/redfish/v1/above",
+    ]
+    assert [record.url for record in held_out] == ["/redfish/v1/below"]
+
+
+def test_all_same_trust_tier_split_preserves_source_order(monkeypatch):
+    """Same-tier records split only by hash threshold and keep input order."""
+    urls = ["/redfish/v1/a", "/redfish/v1/b", "/redfish/v1/c", "/redfish/v1/d"]
+    hash_by_url = {
+        "/redfish/v1/a": 0.10,
+        "/redfish/v1/b": 0.90,
+        "/redfish/v1/c": 0.20,
+        "/redfish/v1/d": 0.80,
+    }
+    monkeypatch.setattr(
+        mixer_module,
+        "unit_hash",
+        lambda key, seed: hash_by_url[key],
+    )
+    mix = SourceMix(
+        [_source("replay", TrustLevel.REPLAY, urls)],
+        eval_fraction=0.5,
+        eval_trust_floor=TrustLevel.REPLAY,
+    )
+
+    train, held_out = mix.split()
+
+    assert [record.url for record in train] == ["/redfish/v1/b", "/redfish/v1/d"]
+    assert [record.url for record in held_out] == ["/redfish/v1/a", "/redfish/v1/c"]
+
+
+def test_equal_trust_dedup_keeps_first_seen_record():
+    """Equal-trust duplicate URLs keep the adapter-order winner."""
+    first = _Source(
+        "real_a",
+        TrustLevel.REAL,
+        [_record("/redfish/v1/shared", "real_a", TrustLevel.REAL)],
+    )
+    second = _Source(
+        "real_b",
+        TrustLevel.REAL,
+        [_record("/redfish/v1/shared", "real_b", TrustLevel.REAL)],
+    )
+
+    records = SourceMix([first, second], dedup=True).records()
+
+    assert len(records) == 1
+    assert records[0].source == "real_a"

--- a/tests/ds/test_tokenizer_provenance_edges.py
+++ b/tests/ds/test_tokenizer_provenance_edges.py
@@ -1,0 +1,75 @@
+"""Edge coverage for dataset tokenizer provenance checks."""
+
+import pytest
+
+from igc.ds.redfish_dataset import JSONDataset
+
+
+def test_string_token_counts_are_compared_as_integers():
+    """String token counts from JSON metadata compare equal to live counts."""
+    JSONDataset.check_tokenizer_provenance(
+        {"num_tokens": "53147", "model_type": "gpt2"},
+        "53147",
+        "gpt2",
+    )
+
+
+def test_none_provenance_fields_are_skipped():
+    """Explicit null tokenizer fields behave like absent legacy fields."""
+    JSONDataset.check_tokenizer_provenance(
+        {"num_tokens": None, "model_type": None},
+        53147,
+        "gpt2",
+    )
+
+
+def test_unknown_live_model_type_skips_model_comparison():
+    """A missing live model id still allows token-count-only validation."""
+    JSONDataset.check_tokenizer_provenance(
+        {"num_tokens": 53147, "model_type": "gpt2"},
+        53147,
+        None,
+    )
+
+
+def test_empty_recorded_model_type_is_an_explicit_mismatch():
+    """An empty recorded model id is not treated as absent provenance."""
+    with pytest.raises(ValueError) as excinfo:
+        JSONDataset.check_tokenizer_provenance(
+            {"num_tokens": 53147, "model_type": ""},
+            53147,
+            "gpt2",
+        )
+
+    message = str(excinfo.value)
+    assert "--model_type ''" in message
+    assert "current run uses 'gpt2'" in message
+    assert "--recreate_dataset" in message
+
+
+def test_smaller_live_vocab_error_pins_counts_and_rebuild_hint():
+    """A cache that can contain out-of-vocab ids reports both vocab sizes."""
+    with pytest.raises(ValueError) as excinfo:
+        JSONDataset.check_tokenizer_provenance(
+            {"num_tokens": "151936"},
+            "53147",
+            "Qwen/Qwen2.5-7B-Instruct",
+        )
+
+    message = str(excinfo.value)
+    assert "151936-token tokenizer" in message
+    assert "only 53147 tokens" in message
+    assert "--recreate_dataset" in message
+
+
+def test_grown_live_vocab_warning_pins_growth_delta():
+    """A grown tokenizer warns with the exact positive delta."""
+    with pytest.warns(UserWarning) as warnings:
+        JSONDataset.check_tokenizer_provenance({"num_tokens": "53140"}, 53147)
+
+    assert len(warnings) == 1
+    message = str(warnings[0].message)
+    assert "53140-token tokenizer" in message
+    assert "the loaded one has 53147" in message
+    assert "grew by 7" in message
+    assert "--recreate_dataset" in message

--- a/tests/modules/test_checkpoint_file_selection.py
+++ b/tests/modules/test_checkpoint_file_selection.py
@@ -1,0 +1,128 @@
+"""Offline coverage for ``IgcModule`` checkpoint file selection.
+
+These tests complement the save/resume regressions by pinning how explicit
+checkpoint paths, checkpoint directories, and copy-to-final-model selection are
+resolved before a checkpoint is loaded.
+"""
+
+import argparse
+import os
+import time
+from pathlib import Path
+
+import loguru
+import torch
+import torch.nn as nn
+
+from igc.modules.base.igc_base_module import IgcModule
+
+
+def _module(tmp_path: Path) -> IgcModule:
+    """Build a minimal CPU-only ``IgcModule`` shell for selection tests."""
+    module = IgcModule.__new__(IgcModule)
+    module._module_checkpoint_dir = str(tmp_path)
+    module.module_name = "tmod"
+    module.logger = loguru.logger
+    module.model = nn.Linear(2, 2)
+    module.optimizer = torch.optim.SGD(module.model.parameters(), lr=0.1)
+    module.scheduler = None
+    module.rank = 0
+    return module
+
+
+def _write_checkpoint(path: Path, model: nn.Module, *, epoch: int) -> None:
+    """Write the minimal resumable checkpoint payload."""
+    torch.save(
+        {
+            "model_state_dict": model.state_dict(),
+            "optimizer_state_dict": torch.optim.SGD(
+                model.parameters(), lr=0.1
+            ).state_dict(),
+            "epoch": epoch,
+            "is_trained": True,
+        },
+        path,
+    )
+
+
+def test_last_checkpoint_chooses_newest_resumable_epoch_file(
+        tmp_path: Path) -> None:
+    """Among resumable files, the newest mtime wins."""
+    model = nn.Linear(2, 2)
+    older = tmp_path / "tmod_epoch_1.pt"
+    newer = tmp_path / "tmod_epoch_2.pt"
+    _write_checkpoint(older, model, epoch=1)
+    time.sleep(0.02)
+    _write_checkpoint(newer, model, epoch=2)
+
+    assert IgcModule.last_checkpoint(str(tmp_path)) == str(newer)
+
+
+def test_checkpoint_file_returns_explicit_file_path(tmp_path: Path) -> None:
+    """A direct checkpoint file path is returned without directory scanning."""
+    module = _module(tmp_path)
+    checkpoint = tmp_path / "manual.pt"
+    _write_checkpoint(checkpoint, module.model, epoch=7)
+
+    assert module.checkpoint_file(str(checkpoint)) == str(checkpoint)
+
+
+def test_checkpoint_file_empty_directory_returns_none(tmp_path: Path) -> None:
+    """An empty checkpoint directory resolves to ``None``."""
+    module = _module(tmp_path)
+
+    assert module.checkpoint_file(str(tmp_path)) is None
+
+
+def test_checkpoint_file_non_resuming_still_selects_checkpoint(
+        tmp_path: Path) -> None:
+    """When a checkpoint exists, non-resume mode still returns that file."""
+    module = _module(tmp_path)
+    checkpoint = tmp_path / "tmod_epoch_1.pt"
+    _write_checkpoint(checkpoint, module.model, epoch=1)
+
+    assert module.checkpoint_file(str(tmp_path), resuming=False) == str(checkpoint)
+
+
+def test_copy_checkpoint_uses_explicit_checkpoint_directory(
+        tmp_path: Path) -> None:
+    """An explicit checkpoint path writes the final model beside that file."""
+    source = nn.Linear(2, 2)
+    checkpoint = tmp_path / "picked.pt"
+    _write_checkpoint(checkpoint, source, epoch=9)
+    target = nn.Linear(2, 2)
+
+    model_payload, epoch, last_model_path = IgcModule.copy_checkpoint(
+        str(tmp_path),
+        "tmod",
+        target,
+        checkpoint_file=str(checkpoint),
+        device="cpu",
+    )
+
+    assert model_payload is not None
+    assert epoch == 9
+    assert last_model_path == str(tmp_path / "tmod_last.pt")
+    assert os.path.exists(last_model_path)
+    assert not any(param.requires_grad for param in target.parameters())
+
+
+def test_copy_checkpoint_discovers_module_subdir_checkpoint(
+        tmp_path: Path) -> None:
+    """Without an explicit file, copy_checkpoint scans ``<output>/<module>``."""
+    module_dir = tmp_path / "tmod"
+    module_dir.mkdir()
+    source = nn.Linear(2, 2)
+    checkpoint = module_dir / "tmod_epoch_3.pt"
+    _write_checkpoint(checkpoint, source, epoch=3)
+    target = nn.Linear(2, 2)
+    specs = argparse.Namespace(output_dir=str(tmp_path))
+
+    model_payload, epoch, last_model_path = IgcModule.copy_checkpoint(
+        specs, "tmod", target, device="cpu"
+    )
+
+    assert model_payload is not None
+    assert epoch == 3
+    assert last_model_path == str(tmp_path / "tmod_last.pt")
+    assert os.path.exists(last_model_path)

--- a/tests/modules/test_checkpoint_file_selection.py
+++ b/tests/modules/test_checkpoint_file_selection.py
@@ -7,7 +7,6 @@ resolved before a checkpoint is loaded.
 
 import argparse
 import os
-import time
 from pathlib import Path
 
 import loguru
@@ -52,10 +51,19 @@ def test_last_checkpoint_chooses_newest_resumable_epoch_file(
     older = tmp_path / "tmod_epoch_1.pt"
     newer = tmp_path / "tmod_epoch_2.pt"
     _write_checkpoint(older, model, epoch=1)
-    time.sleep(0.02)
     _write_checkpoint(newer, model, epoch=2)
+    os.utime(older, (10, 10))
+    os.utime(newer, (20, 20))
 
     assert IgcModule.last_checkpoint(str(tmp_path)) == str(newer)
+
+
+def test_last_checkpoint_returns_none_without_pt_candidates(
+        tmp_path: Path) -> None:
+    """Directories with no checkpoint candidates return ``None``."""
+    (tmp_path / "notes.txt").write_text("not a checkpoint", encoding="utf-8")
+
+    assert IgcModule.last_checkpoint(str(tmp_path)) is None
 
 
 def test_checkpoint_file_returns_explicit_file_path(tmp_path: Path) -> None:
@@ -104,7 +112,13 @@ def test_copy_checkpoint_uses_explicit_checkpoint_directory(
     assert epoch == 9
     assert last_model_path == str(tmp_path / "tmod_last.pt")
     assert os.path.exists(last_model_path)
+    assert torch.allclose(target.weight, source.weight)
+    assert torch.allclose(target.bias, source.bias)
+    assert target.training is False
     assert not any(param.requires_grad for param in target.parameters())
+    saved = torch.load(last_model_path, weights_only=True)
+    assert "optimizer_state_dict" not in saved
+    assert "scheduler_state_dict" not in saved
 
 
 def test_copy_checkpoint_discovers_module_subdir_checkpoint(
@@ -126,3 +140,22 @@ def test_copy_checkpoint_discovers_module_subdir_checkpoint(
     assert epoch == 3
     assert last_model_path == str(tmp_path / "tmod_last.pt")
     assert os.path.exists(last_model_path)
+    assert torch.allclose(target.weight, source.weight)
+    assert torch.allclose(target.bias, source.bias)
+    assert target.training is False
+
+
+def test_copy_checkpoint_returns_none_without_module_candidates(
+        tmp_path: Path) -> None:
+    """An empty ``<output>/<module>`` directory has no checkpoint to copy."""
+    (tmp_path / "tmod").mkdir()
+    target = nn.Linear(2, 2)
+    specs = argparse.Namespace(output_dir=str(tmp_path))
+
+    model_payload, epoch, last_model_path = IgcModule.copy_checkpoint(
+        specs, "tmod", target, device="cpu"
+    )
+
+    assert model_payload is None
+    assert epoch == 0
+    assert last_model_path == str(tmp_path / "tmod_last.pt")

--- a/tests/modules/test_igc_q_network.py
+++ b/tests/modules/test_igc_q_network.py
@@ -1,0 +1,52 @@
+"""Offline tests for the legacy fixed-width Q-network head."""
+
+import torch
+
+from igc.modules.igc_q_network import Igc_QNetwork
+
+
+def test_forward_returns_one_score_per_action_for_batch():
+    """A batch of observations projects to one Q-score per configured action."""
+    net = Igc_QNetwork(input_dim=5, num_actions=7, hidden_dim=11)
+
+    output = net(torch.randn(3, 5))
+
+    assert output.shape == (3, 7)
+
+
+def test_forward_accepts_single_observation_tensor():
+    """A single observation tensor keeps the fixed action width."""
+    net = Igc_QNetwork(input_dim=4, num_actions=2, hidden_dim=6)
+
+    output = net(torch.randn(4))
+
+    assert output.shape == (2,)
+
+
+def test_constructor_uses_configured_dimensions():
+    """The legacy head derives layer sizes from constructor arguments."""
+    net = Igc_QNetwork(input_dim=3, num_actions=9, hidden_dim=13)
+
+    assert net.dense1.in_features == 3
+    assert net.dense1.out_features == 13
+    assert net.dense2.in_features == 13
+    assert net.dense3.out_features == 13
+    assert net.out.in_features == 13
+    assert net.out.out_features == 9
+
+
+def test_backward_updates_input_and_all_layers():
+    """Gradients flow from selected Q-scores back through the full MLP."""
+    torch.manual_seed(0)
+    net = Igc_QNetwork(input_dim=6, num_actions=4, hidden_dim=8)
+    inputs = torch.randn(5, 6, requires_grad=True)
+
+    selected_scores = net(inputs)[:, [0, 2]].sum()
+    selected_scores.backward()
+
+    assert inputs.grad is not None
+    assert torch.isfinite(inputs.grad).all()
+    for parameter in net.parameters():
+        assert parameter.grad is not None
+        assert torch.isfinite(parameter.grad).all()
+

--- a/tests/modules/train/test_emit_edges.py
+++ b/tests/modules/train/test_emit_edges.py
@@ -1,0 +1,111 @@
+"""
+Broad edge tests for run-report emission.
+
+Covers default/empty inputs and immutability boundaries around ``build_run_bundle``
+and ``emit_run_report`` so end-of-run reporting stays deterministic without importing
+the trainer. Pure stdlib.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+from pathlib import Path
+
+from igc.modules.train.emit import build_run_bundle, emit_run_report
+from igc.modules.train.report import ResultBundle
+
+
+def _spec(**overrides):
+    """Minimal parsed-spec dict with realistic run-report keys."""
+    spec = {
+        "model_type": "Qwen/Qwen2.5-7B-Instruct",
+        "profile": "m1_7b_rslora_r32",
+        "use_peft": True,
+        "adapter_method": "rslora",
+        "lora_r": "32",
+        "lora_init": "pissa",
+        "max_train_steps": 120,
+        "seq_len": 1024,
+        "gradient_accumulation_steps": 4,
+        "llm_scheduler": "OneCycleLR",
+        "seed": 7,
+    }
+    spec.update(overrides)
+    return spec
+
+
+def test_missing_dataset_fields_default_to_empty_manifest_ids():
+    """Reports from raw-capture training keep manifest/split ids empty, not missing."""
+    bundle = build_run_bundle(
+        _spec(),
+        training={"optimizer_steps": 120},
+        metrics=None,
+        dataset_fields=None,
+        argv=[],
+    )
+
+    assert bundle.manifest.data_manifest == ""
+    assert bundle.manifest.eval_split == ""
+    assert bundle.metrics == {}
+
+
+def test_run_id_is_stable_for_model_basename_and_timestamp():
+    """run_id uses the model basename and strips timestamp punctuation."""
+    bundle = build_run_bundle(
+        _spec(model_type="/models/Qwen2.5-7B-Instruct"),
+        training={},
+        argv=[],
+        started_at="2026-07-10T01:02:03",
+    )
+
+    assert bundle.manifest.run_id == "m1-Qwen2.5-7B-Instruct-20260710T010203"
+
+
+def test_report_copies_training_and_metrics_inputs():
+    """Caller mutations after bundle creation cannot change the emitted report."""
+    training = {"final_epoch_loss": 3.0}
+    metrics = {"eval/accuracy": 0.62}
+    bundle = build_run_bundle(_spec(), training=training, metrics=metrics, argv=[])
+
+    training["final_epoch_loss"] = 99.0
+    metrics["eval/accuracy"] = 0.0
+
+    assert bundle.manifest.training["final_epoch_loss"] == 3.0
+    assert bundle.metrics["eval/accuracy"] == 0.62
+
+
+def test_settings_include_only_allowlisted_run_knobs():
+    """Settings omit unrelated parser values while preserving selected knobs as strings."""
+    bundle = build_run_bundle(
+        _spec(output_dir="/tmp/run", hf_token="redacted", password="redacted"),
+        training={},
+        argv=[],
+    )
+
+    assert bundle.manifest.settings == {
+        "gradient_accumulation_steps": "4",
+        "llm_scheduler": "OneCycleLR",
+        "seed": "7",
+        "use_peft": "True",
+        "lora_r": "32",
+    }
+
+
+def test_emit_creates_nested_output_directory(tmp_path: Path):
+    """emit_run_report creates the run directory and writes a readable report.json."""
+    bundle = build_run_bundle(
+        _spec(use_peft=False, lora_r=64),
+        training={"epochs_done": 1},
+        argv=["igc_main.py", "--profile", "m1_gpt2_smoke"],
+        checkpoint_path="experiments/smoke",
+    )
+    report_path = emit_run_report(bundle, str(tmp_path / "nested" / "run"))
+
+    assert report_path.endswith("report.json")
+    back = ResultBundle.read(report_path)
+    assert back.manifest.adapter_method == "none"
+    assert back.manifest.adapter_rank is None
+    assert back.manifest.checkpoint_path == "experiments/smoke"
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/test_observation_encoder.py
+++ b/tests/test_observation_encoder.py
@@ -1,0 +1,133 @@
+"""Offline unit tests for the REST observation encoder."""
+
+from types import SimpleNamespace
+
+import torch
+
+from igc.envs.rest_encoder import RestBaseEncoder
+
+
+class _Embeddings:
+    """Minimal embedding table shape used by the resize guard."""
+
+    def __init__(self, rows: int) -> None:
+        self.num_embeddings = rows
+
+
+class _Backbone:
+    """Callable fake backbone that returns deterministic hidden states."""
+
+    def __init__(self, config: SimpleNamespace) -> None:
+        self.config = config
+        self.calls: list[torch.Tensor] = []
+
+    def __call__(self, input_ids: torch.Tensor):
+        self.calls.append(input_ids.clone())
+        hidden = torch.stack(
+            [input_ids.float() + offset for offset in range(self.config.hidden_size)],
+            dim=-1,
+        )
+        return SimpleNamespace(last_hidden_state=hidden)
+
+
+class _Model:
+    """Small model double exposing the methods RestBaseEncoder touches."""
+
+    base_model_prefix = "transformer"
+
+    def __init__(self, *, vocab_rows: int = 6, positions: int | None = 8, hidden_size: int = 4) -> None:
+        self.config = SimpleNamespace(hidden_size=hidden_size)
+        if positions is not None:
+            self.config.max_position_embeddings = positions
+        self.transformer = _Backbone(self.config)
+        self._embeddings = _Embeddings(vocab_rows)
+        self.resized_to: list[int] = []
+
+    def get_input_embeddings(self) -> _Embeddings:
+        return self._embeddings
+
+    def resize_token_embeddings(self, target: int) -> None:
+        self.resized_to.append(target)
+        self._embeddings.num_embeddings = target
+
+
+class _Tokenizer:
+    """Tokenizer double that records encode options."""
+
+    def __init__(self, tokens: list[int], size: int = 6) -> None:
+        self.tokens = tokens
+        self.size = size
+        self.calls: list[dict[str, object]] = []
+
+    def __len__(self) -> int:
+        return self.size
+
+    def encode(self, text: str, **kwargs) -> list[int]:
+        self.calls.append({"text": text, **kwargs})
+        max_length = kwargs.get("max_length")
+        if kwargs.get("truncation") and isinstance(max_length, int):
+            return self.tokens[:max_length]
+        return list(self.tokens)
+
+
+def test_rest_encoder_derives_shape_from_backbone_config():
+    """emb_shape follows backbone positions/hidden size and excludes padding."""
+    model = _Model(positions=9, hidden_size=5)
+
+    encoder = RestBaseEncoder(model=model, tokenizer=_Tokenizer([1, 2, 3]))
+
+    assert encoder.encoder_model is model.transformer
+    assert encoder.emb_shape == (8, 5)
+    assert model.config.is_decoder is False
+    assert model.resized_to == []
+
+
+def test_rest_encoder_uses_default_position_fallback_for_rope_like_model():
+    """Models without max positions use the shared 1024-token fallback."""
+    encoder = RestBaseEncoder(
+        model=_Model(positions=None, hidden_size=7),
+        tokenizer=_Tokenizer([1, 2, 3]),
+    )
+
+    assert encoder.emb_shape == (1023, 7)
+
+
+def test_encode_tokenizes_with_padding_and_returns_hidden_state_without_batch_dim():
+    """encode requests fixed-length tokens and returns [seq, hidden] embeddings."""
+    tokenizer = _Tokenizer([5, 6, 7, 8])
+    model = _Model(hidden_size=3)
+    encoder = RestBaseEncoder(model=model, tokenizer=tokenizer)
+
+    out = encoder.encode("redfish-body", max_chunk_length=3)
+
+    assert tokenizer.calls == [
+        {
+            "text": "redfish-body",
+            "truncation": True,
+            "add_special_tokens": True,
+            "padding": "max_length",
+            "max_length": 3,
+        }
+    ]
+    assert model.transformer.calls[0].tolist() == [[5, 6, 7]]
+    assert out.shape == (3, 3)
+    assert out.tolist() == [
+        [5.0, 6.0, 7.0],
+        [6.0, 7.0, 8.0],
+        [7.0, 8.0, 9.0],
+    ]
+
+
+def test_encode_reuses_cache_without_retokenizing_or_reencoding():
+    """Repeated observations are served from cache."""
+    tokenizer = _Tokenizer([1, 2, 3])
+    model = _Model()
+    encoder = RestBaseEncoder(model=model, tokenizer=tokenizer)
+
+    first = encoder.encode("same-observation", max_chunk_length=3)
+    second = encoder.encode("same-observation", max_chunk_length=3)
+
+    assert second is first
+    assert len(tokenizer.calls) == 1
+    assert len(model.transformer.calls) == 1
+    assert encoder.cache["same-observation"] is first


### PR DESCRIPTION
Batch integration of six READY-FOR-PR Codex worker branches, all test-only and additive (653 lines, 6 new test files):

- `codex/checkpoint-file-selection` — checkpoint file-selection coverage (2 commits)
- `codex/observation-encoder-edges` — fills the zero-byte `tests/test_observation_encoder.py` with RestBaseEncoder edge coverage
- `codex/q-network-edges` — CPU shape/gradient coverage for the legacy Q-network
- `codex/run-report-emit-edges` — run-report emission edge coverage
- `codex/source-mixer-edges` — source mixer edge coverage
- `codex/tokenizer-provenance-edges` — tokenizer provenance edge coverage

Each branch was individually gated green by the worker (board rows carry the evidence); this batch re-gates the combined result.

Gate on the batch: **522 passed, 0 failed** (11 gpu/live deselected); ruff clean on all six new files.