### PR TITLE
Checkpoint the autoencoder, not the frozen backbone

### DIFF
--- a/igc/modules/base/igc_base_module.py
+++ b/igc/modules/base/igc_base_module.py
@@ -500,7 +500,7 @@ class IgcModule(IgcBaseState):
 
         return model, epoch, last_model_path
 
-    def save_model(self, checkpoint_dir):
+    def save_model(self, checkpoint_dir, model=None):
         """
 
         Save model, after we're done training,
@@ -513,10 +513,12 @@ class IgcModule(IgcBaseState):
         :return:
         """
         if self.is_rank_zero():
-            # weights
+            # weights. `model` lets a trainer whose self.model is a frozen backbone
+            # (e.g. the autoencoder) persist the model it actually trained.
+            _model = model if model is not None else self.model
             checkpoint_file = self._model_file(checkpoint_dir)
             torch.save({
-                'model_state_dict': self.model.state_dict(),
+                'model_state_dict': _model.state_dict(),
                 'is_trained': True,
             }, checkpoint_file)
 
@@ -665,6 +667,7 @@ class IgcModule(IgcBaseState):
             resuming: Optional[bool] = True,
             map_location: Optional[Union[str, Dict]] = None,
             lr: Optional[float] = None,
+            model=None,
     ) -> CheckpointState:
         """
         Load model checkpoint for resuming a training,  if resuming is False
@@ -706,11 +709,14 @@ class IgcModule(IgcBaseState):
         if missing_keys:
             warnings.warn("Optional key is missing from the checkpoint file. ")
 
-        if not hasattr(self.model, 'load_state_dict'):
+        # `model` restores into the trainer's actual trained model (the
+        # autoencoder) instead of the frozen backbone self.model.
+        _target = model if model is not None else self.model
+        if not hasattr(_target, 'load_state_dict'):
             warnings.warn("Model does not have load_state_dict method. ")
             return CheckpointState(0, None, 0, float('-inf'), 0)
 
-        self.model.load_state_dict(checkpoint['model_state_dict'])
+        _target.load_state_dict(checkpoint['model_state_dict'])
 
         if resuming:
 

--- a/igc/modules/igc_train_auto_state_encoder.py
+++ b/igc/modules/igc_train_auto_state_encoder.py
@@ -196,7 +196,8 @@ class AutoencoderTrainer(IgcModule):
         if self._module_checkpoint_dir is not None:
             # load_checkpoint returns a CheckpointState namedtuple; the resume epoch
             # is its last_epoch field, not the state object itself.
-            last_epoch = self.load_checkpoint(self._module_checkpoint_dir).last_epoch
+            last_epoch = self.load_checkpoint(
+                self._module_checkpoint_dir, model=self.model_autoencoder).last_epoch
         else:
             last_epoch = 0
 
@@ -264,6 +265,8 @@ class AutoencoderTrainer(IgcModule):
 
             # save best checkpoint
             if self.is_rank_zero() and epoch % 20 == 0:
-                self.save_checkpoint(self._module_checkpoint_dir, epoch + 1)
+                self.save_checkpoint(
+                    self._module_checkpoint_dir, epoch + 1,
+                    model=self.model_autoencoder, optimizer=self.optimizer)
 
-        self.save_model(self._module_checkpoint_dir)
+        self.save_model(self._module_checkpoint_dir, model=self.model_autoencoder)

--- a/tests/modules/test_autoencoder_saves_itself.py
+++ b/tests/modules/test_autoencoder_saves_itself.py
@@ -1,0 +1,73 @@
+"""Regression: the autoencoder trainer checkpoints the model it trains.
+
+``AutoencoderTrainer``'s ``self.model`` is the FROZEN backbone; the trained
+network is ``self.model_autoencoder``. The base save/load hardwired
+``self.model``, so a full run wrote the untouched backbone and downstream RL
+loaded an untrained autoencoder. The base now accepts an optional target model;
+these pin that save_model/save_checkpoint/load_checkpoint persist and restore
+the passed model, not self.model. CPU-only.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import argparse
+
+import loguru
+import torch
+
+from igc.modules.base.igc_base_module import IgcModule
+
+
+def _module(tmp_path):
+    m = IgcModule.__new__(IgcModule)
+    m.rank = 0
+    m.module_name = "state_autoencoder"
+    m.logger = loguru.logger
+    m.model = torch.nn.Linear(4, 4)          # stand-in frozen backbone
+    m.optimizer = None
+    m.scheduler = None
+    m._trainer_args = argparse.Namespace(seed=1, output_dir=str(tmp_path))
+    m._module_checkpoint_dir = str(tmp_path)
+    return m
+
+
+def _distinct_autoencoder():
+    ae = torch.nn.Linear(4, 4)
+    with torch.no_grad():
+        ae.weight.fill_(7.0)  # a value the backbone never has
+    return ae
+
+
+def test_save_model_persists_the_passed_model(tmp_path):
+    """save_model(model=ae) writes the autoencoder weights, not the backbone."""
+    m = _module(tmp_path)
+    ae = _distinct_autoencoder()
+    m.save_model(str(tmp_path), model=ae)
+    saved = torch.load(m._model_file(str(tmp_path)), weights_only=True)
+    assert torch.equal(saved["model_state_dict"]["weight"], ae.weight)
+
+
+def test_save_and_load_checkpoint_round_trip_targets_model(tmp_path):
+    """save_checkpoint(model=ae) then load_checkpoint(model=ae2) restores ae."""
+    m = _module(tmp_path)
+    ae = _distinct_autoencoder()
+    m.optimizer = torch.optim.SGD(ae.parameters(), lr=0.1)
+    m.save_checkpoint(str(tmp_path), epoch=1, model=ae, optimizer=m.optimizer)
+
+    fresh = torch.nn.Linear(4, 4)
+    m.load_checkpoint(str(tmp_path), model=fresh)
+    assert torch.equal(fresh.weight, ae.weight)
+    # the frozen backbone was never overwritten by the restore
+    assert not torch.equal(m.model.weight, ae.weight)
+
+
+def test_default_still_targets_self_model(tmp_path):
+    """Without model=, behavior is unchanged (saves/loads self.model)."""
+    m = _module(tmp_path)
+    m.save_model(str(tmp_path))
+    saved = torch.load(m._model_file(str(tmp_path)), weights_only=True)
+    assert torch.equal(saved["model_state_dict"]["weight"], m.model.weight)
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
Found by inspecting the first successful R2 checkpoint: the autoencoder stage exited clean and wrote state_autoencoder_epoch_1.pt — but it contained the frozen backbone, not the trained autoencoder (audit B3, still live). self.model is the backbone; self.model_autoencoder is trained. Base save_model/save_checkpoint/load_checkpoint gain an optional target-model param (defaults to self.model — no behavior change elsewhere) and the autoencoder trainer now saves/loads self.model_autoencoder. Round-trip regression pins that a distinct model is persisted and restored, and that self.model is untouched. Gate: 569 passed (pipefail).