### PR TITLE
Make the masking curriculum actually run

### DIFF
--- a/igc/modules/llm_train_state_encoder.py
+++ b/igc/modules/llm_train_state_encoder.py
@@ -384,12 +384,15 @@ class LlmEmbeddingsTrainer(LlmModule):
 
         :param mask_type: Masking enum to activate for subsequent dataset samples.
         """
-        if mask_type in self.masking_methods:
-            print(f"Got mask type {mask_type}")
-            callback = self.masking_methods[mask_type]
+        # dispatch through the method DICT — the enum list only orders the
+        # curriculum; indexing it with an enum was a TypeError, so no masking
+        # pass ever activated.
+        if mask_type in self._masking_method_dispatcher:
+            self.logger.info(f"Enabling masking method {mask_type}")
+            callback = self._masking_method_dispatcher[mask_type]
             callback()
         else:
-            raise ValueError("Unknown masking type")
+            raise ValueError(f"Unknown masking type {mask_type}")
 
     def swap_masking_method(
             self, epoch: int,
@@ -406,18 +409,21 @@ class LlmEmbeddingsTrainer(LlmModule):
         :param epoch: Zero-based epoch index used to decide when to swap masks.
         :param mask_type: Ordered masking methods to cycle through.
         """
-        if (epoch + 1) % self._masked_freq == 0 and self._current_mask_method_counter == 0:
-            # switch to masking pass, mask freq how fast i.e after epoch
-            # or after 10 epoch etc.
+        if not mask_type:
+            return
+        if (epoch + 1) % self._masked_freq == 0:
+            # activate the next mask in the curriculum for the coming epoch. The old
+            # `and counter == 0` guard compared against a per-micro-batch counter that
+            # was never reset, so after epoch one no mask could ever activate.
             _current_method = mask_type[self._current_mask_method_idx]
             self.enable_masking_method(_current_method)
             self._current_mask_method_idx = (self._current_mask_method_idx + 1) % len(mask_type)
-        else:
-            # reset back
-            if self._current_mask_method_counter == self._num_mask_passed:
-                self.dataset.disable_masking()
-                self._current_mask_method_counter = 0
-                self.dataset.disable_masking()
+            self._current_mask_method_counter = 0
+        elif self._current_mask_method_counter >= self._num_mask_passed:
+            # enough masked batches seen since activation: back to plain batches.
+            # (>= — the counter advances per micro-batch, an exact == is skipped over.)
+            self.dataset.disable_masking()
+            self._current_mask_method_counter = 0
 
     def _train(
             self,

--- a/tests/modules/test_masking_curriculum.py
+++ b/tests/modules/test_masking_curriculum.py
@@ -1,0 +1,84 @@
+"""Offline regressions for the masking curriculum in the encoder trainer.
+
+The curriculum was inert three ways: activation required a per-micro-batch
+counter to equal zero (never after epoch one), the enable path indexed the
+enum LIST with an enum (TypeError) instead of the dispatcher dict, and
+deactivation compared the counter with ``==`` to a boundary it skips over.
+Drives ``swap_masking_method``/``enable_masking_method`` on a stubbed trainer.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import pytest
+
+from igc.modules.llm_train_state_encoder import LlmEmbeddingsTrainer
+
+
+class _Dataset:
+    def __init__(self):
+        self.disabled = 0
+
+    def disable_masking(self):
+        self.disabled += 1
+
+
+def _trainer(freq=2, passes=10):
+    trainer = LlmEmbeddingsTrainer.__new__(LlmEmbeddingsTrainer)
+    trainer._masked_freq = freq
+    trainer._num_mask_passed = passes
+    trainer._current_mask_method_idx = 0
+    trainer._current_mask_method_counter = 0
+    trainer.dataset = _Dataset()
+    trainer.calls = []
+    trainer._masking_method_dispatcher = {
+        "mask_a": lambda: trainer.calls.append("mask_a"),
+        "mask_b": lambda: trainer.calls.append("mask_b"),
+    }
+    import loguru
+    trainer.logger = loguru.logger
+    return trainer
+
+
+def test_mask_activates_on_frequency_boundary_even_mid_run():
+    """Activation no longer requires the batch counter to be zero."""
+    trainer = _trainer(freq=2)
+    trainer._current_mask_method_counter = 4321  # mid-run counter state
+    trainer.swap_masking_method(epoch=1, mask_type=["mask_a", "mask_b"])
+    assert trainer.calls == ["mask_a"]
+    assert trainer._current_mask_method_idx == 1
+    assert trainer._current_mask_method_counter == 0
+
+
+def test_curriculum_cycles_through_methods():
+    """Consecutive boundaries walk the ordered method list cyclically."""
+    trainer = _trainer(freq=1)
+    for epoch in range(3):
+        trainer.swap_masking_method(epoch, ["mask_a", "mask_b"])
+    assert trainer.calls == ["mask_a", "mask_b", "mask_a"]
+
+
+def test_mask_disables_after_enough_batches():
+    """Off-boundary epochs disable masking once the pass budget is exceeded."""
+    trainer = _trainer(freq=5, passes=10)
+    trainer._current_mask_method_counter = 17  # advanced past the budget
+    trainer.swap_masking_method(epoch=0, mask_type=["mask_a"])
+    assert trainer.dataset.disabled == 1
+    assert trainer._current_mask_method_counter == 0
+
+
+def test_unknown_mask_raises():
+    """An enum missing from the dispatcher fails loudly, not with TypeError."""
+    trainer = _trainer()
+    with pytest.raises(ValueError, match="Unknown masking type"):
+        trainer.enable_masking_method("nope")
+
+
+def test_no_mask_list_is_a_noop():
+    """The smoke path passes mask_type=[] — nothing activates or disables."""
+    trainer = _trainer(freq=1)
+    trainer.swap_masking_method(epoch=0, mask_type=[])
+    assert trainer.calls == [] and trainer.dataset.disabled == 0
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
Closes the final P1 audit item: the state encoder's masking objective — the reason the masked dataset exists — never activated (counter guard impossible after epoch one; list indexed with an enum raising TypeError if it ever fired; deactivation == skipped over). Five regressions drive activation mid-run, curriculum cycling, budget-based deactivation, the loud unknown-mask error, and the empty-list smoke path. Offline gate: 559 passed (pipefail).