### PR TITLE
Add a CLI to summarize and compare training reports

### DIFF
--- a/igc/modules/train/report_cli.py
+++ b/igc/modules/train/report_cli.py
@@ -1,0 +1,96 @@
+"""CLI to summarize and compare M1 training runs.
+
+The training run writes a per-run ``report.json`` (a :class:`ResultBundle` from
+:mod:`igc.modules.train.report`); this command turns those into the human
+output the profile matrix exists for — a single-run summary or a cross-arm
+comparison table with the fairness check and baseline deltas. It reads only
+``report.json`` files, so it runs offline with no GPU or model.
+
+Usage::
+
+    python -m igc.modules.train.report_cli experiments/*/report.json
+    python -m igc.modules.train.report_cli --baseline lora --json out.json run*/report.json
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import argparse
+import glob
+import json
+import sys
+from typing import List, Optional
+
+from igc.modules.train.report import ResultBundle, compare
+
+
+def _resolve_paths(patterns: List[str]) -> List[str]:
+    """Expand path/glob arguments into a sorted, de-duplicated file list.
+
+    :param patterns: literal paths or globs (e.g. ``experiments/*/report.json``).
+    :return: sorted unique matches that exist on disk.
+    """
+    paths = set()
+    for pattern in patterns:
+        matches = glob.glob(pattern, recursive=True)
+        if matches:
+            paths.update(matches)
+        elif not glob.has_magic(pattern) and pattern:
+            # a literal path with no matches is kept so the read raises a clear
+            # error; an unmatched glob simply contributes nothing.
+            paths.add(pattern)
+    return sorted(paths)
+
+
+def build_report(paths: List[str], baseline: Optional[str]) -> dict:
+    """Read report bundles and render a comparison (or single-run summary).
+
+    :param paths: resolved ``report.json`` paths.
+    :param baseline: arm-label prefix to diff against, or None to skip deltas.
+    :return: ``{"markdown": str, "comparison": dict}`` for printing/serialization.
+    :raises FileNotFoundError: if no readable report is found.
+    """
+    bundles = [ResultBundle.read(p) for p in paths]
+    if not bundles:
+        raise FileNotFoundError("no report.json files matched")
+    report = compare(bundles, baseline=baseline)
+    return {"markdown": report.to_markdown(), "comparison": report.to_dict()}
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Entry point: print the comparison table, optionally write the JSON.
+
+    :param argv: CLI args (paths/globs, ``--baseline``, ``--json``).
+    :return: process exit code (0 ok, 2 nothing matched).
+    """
+    parser = argparse.ArgumentParser(
+        description="Summarize and compare igc M1 training report.json files.")
+    parser.add_argument("reports", nargs="+", help="report.json paths or globs.")
+    parser.add_argument(
+        "--baseline", default="lora",
+        help="arm-label prefix to diff against (default: lora); 'none' to skip deltas.")
+    parser.add_argument(
+        "--json", default=None, help="also write the comparison dict to this path.")
+    args = parser.parse_args(argv)
+
+    paths = _resolve_paths(args.reports)
+    baseline = None if args.baseline == "none" else args.baseline
+    try:
+        result = build_report(paths, baseline)
+    except FileNotFoundError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    print(result["markdown"])
+    if args.json:
+        with open(args.json, "w", encoding="utf-8") as fh:
+            json.dump(result["comparison"], fh, indent=2, sort_keys=True, default=str)
+        print(f"\nwrote {args.json}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/modules/train/test_report_cli.py
+++ b/tests/modules/train/test_report_cli.py
@@ -1,0 +1,85 @@
+"""Offline tests for the training-report CLI.
+
+``igc.modules.train.report`` has the library (ResultBundle/compare/markdown)
+but had no executable surface — the profile-matrix comparison the run manifests
+exist for could not be produced. These drive the CLI over fixture report.json
+files: glob resolution, the comparison table, baseline handling, JSON output,
+and the no-match exit code. CPU-only, no GPU/model.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import json
+
+import pytest
+
+from igc.modules.train.report import ResultBundle, RunManifest
+from igc.modules.train.report_cli import build_report, main
+
+
+def _write_report(path, arm_method, rank, loss):
+    """Write a minimal report.json for one arm."""
+    bundle = ResultBundle(
+        manifest=RunManifest(
+            run_id=f"run-{arm_method}", profile="m1", model="gpt2",
+            adapter_method=arm_method, adapter_rank=rank,
+        ),
+        metrics={"eval_loss": loss, "accuracy": 90.0},
+    )
+    bundle.write(str(path))
+
+
+def test_build_report_compares_two_arms(tmp_path):
+    """Two report.json files render a table with both arms and metrics."""
+    _write_report(tmp_path / "a.json", "lora", 16, 1.5)
+    _write_report(tmp_path / "b.json", "rslora", 32, 1.2)
+
+    result = build_report(
+        [str(tmp_path / "a.json"), str(tmp_path / "b.json")], baseline="lora"
+    )
+    assert "eval_loss" in result["markdown"]
+    assert set(result["comparison"]["arms"]) == {"lora-r16", "rslora-r32"}
+    # baseline deltas present for the non-baseline arm
+    assert result["comparison"]["deltas"]["rslora-r32"]["eval_loss"] == pytest.approx(-0.3)
+
+
+def test_main_globs_and_prints(tmp_path, capsys):
+    """The CLI expands a glob and prints the markdown table."""
+    _write_report(tmp_path / "run1-report.json", "lora", 16, 1.5)
+    _write_report(tmp_path / "run2-report.json", "full_finetune", None, 1.1)
+
+    code = main([str(tmp_path / "*-report.json"), "--baseline", "lora"])
+    out = capsys.readouterr().out
+
+    assert code == 0
+    assert "| arm |" in out
+    assert "lora-r16" in out
+
+
+def test_main_writes_json(tmp_path):
+    """--json serializes the comparison dict."""
+    _write_report(tmp_path / "a.json", "lora", 16, 1.5)
+    out_path = tmp_path / "cmp.json"
+
+    main([str(tmp_path / "a.json"), "--json", str(out_path)])
+
+    written = json.loads(out_path.read_text())
+    assert "table" in written and "lora-r16" in written["arms"]
+
+
+def test_main_no_match_exits_2(tmp_path, capsys):
+    """No matching report yields a non-zero exit, not a traceback."""
+    code = main([str(tmp_path / "nothing-*.json")])
+    assert code == 2
+    assert "no report.json" in capsys.readouterr().err
+
+
+def test_baseline_none_skips_deltas(tmp_path):
+    """--baseline none produces a table without deltas."""
+    _write_report(tmp_path / "a.json", "lora", 16, 1.5)
+    result = build_report([str(tmp_path / "a.json")], baseline=None)
+    assert result["comparison"]["deltas"] == {}
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
Gives the report library an executable surface (the gaps audit flagged it had none): `python -m igc.modules.train.report_cli experiments/*/report.json --baseline lora` reads per-run report.json bundles, prints the cross-arm comparison table with the fairness banner and baseline deltas, and optionally writes the comparison JSON. Offline (report.json only). 5 tests cover glob resolution, the table, baseline none, JSON output, and the no-match exit code. Gate: 566 passed (pipefail).