### PR TITLE
Record D-002: action-candidate representation (text + graph, v1 scoped)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -7,6 +7,96 @@ Deeper design context lives in [ARCHITECTURE.md](ARCHITECTURE.md); training mech
 
 ---
 
+## D-002 — Action-candidate representation: text + graph features, v1 scoped (2026-07-11)
+
+**Status: ACCEPTED** (v1 scope; extends D-001).
+**Method:** owner proposal, refined through the same multi-perspective design review as D-001,
+grounded by a feature-derivability census over the real capture corpora.
+
+### Proposal under review
+
+Represent each (endpoint, method) candidate for the D-001 pointer as both **text** and **graph
+context** derived from the walked Redfish resource tree (nodes = resources, edges = containment /
+links / action targets), rather than URL text alone. The original field list also included a
+current-resource state summary and goal-relevance features.
+
+### Grounding census (what the captured corpora actually support)
+
+Measured over the real Supermicro (1,499 resources) and HPE iLO (167) fixture corpora:
+
+| Feature source | Availability | Consequence |
+|---|---|---|
+| `@odata.type` (resource type + schema version) | 92–100% | `resource_type` is derivable nearly everywhere |
+| Parent by URL-prefix containment | 90–98% | containment edges + `child_relation_name` nearly free |
+| Explicit `Links` sections | **10–14%** | link edges are SPARSE — the graph builder must harvest `@odata.id` references from anywhere in the body, not just `Links` |
+| `Actions` with a `target` | 5–17% | `has_action_target` is sparse and therefore discriminative |
+| `Oem` sections / OEM-namespaced types | 16–26% | OEM markers exist but are vendor-specific |
+
+### Decision — v1 candidate schema
+
+```
+candidate_v1 = {
+  endpoint_path_tokens,   # URL path segments, ids normalized
+  http_method,
+  resource_type,          # from @odata.type (standard schema; namespace stays inside the string)
+  child_relation_name,    # the link/containment name that makes this endpoint reachable
+  has_action_target,      # boolean: body carries Actions[*].target
+}
+candidate_emb = concat(f_text(path, method), f_feats(type, relation, action_flag))  # NOT additive
+score = state_latent^T · W · candidate_emb                                          # bilinear, v1
+```
+
+- **Fusion is concatenation, not addition.** Zero is not a neutral element in an additive
+  scheme; under a partial crawl, missing graph features as zero vectors would systematically
+  shift candidate embeddings. Concatenation with zero-padding lets the scorer learn to ignore
+  missing dimensions. Gated fusion is deferred (added parameters that can overfit to the
+  training vendors' crawl-completeness patterns).
+- **Scorer is a bilinear dot product for v1**, not `MLP([s, c, s*c])`: smoother Q-surface
+  (less overestimation with noisy TD targets), and one matrix multiply scores the whole
+  candidate set — which matters because HER relabeling re-scores every candidate for each
+  relabeled goal. Upgrade path if v1 underperforms: 2-layer MLP over `[s, c]` (the MLP can
+  learn interactions; the explicit `s*c` term is not needed).
+
+### Cut from the proposal (with reasons)
+
+- **`current_resource_state_summary` — removed.** Duplicates what the state latent already
+  encodes, and it is the one field that would make candidate embeddings state-dependent —
+  breaking per-host precompute and creating staleness inconsistency under HER relabeling.
+- **`goal_relevance_features` — removed.** A leakage vector: any precomputed relevance
+  heuristic short-circuits the DQN's need to learn goal-action interaction, must be recomputed
+  per relabeled goal, and collapses on unseen vendors/goal phrasings. Goal information reaches
+  the score only through the goal-conditioned state latent.
+- **`schema_or_oem_namespace` as a separate field — removed.** The namespace already lives
+  inside `resource_type`; surfacing it separately invites the model to key on vendor tokens,
+  directly hurting held-out-vendor transfer. Revisit later at most as a binary `is_oem` flag.
+- **`depth_in_tree` — dropped** (duplicates path length; low information density).
+  **`parent_resource_type`, `allowed_methods` — deferred to v2** (partial-crawl sensitive /
+  largely redundant with the candidate's own method + `has_action_target`); add only if the
+  v1 go/no-go fails, as controlled ablations.
+- **Learned graph-neighborhood embeddings (GNN over the local tree) — deferred to v2.** The
+  census shows explicit link coverage is too sparse for reliable neighborhoods on a partial
+  crawl; v1 uses only the cheap, near-universal structural fields above.
+
+### The payoff: caching
+
+With the dynamic fields removed, **every candidate embedding is fully static per host** —
+computed once from the walked tree, cached, and only *filtered* by the per-state legal catalog.
+HER relabeling then re-scores cached embeddings against the new goal-conditioned state latent
+(one matmul) instead of re-encoding candidates. This resolves D-001 binding requirement #2 by
+construction.
+
+### Risks accepted
+
+- Text + shallow structural features may under-discriminate sibling endpoints that differ only
+  deep in their bodies (no neighborhood embedding in v1) — measured by the same zero-shot
+  ranking go/no-go as D-001 (≥ 80% top-5 on a held-out vendor); v2 features are the planned
+  response, not a redesign.
+- ID normalization in `endpoint_path_tokens` (collection members like `/Systems/1` vs
+  `/Systems/Node0`) must not erase member identity where the goal targets a specific member —
+  keep the raw id as a trailing token rather than deleting it.
+
+---
+
 ## D-001 — M6 action-selection objective: hybrid pointer + argument decoder (2026-07-11)
 
 **Status: ACCEPTED** (pending the de-risk experiment below).


### PR DESCRIPTION
Adds D-002 to docs/DECISIONS.md, extending D-001: candidates encode path tokens, method, resource type, child relation, and action-target flag; concatenation fusion; bilinear scorer for v1. Cuts state-summary and goal-relevance fields (precompute-breaking / leakage), folds OEM namespace into resource_type, defers GNN neighborhoods. Grounded by a census over the real Supermicro/HPE corpora (notably: explicit Links sections cover only 10-14% of resources, so graph edges must be harvested from whole-body @odata.id references). Static-per-host candidate embeddings resolve D-001 requirement 2 by construction. Docs-only: diff-check clean, tests/core green.