### PR TITLE
Skip tarball verification when no usable hash is recorded

### DIFF
--- a/igc/ds/redfish_dataset.py
+++ b/igc/ds/redfish_dataset.py
@@ -697,16 +697,18 @@ class JSONDataset(
                 if resource_name == tarball_name:
                     if isinstance(resource_hash, str) and resource_hash.endswith(".md5"):
                         # heal specs written while create_tar_gz's hash-file PATH was
-                        # stored in place of the value: read the sidecar when present,
-                        # else skip verification for this resource (unverifiable).
+                        # stored in place of the value: read the sidecar when present.
                         sidecar = Path(resource_hash)
-                        if sidecar.exists():
-                            resource_hash = sidecar.read_text().strip()
-                        else:
-                            self.logger.warning(
-                                f"Skipping hash check for {resource_name}: spec stores "
-                                f"a missing hash-file path ({resource_hash}).")
-                            break
+                        resource_hash = (
+                            sidecar.read_text().strip() if sidecar.exists() else "")
+                    if not (isinstance(resource_hash, str) and resource_hash.strip()):
+                        # an absent/empty expected hash cannot verify anything; a packaging
+                        # hash is an integrity nice-to-have, not a correctness gate, so skip
+                        # (warn) rather than hard-fail the whole load on unverifiable state.
+                        self.logger.warning(
+                            f"Skipping hash check for {resource_name}: no usable expected "
+                            f"hash recorded in the dataset spec.")
+                        break
                     computed_hash = md5_checksum(tarball_path)
                     if computed_hash != resource_hash:
                         self.logger.debug(f"Hash mismatch for resource: {resource_name}")

--- a/tests/ds/test_tokenizer_provenance.py
+++ b/tests/ds/test_tokenizer_provenance.py
@@ -96,3 +96,38 @@ def test_tarball_check_skips_missing_sidecar(tmp_path):
     ds._dataset_tarballs = [tarball]
     ds._resources = [("igc.tar.gz", hash_file, "x")]
     ds._check_tarball_hash()  # unverifiable -> skip, not fatal
+
+
+def test_tarball_check_skips_empty_expected_hash(tmp_path):
+    """An empty recorded hash is unverifiable — skip with a warning, don't crash."""
+    from igc.ds.ds_utils import create_tar_gz
+
+    src_dir = tmp_path / "payload"
+    src_dir.mkdir()
+    (src_dir / "a.json").write_text("{}")
+    tarball, _ = create_tar_gz(str(src_dir), str(tmp_path / "igc.tar.gz"))
+
+    ds = JSONDataset.__new__(JSONDataset)
+    ds.logger = __import__("loguru").logger
+    ds._dataset_tarballs = [tarball]
+    ds._resources = [("igc.tar.gz", "", "x")]  # empty expected hash
+    ds._check_tarball_hash()  # must not raise
+
+
+def test_tarball_check_still_fails_on_real_value_mismatch(tmp_path):
+    """A genuine value-vs-value mismatch is still a hard error."""
+    import pytest
+    from igc.ds.ds_utils import create_tar_gz
+    from igc.ds.redfish_dataset import DatasetConsistencyError
+
+    src_dir = tmp_path / "payload"
+    src_dir.mkdir()
+    (src_dir / "a.json").write_text("{}")
+    tarball, _ = create_tar_gz(str(src_dir), str(tmp_path / "igc.tar.gz"))
+
+    ds = JSONDataset.__new__(JSONDataset)
+    ds.logger = __import__("loguru").logger
+    ds._dataset_tarballs = [tarball]
+    ds._resources = [("igc.tar.gz", "deadbeef" * 4, "x")]  # wrong but present
+    with pytest.raises(DatasetConsistencyError):
+        ds._check_tarball_hash()


### PR DESCRIPTION
Seventh R2 finding: a rebuilt dataset.json on the node carried an empty expected hash for igc.tar.gz, and the checker hard-failed ('Expected Hash:' blank in the container logs). Packaging hashes are integrity nice-to-haves, not correctness gates — absent/empty/unresolvable expected hashes now warn-and-skip; a real value-vs-value mismatch still raises. Offline gate: 561 passed (pipefail).