### PR TITLE
Profile the RL training critical sections; find and pin the 51x candidate-cache win

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -85,6 +85,18 @@ HER relabeling then re-scores cached embeddings against the new goal-conditioned
 (one matmul) instead of re-encoding candidates. This resolves D-001 binding requirement #2 by
 construction.
 
+**Measured throughput consequence (2026-07-11, `scripts/bench_hot_paths.py --section rl`).** The
+pointer forward's ONLY expensive step is the candidate projection: projecting `[B, N, H]`
+embeddings through the `ActionProjector` MLP (GELU + two Linears over 76.8M elements at B=256,
+N=300, H=768) is 0.193s/step on CPU, while every other RL critical section — DQN target, HER
+relabel loop, replay data feed, done-stacking, the scoring einsum — is under 6ms. Because the
+projector weights are fixed within an optimizer step and a host's candidates are static, the
+correct pattern is to **project the host's UNIQUE candidate set once per step and score with
+`score_candidates` (einsum over cached keys)**, NOT call the full `Igc_PointerQNetwork.forward`
+per state (which re-projects duplicated candidates). Measured: **0.193s → 0.0038s, ~51x**. The
+key cache is not just a HER-relabel convenience — it is the per-step throughput lever for M6
+training, guarded by a machine-independent ratio tripwire in `tests/perf/`.
+
 ### Risks accepted
 
 - Text + shallow structural features may under-discriminate sibling endpoints that differ only

--- a/scripts/bench_hot_paths.py
+++ b/scripts/bench_hot_paths.py
@@ -86,16 +86,16 @@ def print_report(rows: List[Tuple[str, float]], info: Dict) -> None:
         print(f"{label:40} {seconds:10.4f}")
 
 
-def print_critical_sections(corpus: str, top: int = 12) -> None:
-    """cProfile the whole suite and print the top cumulative-time functions.
+def _profile(fn: Callable, top: int = 15) -> None:
+    """cProfile ``fn`` and print the top cumulative-time functions (critical sections).
 
-    :param corpus: fixture directory.
+    :param fn: zero-arg callable to profile.
     :param top: number of functions to show.
     :return: ``None``.
     """
     profiler = cProfile.Profile()
     profiler.enable()
-    run_benchmarks(corpus)
+    fn()
     profiler.disable()
     buffer = io.StringIO()
     pstats.Stats(profiler, stream=buffer).sort_stats("cumulative").print_stats(top)
@@ -103,16 +103,133 @@ def print_critical_sections(corpus: str, top: int = 12) -> None:
     print(buffer.getvalue())
 
 
+def print_critical_sections(corpus: str, top: int = 12) -> None:
+    """cProfile the data-gen suite and print the critical sections.
+
+    :param corpus: fixture directory.
+    :param top: number of functions to show.
+    :return: ``None``.
+    """
+    _profile(lambda: run_benchmarks(corpus), top=top)
+
+
+def run_rl_benchmarks(batch: int = 256, cand: int = 300, h_dim: int = 768,
+                      horizon: int = 50, her_k: int = 8,
+                      buffer_fill: int = 5000) -> Tuple[List[Tuple[str, float]], Dict]:
+    """Benchmark the RL training critical sections on CPU (no GPU, no model download).
+
+    Covers the DQN target math, the HER future-relabel nested loop, the replay-buffer data
+    feed and its per-sample done-stacking loop, and the pointer-policy forward — the loops
+    and feeds that, executed O(steps) times per training epoch, dominate wall-clock if any
+    is accidentally superlinear. Everything runs on CPU with synthetic tensors, so it can be
+    profiled in parallel while the GPU is busy.
+
+    :param batch: replay sample size / batch dimension B.
+    :param cand: candidate count N (pointer width, next_q action dim).
+    :param h_dim: backbone hidden / state dimension H.
+    :param horizon: episode length T (HER nested-loop depth).
+    :param her_k: HER relabels per transition (k).
+    :param buffer_fill: transitions preloaded into the replay buffer.
+    :return: ``(timing rows, context info)``.
+    """
+    import numpy as np
+    import torch
+
+    from igc.modules.igc_experience_buffer import Buffer
+    from igc.modules.policy.pointer_policy import Igc_PointerQNetwork, score_candidates
+    from igc.modules.rl.q_targets import q_learning_target, relabel_future
+
+    torch.manual_seed(0)
+    rows: List[Tuple[str, float]] = []
+
+    # 1. DQN one-step target with terminal mask (fully vectorized).
+    reward = torch.rand(batch)
+    done = (torch.rand(batch) > 0.9).to(torch.float32)
+    next_q = torch.rand(batch, cand)
+    timed("q_learning_target [B,N]", lambda: q_learning_target(reward, done, next_q, 0.99), rows)
+
+    # 2. HER future relabeling over a full episode (nested loop: T timesteps x k relabels).
+    goal_dim = h_dim
+    episode = [(None, None, torch.rand(1), torch.rand(1, goal_dim), None) for _ in range(horizon)]
+    achieved = torch.rand(1, goal_dim)
+    rng = np.random.default_rng(0)
+
+    def reward_fn(state, goal):
+        return torch.all(state == goal, dim=1).to(torch.float32)
+
+    def her_episode():
+        out = []
+        for step in range(horizon):
+            out.extend(relabel_future(episode, step, achieved, her_k, reward_fn, rng))
+        return out
+
+    timed(f"HER relabel, full episode (T={horizon} x k={her_k})", her_episode, rows)
+
+    # 3. Replay buffer: fill (setup, untimed) then time the data-feed sample + the done loop.
+    buf = Buffer(size=buffer_fill * 2, sample_size=batch)
+    for i in range(buffer_fill):
+        done_val = torch.rand(1) if i % 3 == 0 else False   # exercise the _stack_done coercion
+        buf.add(torch.rand(h_dim), torch.rand(cand), torch.rand(1), torch.rand(h_dim), done_val)
+    timed("replay sample_batch (data feed)", buf.sample_batch, rows)
+    samples = list(buf._buffer)[:batch]
+    reward_batch = torch.stack([s[2] for s in samples], dim=0)
+    timed("  _stack_done loop (isolated)", lambda: Buffer._stack_done(samples, reward_batch), rows)
+
+    # 4. Fixed-width Q-network forward (the current agent path: state+goal cat -> num_actions).
+    from igc.modules.igc_q_network import Igc_QNetwork
+    qnet = Igc_QNetwork(input_dim=2 * h_dim, num_actions=cand)
+    qnet.eval()
+    qnet_input = torch.rand(batch, 2 * h_dim)
+    with torch.no_grad():
+        timed("fixed Q-network forward [B,2H]", lambda: qnet(qnet_input), rows)
+
+    # 5. Pointer-policy forward on CPU (query + key projection + einsum scoring).
+    policy = Igc_PointerQNetwork(h_dim=h_dim, q_dim=256)
+    policy.eval()
+    state_h = torch.rand(batch, h_dim)
+    goal_h = torch.rand(batch, h_dim)
+    cand_h = torch.rand(batch, cand, h_dim)
+    mask = (torch.rand(batch, cand) > 0.3).to(torch.float32)
+    with torch.no_grad():
+        timed("pointer forward, re-project B*N (naive)", lambda: policy(state_h, goal_h, cand_h, mask), rows)
+        # D-002 caching: a host's N candidates are static, so project the UNIQUE set once
+        # per optimizer step and reuse across the whole batch (keys expand is a view, no copy).
+        unique_cand = torch.rand(cand, h_dim)
+
+        def cached_forward():
+            query = policy.state_query(state_h, goal_h)
+            keys = policy.action_proj(unique_cand.unsqueeze(0))          # project N once, not B*N
+            return score_candidates(query, keys.expand(batch, -1, -1), mask)
+
+        timed("pointer forward, project-N-once (D-002 cache)", cached_forward, rows)
+        query = torch.rand(batch, 256)
+        keys = torch.rand(batch, cand, 256)
+        timed("  score_candidates einsum (isolated)", lambda: score_candidates(query, keys, mask), rows)
+
+    info = {"corpus": f"synthetic RL  B={batch} N={cand} H={h_dim} T={horizon} k={her_k}",
+            "records": buffer_fill, "nodes": horizon * her_k, "candidates": cand}
+    return rows, info
+
+
 def main() -> None:
     """CLI entry point."""
     parser = argparse.ArgumentParser(description="Benchmark igc hot paths over a real corpus.")
     parser.add_argument("--corpus", default=DEFAULT_CORPUS)
     parser.add_argument("--profile", action="store_true", help="also print cProfile critical sections")
+    parser.add_argument("--section", choices=("data", "rl", "all"), default="all",
+                        help="data-gen path, RL training path, or both (default)")
     args = parser.parse_args()
-    rows, info = run_benchmarks(args.corpus)
-    print_report(rows, info)
-    if args.profile:
-        print_critical_sections(args.corpus)
+    if args.section in ("data", "all"):
+        rows, info = run_benchmarks(args.corpus)
+        print_report(rows, info)
+        if args.profile:
+            print_critical_sections(args.corpus)
+    if args.section in ("rl", "all"):
+        rl_rows, rl_info = run_rl_benchmarks()
+        print()
+        print_report(rl_rows, rl_info)
+        if args.profile:
+            _profile(lambda: run_rl_benchmarks())
 
 
 if __name__ == "__main__":

--- a/tests/perf/test_rl_hot_path_budgets.py
+++ b/tests/perf/test_rl_hot_path_budgets.py
@@ -1,0 +1,104 @@
+"""
+RL training-path performance budgets (regression tripwires, `-m perf`).
+
+Guards the CPU-offline RL critical sections — DQN target, HER relabel loop, replay data
+feed, per-sample done stacking, candidate scoring — with absolute ceilings ~50-100x looser
+than measured, so only an algorithmic regression trips them. Plus a machine-INDEPENDENT
+ratio guard pinning the D-002 static-per-host key cache: projecting the unique candidate set
+once must stay far cheaper than re-projecting B*N (measured 51x). Pure synthetic tensors on
+CPU — no corpus, no GPU, no model download; safe to run in parallel while the GPU is busy.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import time
+
+import numpy as np
+import pytest
+import torch
+
+from igc.modules.igc_experience_buffer import Buffer
+from igc.modules.policy.pointer_policy import Igc_PointerQNetwork, score_candidates
+from igc.modules.rl.q_targets import q_learning_target, relabel_future
+
+pytestmark = pytest.mark.perf
+
+_B, _N, _H, _T, _K = 256, 300, 768, 50, 8
+
+
+def _seconds(fn):
+    start = time.perf_counter()
+    fn()
+    return time.perf_counter() - start
+
+
+def test_q_learning_target_budget():
+    """The DQN target is vectorized: [B, N] batch well under 0.05s (measured ~0.0003s)."""
+    reward, done = torch.rand(_B), (torch.rand(_B) > 0.9).float()
+    next_q = torch.rand(_B, _N)
+    assert _seconds(lambda: q_learning_target(reward, done, next_q, 0.99)) < 0.05
+
+
+def test_her_full_episode_budget():
+    """HER over a full episode (T*k relabels) stays a bounded loop: < 0.5s (measured ~0.004s)."""
+    torch.manual_seed(0)
+    episode = [(None, None, torch.rand(1), torch.rand(1, _H), None) for _ in range(_T)]
+    achieved = torch.rand(1, _H)
+    rng = np.random.default_rng(0)
+
+    def reward_fn(state, goal):
+        return torch.all(state == goal, dim=1).float()
+
+    def run():
+        for step in range(_T):
+            relabel_future(episode, step, achieved, _K, reward_fn, rng)
+
+    assert _seconds(run) < 0.5
+
+
+def test_replay_data_feed_budget():
+    """Replay sample + done-stacking (the per-step data feed) < 0.2s (measured ~0.0015s)."""
+    buf = Buffer(size=10_000, sample_size=_B)
+    for i in range(2_000):
+        done_val = torch.rand(1) if i % 3 == 0 else False
+        buf.add(torch.rand(_H), torch.rand(_N), torch.rand(1), torch.rand(_H), done_val)
+    assert _seconds(buf.sample_batch) < 0.2
+
+
+def test_score_candidates_einsum_budget():
+    """The candidate-scoring einsum [B,N,d] < 0.3s (measured ~0.003s)."""
+    query, keys = torch.rand(_B, 256), torch.rand(_B, _N, 256)
+    mask = (torch.rand(_B, _N) > 0.3).float()
+    assert _seconds(lambda: score_candidates(query, keys, mask)) < 0.3
+
+
+def test_d002_key_cache_beats_reprojection():
+    """D-002 property: projecting N unique candidates once is >= 10x cheaper than B*N.
+
+    Machine-independent ratio (measured ~51x): guards against a training loop that calls the
+    full pointer forward per step (re-projecting duplicated candidates) instead of caching the
+    host's static keys and scoring with a per-step einsum.
+    """
+    torch.manual_seed(0)
+    policy = Igc_PointerQNetwork(h_dim=_H, q_dim=256)
+    policy.eval()
+    state_h, goal_h = torch.rand(_B, _H), torch.rand(_B, _H)
+    cand_h = torch.rand(_B, _N, _H)
+    unique_cand = torch.rand(_N, _H)
+    mask = (torch.rand(_B, _N) > 0.3).float()
+
+    with torch.no_grad():
+        naive = _seconds(lambda: policy(state_h, goal_h, cand_h, mask))
+
+        def cached():
+            query = policy.state_query(state_h, goal_h)
+            keys = policy.action_proj(unique_cand.unsqueeze(0))
+            return score_candidates(query, keys.expand(_B, -1, -1), mask)
+
+        cached_t = _seconds(cached)
+
+    assert naive / max(cached_t, 1e-6) >= 10.0
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
Profiles **every** RL training critical section on CPU, per "make sure we profile all critical sections". Three incremental commits: benchmark → budgets → recorded finding.

## Measured (B=256, N=300, H=768, T=50, k=8)

| RL stage | seconds | CPU-offline? |
|---|---|---|
| q_learning_target (DQN target) | 0.0003 | ✅ |
| HER relabel, full episode (T×k loop) | 0.0043 | ✅ |
| replay sample_batch (data feed) | 0.0014 | ✅ |
| _stack_done loop (isolated) | 0.0003 | ✅ |
| fixed Q-network forward | 0.0005 | ✅ |
| **pointer forward, re-project B×N (naive)** | **0.1926** | GPU-bound |
| **pointer forward, project-N-once (D-002)** | **0.0038** | ✅ |
| score_candidates einsum | 0.0026 | ✅ |

## Findings

- **Every genuinely CPU-offline path — targets, HER loop, replay feed, done-stacking, scoring einsum — is under 6ms.** These are safe to run in parallel while the GPU is busy, exactly as asked; none is superlinear.
- **The one heavy path is the pointer's candidate projection** (`ActionProjector` MLP over `[B,N,H]` = 76.8M elements: GELU 61ms + Linear 73ms). cProfile pinpointed it as `pointer_policy.py:89`.
- **The fix is pure D-002**: candidates are static per host and the projector weights are fixed within an optimizer step, so projecting the *unique* candidate set once and scoring cached keys is **51× faster** (0.193s → 0.0038s). The primitive already exists (`score_candidates` takes pre-projected keys); the guidance is to use it in the M6 training loop rather than the full per-state forward.

## What ships

1. `scripts/bench_hot_paths.py --section rl` — the RL benchmark (synthetic CPU tensors; `--profile` for cProfile critical sections).
2. `tests/perf/test_rl_hot_path_budgets.py` — absolute budgets on the offline control paths + a **machine-independent ratio tripwire** (project-once must stay ≥10× cheaper than re-project-B×N) so the cache can't silently regress.
3. `docs/DECISIONS.md` (D-002) — the throughput finding recorded as the per-step lever for M6.

Gate: full offline suite 561 passed / 0 failed; RL budgets `-m perf` 5 passed; ruff clean.