### PR TITLE
Push large artifacts from a node to LFS (no VPN bulk); document Docker Hub flow

### DIFF
--- a/docs/NODE_ARTIFACTS.md
+++ b/docs/NODE_ARTIFACTS.md
@@ -1,0 +1,70 @@
+# Node artifacts: LFS push from a slot, and Docker Hub images
+
+How to move large artifacts (captured corpora, built datasets, tarballs, images) **without
+dragging multi-GB data across the shared VPN**. The rule: data that is generated on a training
+node is pushed *from* that node over its own datacenter uplink — never pulled to a laptop and
+pushed from there (a multi-GB transfer over the VPN has saturated the shared tunnel and blocked
+SSH for everyone).
+
+## Push large LFS artifacts from a slot
+
+`scripts/lfs_push_from_slot.sh` commits an artifact on a `data/<name>` branch and uploads its
+git-LFS objects to the remote from the node. Run it **on the slot**, inside the repo whose
+`.gitattributes` tracks that file type (the `igc` checkout, or the data-collection submodule for
+capture corpora).
+
+```bash
+# on the slot, in the repo checkout
+scripts/lfs_push_from_slot.sh ~/.json_responses/<host>          # push a captured host walk
+scripts/lfs_push_from_slot.sh datasets/raw/processed_dataset.pt # push a built dataset
+```
+
+It:
+
+1. verifies the artifact is matched by an LFS filter (warns if `.gitattributes` won't catch it —
+   add the pattern via a PR first, so the file lands as an LFS object, not a huge git blob);
+2. creates a `data/<basename>-<UTC>` branch, stages **only** the given paths (never `git add -A`),
+   commits, `git lfs push`es the objects, and pushes the branch;
+3. prints the **PR URL** — integration is PR-only, so the artifact branch is reviewed and merged
+   like any other change; the script never pushes `main`.
+
+### git-lfs on the slot — no OS modification
+
+By default the script fails if `git-lfs` is missing rather than touch the host. Two
+non-destructive opt-ins:
+
+```bash
+IGC_LFS_INSTALL=apt    scripts/lfs_push_from_slot.sh <path>   # minimal: apt-get install
+                                                              # --no-install-recommends git-lfs
+                                                              # (adds one package, no OS upgrade)
+IGC_LFS_INSTALL=docker scripts/lfs_push_from_slot.sh <path>   # git-lfs from a container; the
+                                                              # host OS is never modified
+```
+
+The `docker` path runs git-lfs in a container with the repo and your git config/credentials mounted
+read-only, so nothing is installed on the node.
+
+### Credentials (one-time, operator)
+
+The push uses the node's existing git auth — set up once, then reused:
+
+- **SSH deploy key** (recommended): generate a key on the node (`ssh-keygen -t ed25519`), add the
+  public key as a repo deploy key with write access, and use the `git@github.com:` remote.
+- **Personal access token**: a fine-grained PAT with `contents:write`, stored via
+  `git config --global credential.helper store` on the node, with the `https://` remote.
+
+Never commit or print a key/token; keep node-specific host/key details in the gitignored team
+guide, not in this file.
+
+## Docker Hub images
+
+The CI `docker` job (`.github/workflows/ci.yml`) builds `docker/Dockerfile.test`, smoke-runs the
+gate inside it, and — on pushes to `main` — pushes the image to Docker Hub when the repo secrets
+`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (a Docker Hub access token) are configured. Without the
+secrets the job still builds and tests; only the push is skipped.
+
+Locally or from a node:
+
+```bash
+DOCKER_REPO=youruser/igc-test make docker-push   # build docker/Dockerfile.test and push
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,8 @@ Reinforce Learner).
   what we optimized (with numbers), and the budget tripwire that guards it.
 - [HOW_TO_PROFILE.md](HOW_TO_PROFILE.md) — the one-command way to measure hot paths, find the
   critical section, and prove a change is faster; how CI runs it.
+- [NODE_ARTIFACTS.md](NODE_ARTIFACTS.md) — pushing large LFS artifacts from a training node over
+  its own uplink (never the VPN), git-lfs without OS changes, and the Docker Hub image flow.
 - [TRAINING_OPTIMIZATION_PLAN.md](TRAINING_OPTIMIZATION_PLAN.md) — the large-model training,
   optimization, and GPU-efficiency roadmap for 3B/7B state-encoder work.
 

--- a/scripts/lfs_push_from_slot.sh
+++ b/scripts/lfs_push_from_slot.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# lfs_push_from_slot.sh — push large artifacts (captured corpora, built datasets, tarballs)
+# from a GB300 slot DIRECTLY to the git-LFS remote over the node's own uplink, so the data
+# never crosses the shared VPN. Only the operator has GB300 access; run this ON the slot.
+#
+# WHY: pulling a multi-GB artifact to the laptop and pushing it from there moves the data over
+# the VPN twice and has saturated the shared tunnel before. `git lfs push` from the node uploads
+# LFS objects to the remote's LFS store over the datacenter uplink instead.
+#
+# PR-ONLY: integration is PR-only, so this pushes a `data/<name>` BRANCH and prints the PR URL.
+# It never pushes `main`.
+#
+# NO OS MODIFICATION by default. If git-lfs is missing, this exits with guidance. To auto-install
+# it non-destructively, opt in with IGC_LFS_INSTALL=apt (runs the minimal
+# `apt-get install -y --no-install-recommends git-lfs` — adds one package, no upgrade/remove) or
+# IGC_LFS_INSTALL=docker (runs git-lfs from a container, host untouched — see the docker note).
+#
+# Usage:
+#   scripts/lfs_push_from_slot.sh <artifact_path> [more_paths...]
+# Env:
+#   IGC_BRANCH=data/<auto>     branch to push (default data/<basename>-<UTC stamp>)
+#   IGC_REMOTE=origin          git remote to push to
+#   IGC_LFS_INSTALL=           unset (default: fail if git-lfs missing) | apt | docker
+#   IGC_COMMIT_MSG="..."       commit subject (default: "Add data artifact <name>")
+#   IGC_YES=1                  skip the confirmation prompt
+set -euo pipefail
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+note() { echo ">> $*"; }
+
+[ "$#" -ge 1 ] || die "usage: $0 <artifact_path> [more_paths...]"
+
+REMOTE="${IGC_REMOTE:-origin}"
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "not inside a git repository"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Guard: never operate on a detached/main checkout in a way that could push main.
+CUR_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+[ "$CUR_BRANCH" = "main" ] || note "current branch is '$CUR_BRANCH' (a data/* branch will be created)"
+
+# 1. Ensure git-lfs is available (no OS change unless opted in).
+ensure_lfs() {
+  if git lfs version >/dev/null 2>&1; then
+    LFS_RUN=(git lfs)
+    return
+  fi
+  case "${IGC_LFS_INSTALL:-}" in
+    apt)
+      note "installing git-lfs via apt (--no-install-recommends; one package, no OS upgrade)"
+      sudo apt-get update -qq
+      sudo apt-get install -y --no-install-recommends git-lfs
+      git lfs install --local
+      LFS_RUN=(git lfs)
+      ;;
+    docker)
+      command -v docker >/dev/null 2>&1 || die "IGC_LFS_INSTALL=docker but docker is not available"
+      note "using git-lfs from a container (host OS untouched)"
+      # host repo + git config mounted so credentials/remotes resolve inside the container.
+      LFS_RUN=(docker run --rm -v "$REPO_ROOT:/repo" -v "$HOME/.gitconfig:/root/.gitconfig:ro"
+               -v "$HOME/.git-credentials:/root/.git-credentials:ro" -w /repo
+               ghcr.io/git-lfs/git-lfs:latest)
+      ;;
+    *)
+      die "git-lfs not found. Install it non-destructively and retry:
+       IGC_LFS_INSTALL=apt    $0 $*     # minimal apt (--no-install-recommends)
+       IGC_LFS_INSTALL=docker $0 $*     # containerized git-lfs, host untouched
+     or install git-lfs once yourself, then rerun."
+      ;;
+  esac
+}
+ensure_lfs "$@"
+
+# 2. Verify each artifact exists and is LFS-tracked (warn if .gitattributes won't catch it).
+for path in "$@"; do
+  [ -e "$path" ] || die "no such artifact: $path"
+  if ! git check-attr filter -- "$path" 2>/dev/null | grep -q 'filter: lfs'; then
+    note "WARNING: '$path' is not matched by an LFS filter in .gitattributes — it would commit as
+       a normal (large) git object. Add a pattern to .gitattributes first (via PR), e.g.
+       '$(basename "$path" | sed 's/^[^.]*//')' or the exact path, then rerun."
+  fi
+done
+
+# 3. Confirm the push (large, outbound).
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+BASENAME="$(basename "${1%/}")"
+BRANCH="${IGC_BRANCH:-data/${BASENAME}-${STAMP}}"
+TOTAL="$(du -sh "$@" 2>/dev/null | awk '{s=$1} END{print s}')"
+note "about to push $# artifact(s) (~${TOTAL:-?}) as LFS objects to ${REMOTE} on branch ${BRANCH}"
+if [ "${IGC_YES:-}" != "1" ]; then
+  read -r -p "proceed? [y/N] " reply
+  [ "$reply" = "y" ] || [ "$reply" = "Y" ] || die "aborted"
+fi
+
+# 4. Branch, stage explicitly, commit, LFS-push, push. Never `git add -A`.
+git switch -c "$BRANCH"
+git add -- "$@"
+git commit -m "${IGC_COMMIT_MSG:-Add data artifact ${BASENAME}}"
+note "uploading LFS objects to ${REMOTE} over the node uplink..."
+"${LFS_RUN[@]}" push "${REMOTE}" "${BRANCH}"
+git push -u "${REMOTE}" "${BRANCH}"
+
+# 5. Print the PR URL (PR-only integration).
+URL="$(git remote get-url "${REMOTE}")"
+SLUG="$(printf '%s' "$URL" | sed -E 's#(git@github.com:|https://github.com/)##; s#\.git$##')"
+note "pushed. Open a PR to integrate:"
+echo "   https://github.com/${SLUG}/compare/${BRANCH}?expand=1"


### PR DESCRIPTION
Completes the infra requested: move large data from a GB300 slot to the LFS remote without dragging it across the shared VPN, plus the Docker Hub image path.

## `scripts/lfs_push_from_slot.sh`
Run on the slot: commits an artifact on a `data/<name>` branch and `git lfs push`es its objects to the remote over the **node's uplink**, so the multi-GB data never crosses the VPN. PR-only — pushes a branch and prints the compare URL, never `main`; stages only the given paths.

- **No OS modification by default.** git-lfs missing → fails with guidance. Opt in non-destructively: `IGC_LFS_INSTALL=apt` (minimal `apt-get install -y --no-install-recommends git-lfs` — one package, no OS upgrade) or `IGC_LFS_INSTALL=docker` (containerized git-lfs, host untouched).
- Warns if `.gitattributes` would not track the artifact as an LFS object (so it doesn't land as a giant git blob).
- Credentials use the node's existing git auth (SSH deploy key or PAT) — documented, one-time, operator-owned; never printed or committed.

## `docs/NODE_ARTIFACTS.md`
Public-safe: the no-bulk-over-VPN rule, the push workflow, the git-lfs options, credential setup, and the Docker Hub flow (CI `docker` job + `make docker-push`). Node-specific host/key detail stays in the gitignored team guide.

**Not tested end-to-end from here** (no GB300 access — the operator runs it on the slot). shellcheck clean, bash syntax valid, arg/guard paths exercised locally; doc links resolve.