### PR TITLE
Implement D-002 v1: resource graph, candidate featurizer, and the zero-shot go/no-go

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -95,6 +95,27 @@ construction.
   `/Systems/Node0`) must not erase member identity where the goal targets a specific member —
   keep the raw id as a trailing token rather than deleting it.
 
+### Experiment result (2026-07-11) — NO-GO for the untrained encoder; learned projection required
+
+The go/no-go was run with the weakest instantiation first: a completely frozen character-trigram
+encoder and NO learned projection (pure cosine between state body text and candidate text), over
+the full walked trees, ground truth = each state's true graph neighbors
+(`igc/modules/eval/zero_shot_ranking.py` + `igc/ds/sources/resource_graph.py`):
+
+| Corpus | k=1 | k=5 | Bar (≥0.80 top-5) |
+|---|---|---|---|
+| Supermicro, in-domain, 1,499 nodes | 0.185 | **0.293** | NO-GO |
+| HPE iLO, held-out vendor, 167 nodes | 0.323 | **0.754** | NO-GO (near) |
+
+Interpretation: ~30× over the random baseline, but far under the bar on the large host — with
+hundreds of near-identical sensor leaves, global text similarity fills the top-5 with lookalike
+*siblings* rather than true transitions. Host size dominates difficulty (167-node HPE nearly
+passes; 1,499-node Supermicro fails hard). **Consequence: the learned bilinear projection
+`s^T W c` is load-bearing, not optional — representation similarity alone cannot rank
+transitions.** Next step (before any M6 training spend): behavioral-cloning-train `W` on
+in-domain graph transitions (Supermicro), then re-run this same harness zero-shot on the
+held-out vendor (HPE) for the real go/no-go.
+
 ---
 
 ## D-001 — M6 action-selection objective: hybrid pointer + argument decoder (2026-07-11)

--- a/igc/ds/sources/candidate_features.py
+++ b/igc/ds/sources/candidate_features.py
@@ -1,0 +1,74 @@
+"""
+D-002 v1 action-candidate featurizer with a static per-host cache.
+
+Turns graph nodes into the accepted candidate schema — path tokens, HTTP method, resource
+type, child-relation name, action-target flag — for the D-001 pointer. Per D-002, every
+field is static per host: the cache is built once from the walked tree and only *filtered*
+by a state's legal catalog at decision time (HER relabeling re-scores cached candidates, it
+never re-encodes them). Member ids in the path are kept as trailing tokens, never deleted —
+erasing them would break goals that target a specific collection member.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+from igc.ds.sources.resource_graph import GraphNode, RedfishResourceGraph
+
+# a candidate is (url, METHOD); GET is always legal on a walked resource.
+_DEFAULT_METHODS = ("GET",)
+
+
+def path_tokens(url: str) -> List[str]:
+    """Split a resource URL into path tokens, preserving member ids as their own tokens.
+
+    :param url: canonical resource URL.
+    :return: non-empty path segments in order.
+    """
+    return [seg for seg in url.split("/") if seg]
+
+
+def candidate_v1(node: GraphNode, method: str) -> Dict:
+    """Build the D-002 v1 candidate dict for one (endpoint, method) pair.
+
+    :param node: the endpoint's graph node.
+    :param method: HTTP method for this candidate.
+    :return: the v1 schema — url, path tokens, method, resource type, relation, action flag.
+    """
+    return {
+        "url": node.url,
+        "endpoint_path_tokens": path_tokens(node.url),
+        "http_method": method.upper(),
+        "resource_type": node.resource_type,
+        "child_relation_name": node.child_relation,
+        "has_action_target": node.has_action_target,
+    }
+
+
+def build_candidate_cache(
+    graph: RedfishResourceGraph,
+    allowed_methods: Optional[Dict[str, List[str]]] = None,
+) -> Dict[Tuple[str, str], Dict]:
+    """Build the static per-host candidate cache for every walked (endpoint, method).
+
+    Methods come from the discovery ``allowed_methods_mapping`` when provided (the ``.npy``
+    contract half loaded by ``ds_rest_trajectories``); endpoints missing from the map fall
+    back to GET, so a partial map never drops a walked endpoint.
+
+    :param graph: the host's resource graph.
+    :param allowed_methods: optional ``{url: [methods]}`` from the discovery map.
+    :return: ``{(url, METHOD): candidate_v1}`` — filter per state, never rebuild per state.
+    """
+    allowed_methods = allowed_methods or {}
+    cache: Dict[Tuple[str, str], Dict] = {}
+    for url, node in graph.nodes.items():
+        methods = allowed_methods.get(url) or _DEFAULT_METHODS
+        for method in methods:
+            method_upper = str(method).upper()
+            cache[(url, method_upper)] = candidate_v1(node, method_upper)
+    return cache
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/igc/ds/sources/resource_graph.py
+++ b/igc/ds/sources/resource_graph.py
@@ -1,0 +1,230 @@
+"""
+Redfish resource graph built from provenance-tagged capture records (D-002).
+
+Builds the typed resource graph the D-002 candidate representation needs: nodes are walked
+resources, edges are URL-prefix containment plus ``@odata.id`` references harvested from the
+WHOLE body — the corpus census showed explicit ``Links`` sections cover only 10-14% of real
+resources, so reference edges must come from anywhere in the JSON, not just ``Links``. Each
+node carries the D-002 structural fields: resource type (from ``@odata.type``), depth, the
+child-relation name by which it is reachable, and whether its body exposes an invokable
+action target. The graph is static per host and safe to build from a partial crawl.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional
+
+from igc.ds.sources.base import SourceRecord
+
+
+@dataclass
+class GraphNode:
+    """One walked resource in the host's Redfish tree.
+
+    :param url: canonical resource URL (node key).
+    :param resource_type: the body's ``@odata.type`` (empty when absent).
+    :param depth: number of path segments below ``/``.
+    :param child_relation: name by which this node is reachable — the referencing key in a
+        parent body when one exists, else the node's collection segment (see
+        :meth:`RedfishResourceGraph.from_records`).
+    :param has_action_target: whether ``Actions`` in the body carries an invokable ``target``.
+    :param body_refs: ``@odata.id`` references harvested from the whole body (deduped, no self).
+    """
+    url: str
+    resource_type: str = ""
+    depth: int = 0
+    child_relation: str = ""
+    has_action_target: bool = False
+    body_refs: List[str] = field(default_factory=list)
+
+
+def harvest_refs(body, self_url: str) -> List[str]:
+    """Collect every ``@odata.id`` string reachable anywhere in a JSON body.
+
+    The census rule: explicit ``Links`` sections are too sparse (10-14% coverage) to carry the
+    graph, so references are harvested from all nested dicts/lists. Order of first appearance
+    is preserved; duplicates and the resource's own URL are dropped.
+
+    :param body: decoded JSON body (any nesting).
+    :param self_url: the resource's own URL, excluded from the result.
+    :return: ordered unique referenced URLs.
+    """
+    seen: Dict[str, None] = {}
+
+    def _walk(obj) -> None:
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                if key == "@odata.id" and isinstance(value, str) and value and value != self_url:
+                    seen.setdefault(value.rstrip("/") or value, None)
+                else:
+                    _walk(value)
+        elif isinstance(obj, list):
+            for item in obj:
+                _walk(item)
+
+    _walk(body)
+    return list(seen)
+
+
+def has_action_target(body) -> bool:
+    """Whether the body's ``Actions`` section exposes at least one invokable ``target``.
+
+    :param body: decoded JSON body.
+    :return: ``True`` when any ``Actions`` entry is a dict carrying a ``target`` key.
+    """
+    actions = body.get("Actions") if isinstance(body, dict) else None
+    if not isinstance(actions, dict):
+        return False
+    return any(isinstance(v, dict) and "target" in v for v in actions.values())
+
+
+class RedfishResourceGraph:
+    """Typed resource graph over one (or one host's) set of capture records.
+
+    Nodes key on canonical URL. Two edge families:
+
+    * **containment** — URL-prefix parent/child (``/redfish/v1/Systems/1`` is a child of
+      ``/redfish/v1/Systems``), derivable for 90-98% of real resources;
+    * **references** — body-harvested ``@odata.id`` mentions (see :func:`harvest_refs`).
+    """
+
+    def __init__(self) -> None:
+        self.nodes: Dict[str, GraphNode] = {}
+        # parent bodies are needed once, to resolve referencing keys; kept out of GraphNode
+        # so downstream consumers of nodes stay light.
+        self._bodies: Dict[str, Dict] = {}
+
+    @classmethod
+    def from_records(cls, records: Iterable[SourceRecord]) -> "RedfishResourceGraph":
+        """Build the graph from capture records (tolerant of partial crawls).
+
+        ``child_relation`` resolution, in priority order: (1) the top-level key under which the
+        parent's body references this node; (2) for a collection member whose last segment is
+        an id, the parent's collection segment; (3) the node's own last path segment.
+
+        :param records: provenance-tagged capture records for one host/corpus.
+        :return: the populated graph.
+        """
+        graph = cls()
+        for rec in records:
+            url = rec.url.rstrip("/") or rec.url
+            body = rec.response if isinstance(rec.response, dict) else {}
+            graph._bodies[url] = body
+            graph.nodes[url] = GraphNode(
+                url=url,
+                resource_type=str(body.get("@odata.type", "")),
+                depth=len([seg for seg in url.split("/") if seg]),
+                has_action_target=has_action_target(body),
+                body_refs=harvest_refs(body, url),
+            )
+        for node in graph.nodes.values():
+            node.child_relation = graph._resolve_relation(node.url)
+        return graph
+
+    def parent(self, url: str) -> Optional[str]:
+        """The longest walked URL-prefix parent of ``url``, or ``None``.
+
+        :param url: node URL.
+        :return: parent URL when walked, else ``None``.
+        """
+        candidate = url.rstrip("/")
+        while "/" in candidate.strip("/"):
+            candidate = candidate.rsplit("/", 1)[0]
+            if candidate in self.nodes:
+                return candidate
+        return None
+
+    def children(self, url: str) -> List[str]:
+        """Walked nodes whose nearest walked ancestor is ``url`` (containment children).
+
+        :param url: node URL.
+        :return: child URLs, sorted.
+        """
+        return sorted(u for u in self.nodes if u != url and self.parent(u) == url)
+
+    def neighbors(self, url: str) -> List[str]:
+        """True transition targets from ``url``: containment children, parent, and walked refs.
+
+        :param url: node URL.
+        :return: ordered unique neighbor URLs present in the graph.
+        """
+        out: Dict[str, None] = {}
+        for child in self.children(url):
+            out.setdefault(child, None)
+        parent = self.parent(url)
+        if parent:
+            out.setdefault(parent, None)
+        node = self.nodes.get(url)
+        if node:
+            for ref in node.body_refs:
+                if ref in self.nodes and ref != url:
+                    out.setdefault(ref, None)
+        return list(out)
+
+    def _resolve_relation(self, url: str) -> str:
+        """Resolve the D-002 ``child_relation`` name for ``url`` (see :meth:`from_records`).
+
+        :param url: node URL.
+        :return: relation name; empty only for a root with no segments.
+        """
+        segments = [seg for seg in url.split("/") if seg]
+        parent_url = self.parent(url)
+        if parent_url:
+            parent_body_key = self._referencing_key(parent_url, url)
+            if parent_body_key:
+                return parent_body_key
+        if len(segments) >= 2 and self._looks_like_member_id(segments[-1]):
+            return segments[-2]
+        return segments[-1] if segments else ""
+
+    def _referencing_key(self, parent_url: str, child_url: str) -> str:
+        """Top-level key of the parent body whose subtree references ``child_url``.
+
+        :param parent_url: walked parent URL.
+        :param child_url: child URL to locate.
+        :return: the referencing top-level key, or ``""``.
+        """
+        return _top_level_ref_key(self._bodies.get(parent_url), child_url) or ""
+
+    @staticmethod
+    def _looks_like_member_id(segment: str) -> bool:
+        """Heuristic: a collection-member id segment (digits or short opaque token).
+
+        :param segment: last URL path segment.
+        :return: ``True`` for ids like ``1``, ``0``, ``CPU_0``, UUID-ish tokens.
+        """
+        return segment.isdigit() or any(ch.isdigit() for ch in segment)
+
+
+def _top_level_ref_key(body, child_url: str) -> Optional[str]:
+    """Top-level key of ``body`` whose subtree contains ``@odata.id == child_url``.
+
+    :param body: decoded parent JSON body (or ``None``).
+    :param child_url: URL to find.
+    :return: key name or ``None``.
+    """
+    if not isinstance(body, dict):
+        return None
+
+    def _contains(obj) -> bool:
+        if isinstance(obj, dict):
+            odata = obj.get("@odata.id")
+            if isinstance(odata, str) and odata.rstrip("/") == child_url:
+                return True
+            return any(_contains(v) for v in obj.values())
+        if isinstance(obj, list):
+            return any(_contains(i) for i in obj)
+        return False
+
+    for key, value in body.items():
+        if key.startswith("@"):
+            continue
+        if _contains(value):
+            return key
+    return None
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/igc/modules/eval/__init__.py
+++ b/igc/modules/eval/__init__.py
@@ -1,0 +1,8 @@
+"""
+Offline evaluation harness modules for igc.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+# Author: Mus mbayramo@stanford.edu

--- a/igc/modules/eval/zero_shot_ranking.py
+++ b/igc/modules/eval/zero_shot_ranking.py
@@ -1,0 +1,136 @@
+"""
+D-001/D-002 zero-shot go/no-go representation check.
+
+Deterministic zero-shot ranking of legal action candidates with a frozen character-trigram
+text encoder: for each resource (state) in a walked Redfish tree, all host candidates are
+ranked by similarity to the state text, and the module measures whether the state's TRUE
+graph neighbors (the walked tree's real transitions) appear in the top-k. No training, no
+torch, no randomness — numpy and the standard library only. Go/no-go per D-001: top-5 hit
+rate >= 0.80 on a held-out vendor.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import hashlib
+from typing import Dict, List, Set
+
+import numpy as np
+
+
+def trigram_embed(text: str, dim: int = 512) -> np.ndarray:
+    """Compute a deterministic hashed character-trigram embedding.
+
+    The text is lowercased and padded with a leading and trailing space. Every overlapping
+    3-character window is hashed with blake2b (8-byte digest) and mapped to a bucket index
+    modulo ``dim``; bucket counts are accumulated in a float64 vector, then L2-normalized.
+    An all-zero vector stays zero. Stable across processes (no builtin ``hash()``).
+
+    :param text: input string to embed.
+    :param dim: embedding dimensionality.
+    :return: L2-normalized float64 vector of shape ``(dim,)``.
+    """
+    processed = f" {text.lower()} "
+    vec = np.zeros(dim, dtype=np.float64)
+    if len(processed) < 3:
+        return vec
+    for i in range(len(processed) - 2):
+        trigram = processed[i:i + 3]
+        digest = hashlib.blake2b(trigram.encode("utf-8"), digest_size=8).digest()
+        vec[int.from_bytes(digest, "big") % dim] += 1.0
+    norm = np.linalg.norm(vec)
+    if norm > 0.0:
+        vec /= norm
+    return vec
+
+
+def candidate_text(candidate: Dict) -> str:
+    """Render a candidate dict into its canonical text form for embedding.
+
+    Joins the endpoint path tokens with ``/``, then appends the HTTP method, resource type,
+    child relation name, and the literal ``action`` when the candidate exposes an action
+    target — single spaces between parts.
+
+    :param candidate: D-002 v1 candidate dict (see ``candidate_features.candidate_v1``).
+    :return: canonical text representation.
+    """
+    parts: List[str] = [
+        "/".join(candidate["endpoint_path_tokens"]),
+        candidate["http_method"],
+        candidate["resource_type"],
+        candidate["child_relation_name"],
+    ]
+    if candidate.get("has_action_target", False):
+        parts.append("action")
+    return " ".join(parts)
+
+
+def embed_candidates(candidates: List[Dict], dim: int = 512) -> np.ndarray:
+    """Embed every candidate once (static per host — the D-002 caching contract).
+
+    :param candidates: host candidate dicts.
+    :param dim: embedding dimensionality.
+    :return: float64 matrix of shape ``(len(candidates), dim)``.
+    """
+    if not candidates:
+        return np.zeros((0, dim), dtype=np.float64)
+    return np.stack([trigram_embed(candidate_text(c), dim=dim) for c in candidates])
+
+
+def rank_candidates(state_text: str, candidates: List[Dict], dim: int = 512) -> List[int]:
+    """Rank candidate indices by cosine similarity to the state text, descending.
+
+    Embeddings are L2-normalized, so cosine equals the dot product. Ties break stably by
+    ascending index.
+
+    :param state_text: text representation of the current state.
+    :param candidates: candidate dicts.
+    :param dim: embedding dimensionality.
+    :return: candidate indices, best first.
+    """
+    scores = embed_candidates(candidates, dim=dim) @ trigram_embed(state_text, dim=dim)
+    return sorted(range(len(candidates)), key=lambda i: (-scores[i], i))
+
+
+def top_k_hit_rate(states: Dict[str, str], candidates: List[Dict],
+                   truths: Dict[str, Set[str]], k: int = 5, dim: int = 512) -> Dict:
+    """Measure how often a state's true transitions rank in the top-k of all candidates.
+
+    Candidate embeddings are computed ONCE and reused across states (the same static-per-host
+    property the runtime cache relies on); a state's own endpoint is excluded from its
+    ranking by score masking. A state counts as a hit when any top-k candidate URL is in its
+    truth set; states with empty truth sets are skipped.
+
+    :param states: ``{url: state_text}`` per resource.
+    :param candidates: the full host candidate list.
+    :param truths: ``{url: set of true next-endpoint urls}`` (graph neighbors).
+    :param k: cutoff.
+    :param dim: embedding dimensionality.
+    :return: ``{"evaluated", "hits", "hit_rate", "k"}``.
+    """
+    embeddings = embed_candidates(candidates, dim=dim)
+    urls = [c.get("url") for c in candidates]
+    evaluated = 0
+    hits = 0
+    for state_url, state_text in states.items():
+        truth_set = truths.get(state_url) or set()
+        if not truth_set or embeddings.shape[0] == 0:
+            continue
+        scores = embeddings @ trigram_embed(state_text, dim=dim)
+        for i, url in enumerate(urls):
+            if url == state_url:
+                scores[i] = -np.inf
+        order = sorted(range(len(urls)), key=lambda i: (-scores[i], i))[:k]
+        evaluated += 1
+        if any(urls[i] in truth_set for i in order):
+            hits += 1
+    return {
+        "evaluated": evaluated,
+        "hits": hits,
+        "hit_rate": hits / evaluated if evaluated else 0.0,
+        "k": k,
+    }
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/ds/test_resource_graph.py
+++ b/tests/ds/test_resource_graph.py
@@ -1,0 +1,128 @@
+"""
+Offline tests for the Redfish resource graph and D-002 candidate featurizer.
+
+Pins that the graph harvests @odata.id references from WHOLE bodies (not just Links — the
+census showed Links sections cover only 10-14% of real resources), derives containment
+parents/children from URL prefixes, resolves child_relation from the parent's referencing
+key with collection-segment and last-segment fallbacks, flags action targets, tolerates a
+partial crawl, and that the candidate cache is static per (url, method) with GET fallback
+and preserved member-id tokens. Pure stdlib — no torch, no network.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+from igc.ds.sources.base import SourceRecord, TrustLevel
+from igc.ds.sources.candidate_features import build_candidate_cache, candidate_v1, path_tokens
+from igc.ds.sources.resource_graph import RedfishResourceGraph, harvest_refs, has_action_target
+
+
+def _rec(url, body):
+    """A REAL-tier SourceRecord with the given body."""
+    return SourceRecord(url=url, response=body, source="real_test", trust_level=TrustLevel.REAL)
+
+
+def _walk():
+    """A small walked tree: root -> Systems collection -> member with action + deep ref."""
+    return [
+        _rec("/redfish/v1", {
+            "@odata.id": "/redfish/v1", "@odata.type": "#ServiceRoot.v1.ServiceRoot",
+            "Systems": {"@odata.id": "/redfish/v1/Systems"},
+        }),
+        _rec("/redfish/v1/Systems", {
+            "@odata.id": "/redfish/v1/Systems", "@odata.type": "#Collection.Collection",
+            "Members": [{"@odata.id": "/redfish/v1/Systems/1"}],
+        }),
+        _rec("/redfish/v1/Systems/1", {
+            "@odata.id": "/redfish/v1/Systems/1",
+            "@odata.type": "#ComputerSystem.v1.ComputerSystem",
+            # ref buried OUTSIDE any Links section — the census-mandated harvest path
+            "Status": {"Health": "OK", "Origin": {"@odata.id": "/redfish/v1/Chassis/1"}},
+            "Actions": {"#ComputerSystem.Reset": {"target": "/redfish/v1/Systems/1/Actions/Reset"}},
+        }),
+        _rec("/redfish/v1/Chassis/1", {
+            "@odata.id": "/redfish/v1/Chassis/1", "@odata.type": "#Chassis.v1.Chassis",
+        }),
+    ]
+
+
+def test_harvest_refs_scans_whole_body_not_just_links():
+    """References nested anywhere (here under Status.Origin) are harvested, self excluded."""
+    body = _walk()[2].response
+    refs = harvest_refs(body, "/redfish/v1/Systems/1")
+    assert "/redfish/v1/Chassis/1" in refs
+    assert "/redfish/v1/Systems/1" not in refs  # self excluded
+
+
+def test_has_action_target():
+    """Actions entries carrying a target flag the node; absent/empty Actions do not."""
+    assert has_action_target(_walk()[2].response) is True
+    assert has_action_target(_walk()[3].response) is False
+    assert has_action_target({"Actions": {"#X.Y": "not-a-dict"}}) is False
+
+
+def test_containment_parent_children_and_depth():
+    """URL-prefix containment yields parents, children, and segment depth."""
+    g = RedfishResourceGraph.from_records(_walk())
+    assert g.parent("/redfish/v1/Systems/1") == "/redfish/v1/Systems"
+    assert g.parent("/redfish/v1") is None
+    assert g.children("/redfish/v1/Systems") == ["/redfish/v1/Systems/1"]
+    assert g.nodes["/redfish/v1/Systems/1"].depth == 4
+
+
+def test_child_relation_from_parent_referencing_key():
+    """The relation is the parent's top-level key that references the child."""
+    g = RedfishResourceGraph.from_records(_walk())
+    assert g.nodes["/redfish/v1/Systems"].child_relation == "Systems"     # root refs via key
+    assert g.nodes["/redfish/v1/Systems/1"].child_relation == "Members"   # collection Members
+
+
+def test_child_relation_collection_fallback_without_parent_body():
+    """A member id whose parent is unwalked falls back to the collection segment."""
+    g = RedfishResourceGraph.from_records([
+        _rec("/redfish/v1/Chassis/CPU_0", {"@odata.type": "#Chassis.v1.Chassis"}),
+    ])
+    assert g.nodes["/redfish/v1/Chassis/CPU_0"].child_relation == "Chassis"
+
+
+def test_neighbors_union_children_parent_refs():
+    """neighbors() = containment children + parent + walked body refs, deduped."""
+    g = RedfishResourceGraph.from_records(_walk())
+    n = g.neighbors("/redfish/v1/Systems/1")
+    assert "/redfish/v1/Systems" in n          # parent
+    assert "/redfish/v1/Chassis/1" in n        # harvested ref (walked)
+    assert len(n) == len(set(n))
+
+
+def test_partial_crawl_is_safe():
+    """Refs to unwalked resources are kept in body_refs but never appear as neighbors."""
+    g = RedfishResourceGraph.from_records(_walk()[:3])  # Chassis/1 NOT walked
+    node = g.nodes["/redfish/v1/Systems/1"]
+    assert "/redfish/v1/Chassis/1" in node.body_refs
+    assert "/redfish/v1/Chassis/1" not in g.neighbors("/redfish/v1/Systems/1")
+
+
+def test_candidate_v1_schema_and_member_id_tokens():
+    """candidate_v1 carries the D-002 fields; member ids stay as trailing path tokens."""
+    g = RedfishResourceGraph.from_records(_walk())
+    c = candidate_v1(g.nodes["/redfish/v1/Systems/1"], "get")
+    assert c["endpoint_path_tokens"] == ["redfish", "v1", "Systems", "1"]  # id kept
+    assert c["http_method"] == "GET"
+    assert c["resource_type"] == "#ComputerSystem.v1.ComputerSystem"
+    assert c["child_relation_name"] == "Members"
+    assert c["has_action_target"] is True
+    assert path_tokens("/redfish/v1") == ["redfish", "v1"]
+
+
+def test_candidate_cache_static_with_get_fallback_and_method_map():
+    """The cache keys every (url, METHOD); mapped endpoints expand, unmapped fall back to GET."""
+    g = RedfishResourceGraph.from_records(_walk())
+    cache = build_candidate_cache(g, {"/redfish/v1/Systems/1": ["GET", "PATCH"]})
+    assert ("/redfish/v1/Systems/1", "PATCH") in cache
+    assert ("/redfish/v1/Systems/1", "GET") in cache
+    assert ("/redfish/v1/Chassis/1", "GET") in cache            # fallback
+    assert ("/redfish/v1/Chassis/1", "PATCH") not in cache
+    assert len({id(v) for v in cache.values()}) == len(cache)   # distinct dicts
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/modules/eval/test_zero_shot_ranking.py
+++ b/tests/modules/eval/test_zero_shot_ranking.py
@@ -1,0 +1,81 @@
+"""
+Offline tests for the D-001/D-002 zero-shot ranking check.
+
+Pins that the trigram embedding is deterministic, L2-normalized, and process-stable; that
+candidate text includes the structural fields; that ranking is cosine-descending with a
+stable tiebreak; and that top_k_hit_rate excludes the state's own endpoint, skips truthless
+states, embeds candidates once, and reports the go/no-go rate. Pure numpy — no torch.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import numpy as np
+
+from igc.modules.eval.zero_shot_ranking import (
+    candidate_text,
+    embed_candidates,
+    rank_candidates,
+    top_k_hit_rate,
+    trigram_embed,
+)
+
+
+def _cand(url, tokens=None, rtype="#T.v1.T", relation="Members", action=False):
+    return {"url": url,
+            "endpoint_path_tokens": tokens or [s for s in url.split("/") if s],
+            "http_method": "GET", "resource_type": rtype,
+            "child_relation_name": relation, "has_action_target": action}
+
+
+def test_trigram_embed_deterministic_and_normalized():
+    """Same text -> identical unit vector; different text -> different vector."""
+    a, b = trigram_embed("redfish systems"), trigram_embed("redfish systems")
+    assert np.array_equal(a, b)
+    assert abs(np.linalg.norm(a) - 1.0) < 1e-9
+    assert not np.array_equal(a, trigram_embed("chassis thermal"))
+    assert np.linalg.norm(trigram_embed("")) == 0.0  # all-zero stays zero
+
+
+def test_candidate_text_carries_structural_fields():
+    """Path, method, type, relation, and the action flag all reach the text."""
+    text = candidate_text(_cand("/redfish/v1/Systems/1", action=True))
+    for expect in ("redfish/v1/Systems/1", "GET", "#T.v1.T", "Members", "action"):
+        assert expect in text
+    assert "action" not in candidate_text(_cand("/x", action=False)).split()[-1:][0] or True
+
+
+def test_rank_candidates_orders_by_similarity():
+    """A candidate sharing the state's vocabulary outranks an unrelated one."""
+    cands = [_cand("/redfish/v1/PowerEquipment/Rectifier"),
+             _cand("/redfish/v1/Systems/1/Processors")]
+    order = rank_candidates("computer system processors cpu core", cands)
+    assert order[0] == 1
+
+
+def test_top_k_hit_rate_excludes_self_and_scores_hits():
+    """The state's own endpoint never ranks; a true neighbor in top-k counts as a hit."""
+    cands = [_cand("/redfish/v1/Systems"),
+             _cand("/redfish/v1/Systems/1"),
+             _cand("/redfish/v1/Chassis/1", rtype="#Chassis.v1.Chassis", relation="Chassis")]
+    states = {"/redfish/v1/Systems/1": "computer system 1 systems redfish"}
+    truths = {"/redfish/v1/Systems/1": {"/redfish/v1/Systems"}}
+    out = top_k_hit_rate(states, cands, truths, k=1)
+    assert out == {"evaluated": 1, "hits": 1, "hit_rate": 1.0, "k": 1}
+
+
+def test_top_k_hit_rate_skips_truthless_and_handles_empty():
+    """States without truths are skipped; empty inputs yield rate 0.0, not a crash."""
+    out = top_k_hit_rate({"/a": "text"}, [_cand("/b")], {"/a": set()}, k=5)
+    assert out["evaluated"] == 0 and out["hit_rate"] == 0.0
+    assert top_k_hit_rate({}, [], {}, k=5)["hit_rate"] == 0.0
+
+
+def test_embed_candidates_shape():
+    """One row per candidate; empty list yields an empty (0, dim) matrix."""
+    m = embed_candidates([_cand("/a"), _cand("/b")], dim=64)
+    assert m.shape == (2, 64)
+    assert embed_candidates([], dim=64).shape == (0, 64)
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
## What (3 incremental commits)

1. **`igc/ds/sources/resource_graph.py`** — the typed Redfish graph from capture records: URL-prefix containment + `@odata.id` references harvested from whole bodies (per the corpus census, explicit `Links` sections cover only 10–14% of real resources), `child_relation` from the parent's referencing key with collection-segment fallback, action-target flags, partial-crawl safe. Plus `candidate_features.py`: the D-002 v1 candidate schema with a static per-`(url, method)` cache (discovery method maps expand candidates; unmapped endpoints fall back to GET; member ids kept as trailing tokens). 9 tests.
2. **`igc/modules/eval/zero_shot_ranking.py`** — the D-001 go/no-go harness: deterministic hashed-trigram embedding, candidate text rendering, cosine ranking, top-k hit rate with candidates embedded once per host and self-masking. 6 tests.
3. **`docs/DECISIONS.md`** — the measured result.

## The measurement (run on the real corpora)

Weakest instantiation first — frozen encoder, no learned projection:

| Corpus | k=1 | k=5 | Bar ≥ 0.80 top-5 |
|---|---|---|---|
| Supermicro (in-domain, 1,499 nodes) | 0.185 | 0.293 | **NO-GO** |
| HPE iLO (held-out vendor, 167 nodes) | 0.323 | 0.754 | NO-GO (near) |

~30× over random, far under the bar on the large host: global text similarity fills top-5 with lookalike sensor siblings instead of true transitions. Conclusion recorded in D-002: **the learned bilinear projection is load-bearing** — next step is BC-training the projection on in-domain transitions and re-running zero-shot on the held-out vendor, before any M6 training spend.

## Gate

Full offline suite on the branch: **541 passed, 0 failed** (11 gpu/live deselected); ruff clean on all new files.