### PR TITLE
Store tarball hash values, not the sidecar path, and heal old specs

### DIFF
--- a/igc/ds/redfish_dataset.py
+++ b/igc/ds/redfish_dataset.py
@@ -462,8 +462,10 @@ class JSONDataset(
         if not os.path.exists(self._dataset_json_tarball_name):
             logging.debug(f"Creating tarball {self._dataset_json_tarball_name}")
             if os.path.exists(self._json_directory_path):
-                _, _tarball_hash = create_tar_gz(
+                _, _hash_file = create_tar_gz(
                     self._json_directory_path, self._dataset_json_tarball_name)
+                # create_tar_gz returns the hash-file path; resources store the value.
+                _tarball_hash = Path(_hash_file).read_text().strip()
 
                 # update hash values in _resources
                 tarball_name = os.path.basename(self._dataset_json_tarball_name)
@@ -478,8 +480,9 @@ class JSONDataset(
                 os.makedirs(self._dataset_root_dir, exist_ok=True)
                 logging.debug(f"Creating tarball {self._dataset_tarball_name} file.")
                 if os.path.exists(self.raw_dir()):
-                    _, _tarball_hash = create_tar_gz(
+                    _, _hash_file = create_tar_gz(
                         self.raw_dir(), self._dataset_tarball_name)
+                    _tarball_hash = Path(_hash_file).read_text().strip()
 
                     # update hash
                     tarball_name = os.path.basename(self._dataset_tarball_name)
@@ -494,8 +497,9 @@ class JSONDataset(
                 os.makedirs(self._dataset_root_dir, exist_ok=True)
                 logging.debug(f"Creating tarball {self._dataset_tokenizer_tarball_name} file.")
                 if os.path.exists(self.tokenizer_dir()):
-                    _, _tarball_hash = create_tar_gz(
+                    _, _hash_file = create_tar_gz(
                         self.tokenizer_dir(), self._dataset_tokenizer_tarball_name)
+                    _tarball_hash = Path(_hash_file).read_text().strip()
 
                     # update hash
                     tarball_name = os.path.basename(self._dataset_tokenizer_tarball_name)
@@ -691,6 +695,18 @@ class JSONDataset(
                 resource_name = resource[0]
                 resource_hash = resource[1]
                 if resource_name == tarball_name:
+                    if isinstance(resource_hash, str) and resource_hash.endswith(".md5"):
+                        # heal specs written while create_tar_gz's hash-file PATH was
+                        # stored in place of the value: read the sidecar when present,
+                        # else skip verification for this resource (unverifiable).
+                        sidecar = Path(resource_hash)
+                        if sidecar.exists():
+                            resource_hash = sidecar.read_text().strip()
+                        else:
+                            self.logger.warning(
+                                f"Skipping hash check for {resource_name}: spec stores "
+                                f"a missing hash-file path ({resource_hash}).")
+                            break
                     computed_hash = md5_checksum(tarball_path)
                     if computed_hash != resource_hash:
                         self.logger.debug(f"Hash mismatch for resource: {resource_name}")

--- a/tests/ds/test_tokenizer_provenance.py
+++ b/tests/ds/test_tokenizer_provenance.py
@@ -63,3 +63,36 @@ def test_rebuild_skips_tarball_verification():
     assert ds._should_verify_tarballs() is False
     ds._recreate_dataset = False
     assert ds._should_verify_tarballs() is True
+
+
+def test_tarball_check_heals_pathlike_hash(tmp_path):
+    """Specs poisoned with the hash-file PATH verify via the sidecar content."""
+    from igc.ds.ds_utils import create_tar_gz
+
+    src_dir = tmp_path / "payload"
+    src_dir.mkdir()
+    (src_dir / "a.json").write_text("{}")
+    tarball, hash_file = create_tar_gz(str(src_dir), str(tmp_path / "igc.tar.gz"))
+
+    ds = JSONDataset.__new__(JSONDataset)
+    ds.logger = __import__("loguru").logger
+    ds._dataset_tarballs = [tarball]
+    ds._resources = [("igc.tar.gz", hash_file, "x")]  # poisoned: path not value
+    ds._check_tarball_hash()  # must heal via sidecar content, not raise
+
+
+def test_tarball_check_skips_missing_sidecar(tmp_path):
+    """A poisoned spec whose sidecar is gone skips verification with a warning."""
+    from igc.ds.ds_utils import create_tar_gz
+
+    src_dir = tmp_path / "payload"
+    src_dir.mkdir()
+    (src_dir / "a.json").write_text("{}")
+    tarball, hash_file = create_tar_gz(str(src_dir), str(tmp_path / "igc.tar.gz"))
+    __import__("os").remove(hash_file)
+
+    ds = JSONDataset.__new__(JSONDataset)
+    ds.logger = __import__("loguru").logger
+    ds._dataset_tarballs = [tarball]
+    ds._resources = [("igc.tar.gz", hash_file, "x")]
+    ds._check_tarball_hash()  # unverifiable -> skip, not fatal


### PR DESCRIPTION
Sixth R2 finding — and a regression from my own earlier contract fix: create_tar_gz now returns the hash-file path (as its docstring promised), but the dataset save path stored that return verbatim into resources, so rebuilt specs carried a filename where a hash belongs ('Expected Hash: .../igc.tar.gz.md5' in the container logs). Save sites now read the sidecar value; the checker additionally heals poisoned specs in place (resolves path-like hashes via the sidecar, warns and skips when the sidecar is gone) — so the node's already-written dataset.json loads without another rebuild. Offline gate: 552 passed (pipefail).