### PR TITLE
Add hot-path benchmark harness and perf budget tripwires

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -13,5 +13,6 @@ markers =
     download: needs network / HuggingFace downloads (excluded from the offline gate)
     dataset: needs the captured ~/.json_responses dataset staged (excluded from the offline gate)
     live: needs a live Redfish/BMC host (never run unattended)
+    perf: hot-path performance budgets (run explicitly: pytest -m perf)
 
-addopts = -m "not gpu and not slow and not download and not dataset and not live"
+addopts = -m "not gpu and not slow and not download and not dataset and not live and not perf"

--- a/scripts/bench_hot_paths.py
+++ b/scripts/bench_hot_paths.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Hot-path benchmark harness: the numbers behind every performance claim.
+
+Benchmarks the code on the RL decision path — resource-graph build, all-node neighbor
+expansion (the HER-relabel access pattern), candidate-cache construction, candidate
+embedding, and zero-shot ranking — over a real fixture corpus from the data-collection
+submodule, then prints a timing table and the top cumulative-time functions (the critical
+sections) from cProfile. Run it before AND after touching any of these modules; paste the
+table into the PR (TEAM_GUIDE: "Hot-path code ships with numbers").
+
+Usage:
+    python scripts/bench_hot_paths.py                       # default corpus
+    python scripts/bench_hot_paths.py --corpus idrac_ctl/tests/hpe_fixtures
+    python scripts/bench_hot_paths.py --profile             # + cProfile critical sections
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import argparse
+import cProfile
+import io
+import json
+import pstats
+import time
+from typing import Callable, Dict, List, Tuple
+
+from igc.ds.sources import RedfishFixtureSource, TrustLevel
+from igc.ds.sources.candidate_features import build_candidate_cache
+from igc.ds.sources.resource_graph import RedfishResourceGraph
+from igc.modules.eval.zero_shot_ranking import embed_candidates, top_k_hit_rate
+
+DEFAULT_CORPUS = "idrac_ctl/tests/supermicro_fixtures"
+
+
+def timed(label: str, fn: Callable, results: List[Tuple[str, float]]):
+    """Run ``fn`` once, record wall time under ``label``, return its value.
+
+    :param label: row name in the printed table.
+    :param fn: zero-arg callable to time.
+    :param results: accumulator of ``(label, seconds)`` rows.
+    :return: whatever ``fn`` returns.
+    """
+    start = time.perf_counter()
+    value = fn()
+    results.append((label, time.perf_counter() - start))
+    return value
+
+
+def run_benchmarks(corpus: str) -> Tuple[List[Tuple[str, float]], Dict]:
+    """Execute the hot-path suite over ``corpus``.
+
+    :param corpus: fixture directory of captured Redfish JSON.
+    :return: ``(timing rows, context info)``.
+    """
+    rows: List[Tuple[str, float]] = []
+    records = timed("load records", lambda: list(
+        RedfishFixtureSource(corpus, "bench", TrustLevel.REAL)), rows)
+    graph = timed("graph build (from_records)", lambda: RedfishResourceGraph.from_records(records), rows)
+    neighbors = timed("neighbors, ALL nodes (HER pattern)", lambda: {
+        u: graph.neighbors(u) for u in graph.nodes}, rows)
+    cache = timed("candidate cache build", lambda: build_candidate_cache(graph), rows)
+    candidates = list(cache.values())
+    timed("embed candidates (static, once/host)", lambda: embed_candidates(candidates), rows)
+    states = {r.url.rstrip("/") or r.url: json.dumps(r.response, sort_keys=True) for r in records}
+    truths = {u: set(neighbors[u]) for u in graph.nodes}
+    timed("zero-shot rank+score, ALL states", lambda: top_k_hit_rate(states, candidates, truths, k=5), rows)
+    info = {"corpus": corpus, "records": len(records), "nodes": len(graph.nodes),
+            "candidates": len(candidates)}
+    return rows, info
+
+
+def print_report(rows: List[Tuple[str, float]], info: Dict) -> None:
+    """Print the timing table.
+
+    :param rows: ``(label, seconds)`` rows.
+    :param info: corpus context.
+    :return: ``None``.
+    """
+    print(f"corpus={info['corpus']}  records={info['records']} "
+          f"nodes={info['nodes']} candidates={info['candidates']}")
+    print(f"{'stage':40} {'seconds':>10}")
+    for label, seconds in rows:
+        print(f"{label:40} {seconds:10.4f}")
+
+
+def print_critical_sections(corpus: str, top: int = 12) -> None:
+    """cProfile the whole suite and print the top cumulative-time functions.
+
+    :param corpus: fixture directory.
+    :param top: number of functions to show.
+    :return: ``None``.
+    """
+    profiler = cProfile.Profile()
+    profiler.enable()
+    run_benchmarks(corpus)
+    profiler.disable()
+    buffer = io.StringIO()
+    pstats.Stats(profiler, stream=buffer).sort_stats("cumulative").print_stats(top)
+    print("\n=== critical sections (cumulative) ===")
+    print(buffer.getvalue())
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Benchmark igc hot paths over a real corpus.")
+    parser.add_argument("--corpus", default=DEFAULT_CORPUS)
+    parser.add_argument("--profile", action="store_true", help="also print cProfile critical sections")
+    args = parser.parse_args()
+    rows, info = run_benchmarks(args.corpus)
+    print_report(rows, info)
+    if args.profile:
+        print_critical_sections(args.corpus)
+
+
+if __name__ == "__main__":
+    main()
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/perf/test_hot_path_budgets.py
+++ b/tests/perf/test_hot_path_budgets.py
@@ -1,0 +1,83 @@
+"""
+Hot-path performance budgets (regression tripwires, `-m perf`).
+
+Each budget is ~50-100x looser than the measured number on the reference corpus, so a pass
+never depends on machine speed — only an algorithmic regression (e.g. the O(V^2) neighbor
+scan this suite was born from: 0.71s measured, budget 0.5s per 1,000 nodes) trips it.
+Excluded from the default offline gate; run explicitly with `pytest -m perf` (the fixture
+corpus lives in the data-collection submodule, so a checkout without submodules skips).
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import json
+import os
+import time
+
+import pytest
+
+from igc.ds.sources import RedfishFixtureSource, TrustLevel
+from igc.ds.sources.candidate_features import build_candidate_cache
+from igc.ds.sources.resource_graph import RedfishResourceGraph
+from igc.modules.eval.zero_shot_ranking import embed_candidates
+
+_CORPUS = "idrac_ctl/tests/supermicro_fixtures"
+
+pytestmark = [
+    pytest.mark.perf,
+    pytest.mark.skipif(not os.path.isdir(_CORPUS),
+                       reason="fixture corpus not present (submodule not initialized)"),
+]
+
+
+@pytest.fixture(scope="module")
+def corpus():
+    """Records + graph for the reference corpus, built once per module."""
+    records = list(RedfishFixtureSource(_CORPUS, "perf", TrustLevel.REAL))
+    return records, RedfishResourceGraph.from_records(records)
+
+
+def _seconds(fn):
+    start = time.perf_counter()
+    fn()
+    return time.perf_counter() - start
+
+
+def test_graph_build_budget(corpus):
+    """Graph build stays linear-ish: <= 2s per 1,000 nodes (measured ~0.03s/1,499)."""
+    records, graph = corpus
+    budget = 2.0 * max(1, len(graph.nodes)) / 1000
+    assert _seconds(lambda: RedfishResourceGraph.from_records(records)) < budget
+
+
+def test_neighbors_all_nodes_budget(corpus):
+    """The HER access pattern stays indexed: <= 0.5s per 1,000 nodes (O(V^2) was 0.71s)."""
+    _, graph = corpus
+    budget = 0.5 * max(1, len(graph.nodes)) / 1000
+    assert _seconds(lambda: {u: graph.neighbors(u) for u in graph.nodes}) < budget
+
+
+def test_candidate_cache_budget(corpus):
+    """Cache build is a linear pass: <= 1s per 1,000 nodes."""
+    _, graph = corpus
+    budget = 1.0 * max(1, len(graph.nodes)) / 1000
+    assert _seconds(lambda: build_candidate_cache(graph)) < budget
+
+
+def test_candidate_embedding_budget(corpus):
+    """Static per-host embedding: <= 20s per 1,000 candidates (measured ~4s/1,499)."""
+    _, graph = corpus
+    candidates = list(build_candidate_cache(graph).values())
+    budget = 20.0 * max(1, len(candidates)) / 1000
+    assert _seconds(lambda: embed_candidates(candidates)) < budget
+
+
+def test_state_text_render_budget(corpus):
+    """Rendering every state body to text stays cheap: <= 2s per 1,000 records."""
+    records, _ = corpus
+    budget = 2.0 * max(1, len(records)) / 1000
+    assert _seconds(lambda: [json.dumps(r.response, sort_keys=True) for r in records]) < budget
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
Makes performance a measured, unskippable practice for hot-path code:

1. **`scripts/bench_hot_paths.py`** — times every RL decision-path stage over a real corpus and prints the table + cProfile critical sections (`--profile`). First run (1,499-node Supermicro walk): load 0.080s / graph build 0.047s / neighbors-all 0.0015s / cache 0.0037s / embed 0.122s / zero-shot rank+score 4.00s — the last is the trigram loop over full body text, the now-documented dominant offline-eval cost (not on the RL decision path).
2. **`tests/perf/`** — five budget tripwires, per-1,000-node ceilings 50–100× looser than measured so machine speed never flakes them; only an algorithmic regression (like the O(V²) neighbor scan this came from: 0.71s vs 0.5s budget) trips. New `perf` marker in `pytest.ini`, excluded from the default gate, run via `pytest -m perf`; skips cleanly without the submodule.

Gate: default suite 544 passed / 0 failed (perf correctly deselected); `pytest -m perf` 5 passed; ruff clean.