### PR TITLE
Detect GPT-2 Conv1D attention to reject FlashAttention-2

### DIFF
--- a/igc/modules/shared/llm_shared.py
+++ b/igc/modules/shared/llm_shared.py
@@ -34,6 +34,22 @@ def _resolve_dtype(name: Optional[str]):
     return getattr(torch, name)
 
 
+def _uses_conv1d_attention(model) -> bool:
+    """Whether a model uses transformers' Conv1D (GPT-2 family) anywhere.
+
+    Conv1D-based attention is the marker for backbones that break the
+    FlashAttention-2 dtype probe (which requires an ``nn.Linear``).
+
+    :param model: a loaded ``PreTrainedModel``.
+    :return: True if any submodule is a ``transformers`` ``Conv1D``.
+    """
+    try:
+        from transformers.pytorch_utils import Conv1D
+    except ImportError:
+        return False
+    return any(isinstance(m, Conv1D) for m in model.modules())
+
+
 def _from_pretrained_best_attention(model_id: str, load_kwargs: dict):
     """Load a causal LM preferring the fastest attention kernel the env supports.
 
@@ -58,11 +74,12 @@ def _from_pretrained_best_attention(model_id: str, load_kwargs: dict):
                 model_id, attn_implementation=impl, **load_kwargs)
         except (ImportError, ValueError, RuntimeError, OSError):
             continue
-        if impl == "flash_attention_2" and not any(
-                isinstance(m, torch.nn.Linear) for m in model.modules()):
-            # transformers' FA2 dtype probe needs an nn.Linear; Conv1D-only
-            # backbones (GPT-2 family) load fine but StopIteration at the first
-            # forward — fall through to sdpa for them.
+        if impl == "flash_attention_2" and _uses_conv1d_attention(model):
+            # GPT-2-family backbones use Conv1D (not nn.Linear) in attention; they
+            # load under FA2 but transformers' FA2 dtype probe walks for the first
+            # nn.Linear and StopIterations at the first forward — and the state
+            # encoder runs the Conv1D-only BODY (no lm_head Linear to mask it), so
+            # checking the whole model is not enough. Fall through to sdpa.
             del model
             continue
         return model

--- a/tests/modules/test_llm_loader.py
+++ b/tests/modules/test_llm_loader.py
@@ -161,10 +161,15 @@ def test_fa2_rejected_for_conv1d_only_backbones(monkeypatch):
 
     attempts = []
 
+    from transformers.pytorch_utils import Conv1D
+
     class _Conv1DOnly(torch.nn.Module):
         def __init__(self):
             super().__init__()
-            self.weight = torch.nn.Parameter(torch.zeros(1))
+            # a GPT-2-style Conv1D "attention" plus an lm_head Linear: the whole
+            # model HAS a Linear, so only the Conv1D marker distinguishes it.
+            self.attn = Conv1D(2, 2)
+            self.lm_head = torch.nn.Linear(2, 2)
 
     class _LinearModel(torch.nn.Module):
         def __init__(self):


### PR DESCRIPTION
Eighth R2 finding — my #30 guard was fooled: GPT-2's lm_head is nn.Linear so the whole-model check accepted FA2, but the autoencoder trainer runs the Conv1D-only backbone body which StopIterations in transformers' FA2 dtype probe. Detect transformers' Conv1D module directly (the reliable GPT-2-family marker) and fall through to sdpa; regression updated to a Conv1D+lm_head model so the whole-model-has-Linear false positive is pinned. Gate: 566 passed (pipefail).