### PR TITLE
Fix GPT-2 FlashAttention fallback and autoencoder device placement

### DIFF
--- a/igc/modules/igc_train_auto_state_encoder.py
+++ b/igc/modules/igc_train_auto_state_encoder.py
@@ -216,6 +216,9 @@ class AutoencoderTrainer(IgcModule):
         self.model_autoencoder.eval()
         self.model_autoencoder.train()
         self.model_autoencoder.to(self.device)
+        # the frozen backbone must sit on the same device as its inputs; it was
+        # never placed, silently running the big forward on CPU on GPU nodes.
+        self._encoder_model.to(self.device)
 
         total_batches = len(train_dataloader)
         batch_log_frequency = round(32 * 0.2)
@@ -226,6 +229,7 @@ class AutoencoderTrainer(IgcModule):
 
             batch_losses = np.zeros(total_batches)
             for batch in train_dataloader:
+                batch = {k: v.to(self.device) for k, v in batch.items()}
                 with torch.no_grad():
                     output = self._encoder_model(**batch).last_hidden_state.to(self.device)
                 reconstructed = self.model_autoencoder(output)

--- a/igc/modules/shared/llm_shared.py
+++ b/igc/modules/shared/llm_shared.py
@@ -54,10 +54,18 @@ def _from_pretrained_best_attention(model_id: str, load_kwargs: dict):
     candidates.append("sdpa")
     for impl in candidates:
         try:
-            return AutoModelForCausalLM.from_pretrained(
+            model = AutoModelForCausalLM.from_pretrained(
                 model_id, attn_implementation=impl, **load_kwargs)
         except (ImportError, ValueError, RuntimeError, OSError):
             continue
+        if impl == "flash_attention_2" and not any(
+                isinstance(m, torch.nn.Linear) for m in model.modules()):
+            # transformers' FA2 dtype probe needs an nn.Linear; Conv1D-only
+            # backbones (GPT-2 family) load fine but StopIteration at the first
+            # forward — fall through to sdpa for them.
+            del model
+            continue
+        return model
     return AutoModelForCausalLM.from_pretrained(model_id, **load_kwargs)
 
 

--- a/tests/modules/test_llm_loader.py
+++ b/tests/modules/test_llm_loader.py
@@ -151,3 +151,36 @@ if __name__ == "__main__":
 
 
 # Author: Mus mbayramo@stanford.edu
+
+
+def test_fa2_rejected_for_conv1d_only_backbones(monkeypatch):
+    """A FA2 load with no nn.Linear falls through to the next kernel."""
+    import torch
+    import types
+    import igc.modules.shared.llm_shared as llm_shared
+
+    attempts = []
+
+    class _Conv1DOnly(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.zeros(1))
+
+    class _LinearModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(2, 2)
+
+    class _FakeAuto:
+        @staticmethod
+        def from_pretrained(model_id, attn_implementation=None, **kwargs):
+            attempts.append(attn_implementation)
+            return _Conv1DOnly() if attn_implementation == "flash_attention_2" else _LinearModel()
+
+    monkeypatch.setattr(llm_shared, "AutoModelForCausalLM", _FakeAuto)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    model = llm_shared._from_pretrained_best_attention("any", {})
+
+    assert attempts == ["flash_attention_2", "sdpa"]
+    assert isinstance(model, _LinearModel)


### PR DESCRIPTION
Fifth R2-rung finding, first inside the training loop: the NGC image ships flash-attn, so the kernel-fallback loader accepted FA2 for GPT-2 — whose Conv1D-only body breaks transformers' FA2 dtype probe (StopIteration at first forward; invisible locally where flash-attn is absent). The loader now rejects an FA2 load lacking nn.Linear and falls through to SDPA (regression with a fake Auto class pins the fallback order). Second commit lands the audit's device-placement fix in the same trainer: backbone and batches now move to the training device. Offline gate: 550 passed (pipefail).