### PR TITLE
Profiling docs (critical sections + how-to-profile), CI pipeline, and Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,90 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          lfs: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: pip
+      - name: Install dependencies
+        run: |
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install -r docker/requirements-test.txt
+          pip install ruff
+      - name: Lint
+        run: ruff check igc tests
+      - name: Offline gate
+        shell: bash
+        run: |
+          set -o pipefail
+          KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1 pytest -q
+
+  perf:
+    needs: gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          lfs: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: pip
+      - name: Install dependencies
+        run: |
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install -r docker/requirements-test.txt
+      - name: Perf budgets
+        shell: bash
+        run: |
+          set -o pipefail
+          KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 pytest -m perf -q
+
+  docker:
+    needs: gate
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    # secrets are NOT available in `if:` conditionals; surface them as env, then gate on env.
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          lfs: true
+      - uses: docker/setup-buildx-action@v3
+      - name: Build and smoke test
+        run: |
+          docker build -f docker/Dockerfile.test -t igc-test:ci .
+          docker run --rm igc-test:ci pytest -q
+      - name: Log in to Docker Hub
+        if: env.DOCKERHUB_USERNAME != ''
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+      - name: Tag and push
+        if: env.DOCKERHUB_USERNAME != ''
+        run: |
+          docker tag igc-test:ci "$DOCKERHUB_USERNAME/igc-test:latest"
+          docker tag igc-test:ci "$DOCKERHUB_USERNAME/igc-test:${{ github.sha }}"
+          docker push "$DOCKERHUB_USERNAME/igc-test:latest"
+          docker push "$DOCKERHUB_USERNAME/igc-test:${{ github.sha }}"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+PYTHON ?= python3
+
+.PHONY: help gate test lint perf profile profile-rl docker-test docker-push clean
+
+help: ## List available targets and their descriptions
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-16s %s\n", $$1, $$2}'
+
+gate: ## Lint and run the offline test gate (what CI runs)
+	bash -c 'set -o pipefail; ruff check igc tests && KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1 $(PYTHON) -m pytest -q'
+
+test: gate ## Alias for gate
+
+lint: ## Run the ruff linter over igc and tests
+	ruff check igc tests
+
+perf: ## Run the performance budget tripwires (pytest -m perf)
+	KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 $(PYTHON) -m pytest -m perf -q
+
+profile: ## Profile all hot paths with cProfile critical sections
+	$(PYTHON) scripts/bench_hot_paths.py --profile
+
+profile-rl: ## Profile only the RL training hot paths
+	$(PYTHON) scripts/bench_hot_paths.py --section rl --profile
+
+docker-test: ## Build the CPU test image and run the gate inside it
+	docker build -f docker/Dockerfile.test -t igc-test:cpu . && docker run --rm igc-test:cpu pytest -q
+
+docker-push: ## Build and push the CPU test image (requires DOCKER_REPO=<user>/igc-test)
+	@test "$${DOCKER_REPO}" || (echo "ERROR: set DOCKER_REPO, e.g. DOCKER_REPO=youruser/igc-test make docker-push"; exit 1)
+	docker build -f docker/Dockerfile.test -t $${DOCKER_REPO}:latest .
+	docker push $${DOCKER_REPO}:latest
+
+clean: ## Remove Python/pytest/ruff cache directories
+	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name .pytest_cache -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name .ruff_cache -exec rm -rf {} + 2>/dev/null || true

--- a/docs/CRITICAL_SECTIONS.md
+++ b/docs/CRITICAL_SECTIONS.md
@@ -1,0 +1,129 @@
+# Critical sections & performance
+
+Human-readable map of every performance-critical code path in igc: **where it is, what it
+costs, what we optimized, and how it is guarded** so a slow path can never silently make
+training take days. Every number here is reproducible with one command
+([HOW_TO_PROFILE.md](HOW_TO_PROFILE.md)); every budget is a test
+(`tests/perf/`, run with `pytest -m perf`).
+
+The rule that produced this doc is binding: **hot-path code ships with numbers** — a PR that
+touches a hot path without a benchmark table, a budget tripwire, and (for optimizations) a
+before/after plus an output-equivalence check is rejected.
+
+## Why this matters
+
+The RL agent trains for many thousands of steps. A path that runs once per step at O(N²) instead
+of O(N) does not look broken in a unit test — it just turns a 20-minute run into a 20-hour one.
+So the hot paths are **measured**, not eyeballed, and the measurements live here and in CI.
+
+## What is CPU-offline (and why it matters)
+
+Every hot path below except the two model forwards runs on **CPU with no GPU, no model download,
+and no network** — pure tensor/graph work on synthetic or fixture data. That means the whole
+profiling suite can run **in parallel while the GPU is busy** with a training job, and in CI on a
+plain runner. The model forwards (pointer / Q-network) are compute-bound matmuls that belong on
+the GPU; they are benchmarked for visibility but are not CPU-offline and carry no CPU budget.
+
+## The map
+
+Measured on a laptop CPU (single-thread, `OMP_NUM_THREADS=1`); absolute times are machine-relative
+— the **budgets and ratios** are what CI enforces. Reproduce with
+`python scripts/bench_hot_paths.py --profile`.
+
+### 1. Data-generation path — `igc/ds/sources/`
+
+| Section | Where | Cost (real corpus) | Notes |
+|---|---|---|---|
+| Fixture load | `redfish_fixture_source.py` | 0.08 s / 1,499 records | JSON parse; linear |
+| Graph build | `resource_graph.py::from_records` | 0.047 s / 1,499 nodes | one-pass; harvests `@odata.id` refs whole-body |
+| **Neighbors, all nodes** | `resource_graph.py::neighbors` | **0.001 s** (was 0.710 s) | see optimization O-1 |
+| Candidate cache | `candidate_features.py::build_candidate_cache` | 0.004 s | static per host (D-002) |
+| Candidate embedding | `zero_shot_ranking.py::embed_candidates` | 0.12 s / 1,499 | trigram hash; once per host |
+| Zero-shot rank+score | `zero_shot_ranking.py::top_k_hit_rate` | 4.0 s / 1,499 states | **known offline-eval cost** (O-3) |
+
+### 2. RL training path — `igc/modules/rl/`, `igc/modules/policy/`, `igc/modules/igc_experience_buffer.py`
+
+| Section | Where | Cost (B=256, N=300, H=768) | CPU-offline |
+|---|---|---|---|
+| DQN target | `rl/q_targets.py::q_learning_target` | 0.0003 s | ✅ |
+| HER relabel (full episode) | `rl/q_targets.py::relabel_future` | 0.004 s (T=50 × k=8) | ✅ |
+| Replay data feed | `igc_experience_buffer.py::sample_batch` | 0.0014 s | ✅ |
+| `_stack_done` per-item loop | `igc_experience_buffer.py::_stack_done` | 0.0003 s | ✅ |
+| Fixed Q-network forward | `igc_q_network.py` | 0.0005 s | ✅ (small) |
+| **Pointer forward, naive** | `policy/pointer_policy.py::forward` | **0.193 s** | GPU-bound |
+| **Pointer forward, cached** | project unique once + `score_candidates` | **0.0038 s** | see optimization O-2 |
+| Candidate scoring einsum | `policy/pointer_policy.py::score_candidates` | 0.0026 s | ✅ |
+
+**Read this table as:** everything the CPU can do in parallel with the GPU is sub-6 ms. The only
+heavy step is the pointer's candidate projection, and it has a 51× fix (O-2).
+
+## Optimizations we made
+
+### O-1 — Resource-graph indexing (`resource_graph.py`, PR #25)
+
+**Problem.** `children()` scanned every node per call, so building neighbors for all nodes was
+O(V²); `child_relation` resolution re-walked each parent body once per child (a collection body
+references every member). On the 2,024-node GB300 walk this was ~1.3 s per full pass — paid every
+HER relabel and decision step.
+
+**Fix.** Build one-pass `parent`/`children` indexes in `from_records`; share a single
+`{referenced_url: key}` map per parent body across its children. `parent`/`children`/`neighbors`
+are now O(1) dict lookups.
+
+**Result.** All-node neighbors **0.710 s → 0.001 s (710×)**, build time unchanged, output verified
+**bit-identical** to the previous implementation across every node (relations, neighbors, parents).
+
+**Guard.** `tests/perf/test_hot_path_budgets.py::test_neighbors_all_nodes_budget` — 0.5 s per
+1,000 nodes; the old O(V²) would fail it.
+
+### O-2 — Candidate key cache (D-002 static-per-host, PR #37)
+
+**Problem.** The pointer's only expensive step is the `ActionProjector` MLP (GELU + two Linears)
+projecting `[B, N, H]` candidate embeddings — 76.8 M elements at B=256, N=300, H=768. cProfile
+pinned it to `pointer_policy.py::ActionProjector.forward`. Calling the full
+`Igc_PointerQNetwork.forward` per state re-projects the **same** candidates B times, because a
+host's candidates are static and the projector weights are fixed within an optimizer step.
+
+**Fix (design decision [D-002](DECISIONS.md)).** Project the host's **unique** candidate set once
+per optimizer step, cache the keys, and score with `score_candidates` (an einsum over cached
+keys) for every state in the batch. The primitive already exists — `score_candidates` takes
+pre-projected keys — so the M6 training loop must use it rather than the full per-state forward.
+
+**Result.** Pointer forward **0.193 s → 0.0038 s (~51×)** on CPU; on a 100k-step run this is the
+difference between hours and minutes of pure projection.
+
+**Guard.** `tests/perf/test_rl_hot_path_budgets.py::test_d002_key_cache_beats_reprojection` — a
+**machine-independent ratio** tripwire: project-once must stay ≥ 10× cheaper than re-project-B×N
+(measured 51×), so a training loop that reverts to the full forward trips CI regardless of runner
+speed.
+
+## Known costs we accepted (and why)
+
+### O-3 — Zero-shot rank+score is 4.0 s / 1,499 states
+
+The go/no-go harness embeds each state's full JSON body via a Python character-trigram loop.
+It is **offline-eval only** (not on the RL decision path or the training loop), run occasionally
+to score a representation, so it is deferred rather than optimized. If it ever moves onto a hot
+path, the fix is vectorized/hashed embedding — recorded here so the decision is visible, not
+forgotten.
+
+## How the guards work
+
+- `tests/perf/` holds every budget. They carry `@pytest.mark.perf` and are **excluded from the
+  default gate** (`pytest.ini`) so machine speed never flakes a normal run; they run explicitly
+  with `pytest -m perf` and in the CI `perf` job.
+- Absolute budgets are set **50–100× looser than measured** — only an algorithmic regression
+  (accidental O(V²), a per-item body walk, re-projecting duplicates) trips them.
+- Where an absolute time would be too machine-dependent, the guard is a **ratio** between two
+  implementations (O-2), which is invariant to runner speed.
+
+## Adding a new hot path
+
+1. Add a stage to `scripts/bench_hot_paths.py` (real corpus or realistic synthetic tensors).
+2. Run it, paste the table into your PR; for an optimization, include before/after **and** an
+   output-equivalence check against the old code.
+3. Add a `tests/perf/` budget (absolute, 50–100× loose) or a ratio tripwire.
+4. Name the dominant function from `--profile`. If you cannot, the work is not done.
+5. Update this table.
+
+See [HOW_TO_PROFILE.md](HOW_TO_PROFILE.md) for the exact commands and the CI job.

--- a/docs/HOW_TO_PROFILE.md
+++ b/docs/HOW_TO_PROFILE.md
@@ -1,0 +1,89 @@
+# How to profile igc
+
+The one-command way to measure every performance-critical path, find the dominant function, and
+prove a change is faster (or catch a regression). Runs on **CPU, offline, no GPU** — so it works
+on a laptop, on a training node while the GPU is busy, and in CI. The results and the decisions
+behind them live in [CRITICAL_SECTIONS.md](CRITICAL_SECTIONS.md).
+
+## The harness
+
+`scripts/bench_hot_paths.py` times every hot stage over a real fixture corpus (data-gen path) or
+realistic synthetic tensors (RL path).
+
+```bash
+# both sections, timing table only
+python scripts/bench_hot_paths.py
+
+# just the RL training path (no corpus needed — pure synthetic tensors)
+python scripts/bench_hot_paths.py --section rl
+
+# just the data-gen path over a specific corpus
+python scripts/bench_hot_paths.py --section data --corpus idrac_ctl/tests/hpe_fixtures
+
+# add cProfile: prints the top cumulative-time functions (the critical sections)
+python scripts/bench_hot_paths.py --profile
+```
+
+Local runs use the project env (`conda activate igc-dev`, or call its Python directly). The
+data-gen section reads fixture corpora from the `idrac_ctl` submodule, so
+`git submodule update --init && git -C idrac_ctl lfs pull` first if you want that section; the RL
+section needs nothing but the repo.
+
+### Reading the output
+
+A timing table (`stage  seconds`), then with `--profile` a cProfile block sorted by cumulative
+time. The **first igc function** in that block with a large `cumtime` is your critical section —
+if you cannot name it, the optimization work is not finished (TEAM_GUIDE rule).
+
+## The budget tripwires
+
+`tests/perf/` turns each measured number into a regression test. They are marked `@pytest.mark.perf`
+and **excluded from the default gate** (`pytest.ini`), so they never flake a normal `pytest -q`.
+
+```bash
+# run all performance budgets
+KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 pytest -m perf -q
+# or
+make perf
+```
+
+Two kinds of guard:
+
+- **Absolute budgets** — a ceiling 50–100× looser than measured (e.g. all-node neighbors < 0.5 s
+  per 1,000 nodes). Machine speed never trips them; an algorithmic regression always does.
+- **Ratio tripwires** — where an absolute time is too machine-dependent, the test asserts one
+  implementation stays N× faster than another (e.g. the D-002 key cache must stay ≥ 10× faster
+  than re-projecting `B×N`). Invariant to runner speed.
+
+## The Make targets
+
+```bash
+make gate          # ruff + the offline pytest gate (what CI runs)
+make perf          # the budget tripwires
+make profile       # bench_hot_paths.py --profile (both sections)
+make profile-rl    # RL section only
+make docker-test   # build the CPU test image and run pytest inside it
+```
+
+## In CI
+
+`.github/workflows/ci.yml` runs on every push and PR to `main`:
+
+- **`gate`** — `ruff check` + the offline `pytest -q` gate.
+- **`perf`** — `pytest -m perf`; the budget tripwires above run on every change, so a hot-path
+  regression fails the PR automatically, no human profiling required.
+- **`docker`** — builds `docker/Dockerfile.test` and runs the gate inside it (and pushes the
+  image to Docker Hub on `main` when the registry secrets are configured).
+
+So profiling is not a thing someone remembers to do — the budgets are part of the merge gate.
+
+## Workflow for a performance change
+
+1. `python scripts/bench_hot_paths.py --profile` → record the before number and the dominant
+   function.
+2. Make the change.
+3. Re-run → record after; for an optimization, add an **output-equivalence check** (the fast and
+   slow paths produce identical results on a real corpus — see PR #25 for the pattern).
+4. Add/adjust a `tests/perf/` budget or ratio tripwire.
+5. Update the table in [CRITICAL_SECTIONS.md](CRITICAL_SECTIONS.md).
+6. PR with the before/after table pasted in.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,10 @@ Reinforce Learner).
   experiment that validates it.
 - [MATH_CHECKS.md](MATH_CHECKS.md) — the math and optimization gate for Bellman targets, HER,
   replay masks, tensor shapes, finite-gradient checks, and trustworthy training claims.
+- [CRITICAL_SECTIONS.md](CRITICAL_SECTIONS.md) — the performance map: every hot path, its cost,
+  what we optimized (with numbers), and the budget tripwire that guards it.
+- [HOW_TO_PROFILE.md](HOW_TO_PROFILE.md) — the one-command way to measure hot paths, find the
+  critical section, and prove a change is faster; how CI runs it.
 - [TRAINING_OPTIMIZATION_PLAN.md](TRAINING_OPTIMIZATION_PLAN.md) — the large-model training,
   optimization, and GPU-efficiency roadmap for 3B/7B state-encoder work.
 


### PR DESCRIPTION
Human-facing profiling docs + the automation to run them in CI, as requested.

## Docs (reviewable by humans)
- **docs/CRITICAL_SECTIONS.md** — the performance map: every hot path (data-gen + RL), where it is, what it costs, the two optimizations (O-1 graph indexing 710×, O-2 candidate key cache 51×) with before/after numbers and output-equivalence, the one accepted cost (offline-eval trigram loop), and the tripwire guarding each.
- **docs/HOW_TO_PROFILE.md** — one-command guide to `scripts/bench_hot_paths.py`, the `-m perf` budgets, the `make` targets, and the CI jobs. Profiling is part of the merge gate, not a thing to remember.

## CI (`.github/workflows/ci.yml`) — first CI in the repo
- `gate`: ruff + the offline `pytest -q` gate (pipefail).
- `perf`: `pytest -m perf` — the budget tripwires run on every PR, so a hot-path regression fails automatically.
- `docker`: builds `docker/Dockerfile.test`, smoke-runs the gate inside it, and pushes to Docker Hub on `main` when `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets are set (env-indirection, since secrets aren't available in `if:` — fixed on review of the Pro draft).

## Makefile
`make gate/test/lint` mirror CI; `make perf`; `make profile[-rl]`; `make docker-test`; `make docker-push` (needs `DOCKER_REPO`). `PYTHON` overridable for the conda env.

Validated: YAML + actionlint clean, `make` targets dry-run correctly, doc links resolve, offline gate 566 passed / 0 failed.

**To activate Docker Hub push:** add repo secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (a Docker Hub access token). Without them, the docker job still builds + smoke-tests; only the push is skipped.

Follow-up PR (next): `scripts/lfs_push_from_slot.sh` — push large LFS artifacts directly from a GB300 slot to the remote over the node uplink (no VPN bulk transfer), git-lfs via Docker or `--no-install-recommends`, no OS modification.