### PR TITLE
Align validation accuracy with the shifted-caller contract

### DIFF
--- a/igc/modules/llm_train_state_encoder.py
+++ b/igc/modules/llm_train_state_encoder.py
@@ -955,14 +955,16 @@ class LlmEmbeddingsTrainer(LlmModule):
             y = y.type(torch.float)
             return torch.mean(y).item()
         elif logits.dim() == 3:
-            shifted_step_logits = logits[..., :-1, :].contiguous()
-            shift_step_labels = targets[..., 1:].contiguous()
-            masked_logits = shifted_step_logits.eq(-100)
-            logits_inf = shifted_step_logits.masked_fill_(masked_logits, float("-Inf"))
-            arg_maxed_idx = torch.argmax(logits_inf, dim=-1)
-            r = shift_step_labels == arg_maxed_idx
-            r = r.type(torch.float)
-            return r.mean().item()
+            # callers (validate/test_inference) already shift inputs vs targets by one,
+            # so logits[t] predicts targets[t]; shifting again here measured a
+            # two-tokens-ahead objective. The old -100 mask was applied to LOGIT VALUES
+            # (a no-op), so pad positions counted as wrong — restrict to real labels.
+            predictions = torch.argmax(logits, dim=-1)
+            valid = targets.ne(-100)
+            if valid.sum() == 0:
+                return 0.0
+            correct = (predictions == targets) & valid
+            return (correct.sum().float() / valid.sum().float()).item()
         else:
             raise ValueError("Invalid shape")
 
@@ -1025,7 +1027,9 @@ class LlmEmbeddingsTrainer(LlmModule):
                 loss = F.cross_entropy(logits.view(-1, logits.size(-1)),
                                        target_ids.view(-1).to(self.device),
                                        ignore_index=-100)
-                total_loss += loss.item() * target_ids.numel()
+                # cross_entropy averaged over NON-PAD tokens; weight by the same
+                # count so the final divide by total non-pad tokens is consistent.
+                total_loss += loss.item() * non_pad_tokens
 
         end_time = time.time()
         time_taken = end_time - start_time

--- a/tests/modules/test_validation_metrics.py
+++ b/tests/modules/test_validation_metrics.py
@@ -1,0 +1,66 @@
+"""Offline regressions for the encoder validation metrics.
+
+``compute_accuracy`` double-shifted (callers already shift inputs vs targets
+by one, so it measured two-tokens-ahead) and masked LOGIT VALUES against -100
+(a no-op), counting every pad position as wrong — and this metric drives
+best-checkpoint selection. Perplexity weighted the mean loss by ALL positions
+while dividing by non-pad ones. Pins the aligned, pad-aware contract.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import torch
+
+from igc.modules.llm_train_state_encoder import LlmEmbeddingsTrainer
+
+
+def _aligned_logits(targets, vocab=7):
+    """Logits whose argmax equals targets wherever targets are valid."""
+    batch, seq = targets.shape
+    logits = torch.zeros(batch, seq, vocab)
+    for b in range(batch):
+        for t in range(seq):
+            idx = targets[b, t].item()
+            logits[b, t, idx if idx >= 0 else 0] = 5.0
+    return logits
+
+
+def test_perfect_predictions_score_one():
+    """Aligned argmax == targets gives 100% (old double-shift gave less)."""
+    targets = torch.tensor([[1, 2, 3, 4]])
+    accuracy = LlmEmbeddingsTrainer.compute_accuracy(
+        _aligned_logits(targets), targets, original_mask=None
+    )
+    assert accuracy == 1.0
+
+
+def test_pad_positions_do_not_deflate_accuracy():
+    """-100 labels are excluded, not counted as wrong."""
+    targets = torch.tensor([[1, 2, -100, -100]])
+    accuracy = LlmEmbeddingsTrainer.compute_accuracy(
+        _aligned_logits(targets), targets, original_mask=None
+    )
+    assert accuracy == 1.0
+
+
+def test_wrong_predictions_counted_over_valid_only():
+    """One wrong of two valid positions = 0.5 regardless of padding."""
+    targets = torch.tensor([[1, 2, -100]])
+    logits = _aligned_logits(targets)
+    logits[0, 1] = torch.zeros(7)
+    logits[0, 1, 5] = 5.0  # wrong prediction at the second valid slot
+    accuracy = LlmEmbeddingsTrainer.compute_accuracy(logits, targets, None)
+    assert accuracy == 0.5
+
+
+def test_all_pad_batch_is_zero_not_nan():
+    """A fully-padded batch returns 0.0 instead of dividing by zero."""
+    targets = torch.full((1, 3), -100)
+    accuracy = LlmEmbeddingsTrainer.compute_accuracy(
+        torch.zeros(1, 3, 7), targets, None
+    )
+    assert accuracy == 0.0
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
P1 metrics cluster, unblocked now the trainer file is free: compute_accuracy double-shifted (two-tokens-ahead objective) and no-op-masked logits against -100 so pads counted as wrong — the exact metric that picks best checkpoints; test perplexity multiplied mean loss by all positions but divided by non-pad ones. Fixed both; 4 regressions pin perfect-score alignment, pad exclusion, valid-only denominators, and the all-pad edge. Offline gate: 548 passed (pipefail).