### PR TITLE
Skip tarball hash verification after a dataset rebuild

### DIFF
--- a/igc/ds/redfish_dataset.py
+++ b/igc/ds/redfish_dataset.py
@@ -779,6 +779,19 @@ class JSONDataset(
                 f"Dataset caches were built for --model_type {recorded_model!r} but the "
                 f"current run uses {model_type!r}. Rebuild with --recreate_dataset.")
 
+
+    def _should_verify_tarballs(self) -> bool:
+        """Whether distribution-tarball hashes should gate this load.
+
+        A fresh rebuild (``--recreate_dataset``) supersedes the recorded
+        distribution hashes — the tarballs are packaging artifacts, not build
+        inputs — so verifying them after rebuilding fails on any node that
+        lacks (or holds a partial download of) the tarball.
+
+        :return: True only when loading prebuilt artifacts without a rebuild.
+        """
+        return not self._recreate_dataset
+
     def _load_dataset_spec(self):
         """Read dataset spec and update mirror and resources.
         :return:
@@ -842,7 +855,8 @@ class JSONDataset(
         # load dataset json file, and
         # so we have all hash values for each file.
         self._load_dataset_spec()
-        self._check_tarball_hash()
+        if self._should_verify_tarballs():
+            self._check_tarball_hash()
 
         self.logger.debug(f"Loading dataset from {self._dataset_file_name}")
         self.logger.debug(f"Loading dataset from disk. {self._dataset_file_name}")

--- a/tests/ds/test_tokenizer_provenance.py
+++ b/tests/ds/test_tokenizer_provenance.py
@@ -54,3 +54,12 @@ def test_absent_model_type_only_checks_tokens():
 
 
 # Author: Mus mbayramo@stanford.edu
+
+
+def test_rebuild_skips_tarball_verification():
+    """--recreate_dataset supersedes stale distribution-tarball hashes."""
+    ds = JSONDataset.__new__(JSONDataset)
+    ds._recreate_dataset = True
+    assert ds._should_verify_tarballs() is False
+    ds._recreate_dataset = False
+    assert ds._should_verify_tarballs() is True


### PR DESCRIPTION
Fourth rebuild bug from the R2 rung: after a successful on-node rebuild (tokenizer now builds at 53140 tokens, matching recorded provenance), the loader still verified distribution-tarball hashes and raised DatasetConsistencyError on the node's partial mirror-download junk. Rebuilds supersede packaging hashes by definition. Predicate extracted for a direct unit. Offline gate: 549 passed (pipefail).