### PR TITLE
Track tests, coverage, and hot-path timings per commit for over-time comparison

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,26 @@ jobs:
           pip install ruff
       - name: Lint
         run: ruff check igc tests
-      - name: Offline gate
+      - name: Offline gate with coverage
         shell: bash
         run: |
           set -o pipefail
-          KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1 pytest -q
+          KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1 \
+            pytest -q --cov=igc --cov-report=term --cov-report=xml --cov-report=json
+      - name: Metrics snapshot
+        shell: bash
+        run: |
+          python scripts/metrics_snapshot.py --coverage-json coverage.json --out metrics.json | tee -a "$GITHUB_STEP_SUMMARY"
+      - name: Upload coverage and metrics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: metrics-${{ github.sha }}
+          path: |
+            coverage.xml
+            coverage.json
+            metrics.json
+          retention-days: 90
 
   perf:
     needs: gate

--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,8 @@ docs/internal/
 # Slurm job logs (training output) — never commit
 *.out
 slurm-*.out
+
+# generated metrics/coverage reports (CI artifacts, not committed)
+coverage.json
+coverage.xml
+metrics.json

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON ?= python3
 
-.PHONY: help gate test lint perf profile profile-rl docker-test docker-push clean
+.PHONY: help gate test lint perf coverage metrics profile profile-rl docker-test docker-push clean
 
 help: ## List available targets and their descriptions
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-16s %s\n", $$1, $$2}'
@@ -15,6 +15,12 @@ lint: ## Run the ruff linter over igc and tests
 
 perf: ## Run the performance budget tripwires (pytest -m perf)
 	KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 $(PYTHON) -m pytest -m perf -q
+
+coverage: ## Run the offline gate with coverage (term + coverage.xml + coverage.json)
+	KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1 $(PYTHON) -m pytest -q --cov=igc --cov-report=term --cov-report=xml --cov-report=json
+
+metrics: coverage ## Write a per-commit metrics snapshot (tests + coverage + hot-path timings) to metrics.json
+	$(PYTHON) scripts/metrics_snapshot.py --coverage-json coverage.json --out metrics.json
 
 profile: ## Profile all hot paths with cProfile critical sections
 	$(PYTHON) scripts/bench_hot_paths.py --profile

--- a/docker/requirements-test.txt
+++ b/docker/requirements-test.txt
@@ -31,3 +31,7 @@ evaluate
 # dev / test
 pytest
 ruff
+
+# coverage reporting for the gate + metrics snapshot
+pytest-cov
+coverage

--- a/docs/HOW_TO_PROFILE.md
+++ b/docs/HOW_TO_PROFILE.md
@@ -77,6 +77,25 @@ make docker-test   # build the CPU test image and run pytest inside it
 
 So profiling is not a thing someone remembers to do — the budgets are part of the merge gate.
 
+## Comparing over time (tests, coverage, hot-path timings)
+
+Because the codebase keeps growing, each CI run archives a **per-commit snapshot** so any two
+points in history can be diffed instead of re-derived:
+
+- The `gate` job runs the suite **with coverage** (`--cov=igc`, producing `coverage.xml` /
+  `coverage.json`), then `scripts/metrics_snapshot.py` writes `metrics.json` —
+  `{commit, num_tests, coverage_pct, hot_paths_sec}` — and echoes a table into the run's
+  **summary page**. All three are uploaded as the `metrics-<sha>` artifact (90-day retention).
+- So "did coverage drop or a hot path get slower since last week?" is: download the two runs'
+  `metrics.json` and diff them.
+
+Locally:
+
+```bash
+make coverage   # run the gate with coverage (term + coverage.xml + coverage.json)
+make metrics    # coverage + write metrics.json and print the summary table
+```
+
 ## Workflow for a performance change
 
 1. `python scripts/bench_hot_paths.py --profile` → record the before number and the dominant

--- a/scripts/metrics_snapshot.py
+++ b/scripts/metrics_snapshot.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Emit a machine-readable metrics snapshot for the current commit.
+
+Records what is easy to forget across a fast-moving history: how many tests exist, the line
+coverage, and the hot-path timings — one JSON object per commit that any two points in time
+can be diffed. CI writes one snapshot per run (uploaded as an artifact and echoed into the
+run summary), so "has coverage dropped / did a hot path get slower since last week?" is a
+`git`-and-`diff` question, not an archaeology dig.
+
+Used by: ``.github/workflows/ci.yml`` (the gate job) runs it after the coverage pass and
+uploads ``metrics.json``; ``make metrics`` runs it locally. It shells out to ``pytest --co``
+for the test count and to ``scripts/bench_hot_paths.py --section rl`` for timings, and reads
+a ``coverage.json`` (from ``pytest --cov-report=json``) for the coverage percent.
+
+Usage:
+    python scripts/metrics_snapshot.py [--coverage-json coverage.json] [--out metrics.json]
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import Dict, Optional
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _git(*args: str) -> str:
+    """Return the stripped stdout of a git command, or ``""`` on failure."""
+    try:
+        return subprocess.check_output(["git", *args], cwd=_REPO_ROOT).decode().strip()
+    except (subprocess.CalledProcessError, OSError):
+        return ""
+
+
+def parse_collected(pytest_co_output: str) -> int:
+    """Parse the test count from ``pytest --co -q`` output.
+
+    :param pytest_co_output: stdout of a collect-only run.
+    :return: number of collected tests (0 if not found).
+    """
+    match = re.search(r"(\d+)\s+tests?\s+collected", pytest_co_output)
+    if match:
+        return int(match.group(1))
+    return sum(1 for line in pytest_co_output.splitlines() if "::" in line)
+
+
+def parse_bench_table(bench_output: str) -> Dict[str, float]:
+    """Parse ``stage  seconds`` rows from a bench_hot_paths.py table.
+
+    :param bench_output: stdout of the benchmark harness.
+    :return: mapping of stage label to seconds.
+    """
+    timings: Dict[str, float] = {}
+    for line in bench_output.splitlines():
+        match = re.match(r"^(.*?\S)\s+(\d+\.\d+)\s*$", line)
+        if match and match.group(1).lower() not in ("stage",):
+            timings[match.group(1).strip()] = float(match.group(2))
+    return timings
+
+
+def read_coverage(coverage_json_path: Optional[str]) -> Optional[float]:
+    """Read the total line-coverage percent from a ``coverage.json`` report.
+
+    :param coverage_json_path: path to ``pytest --cov-report=json`` output, or ``None``.
+    :return: percent covered rounded to 2 dp, or ``None`` when unavailable.
+    """
+    if not coverage_json_path or not os.path.isfile(coverage_json_path):
+        return None
+    data = json.load(open(coverage_json_path))
+    return round(data.get("totals", {}).get("percent_covered", 0.0), 2)
+
+
+def _run(cmd) -> str:
+    """Run a command from the repo root and return combined stdout (best effort).
+
+    Puts the repo root on ``PYTHONPATH`` so a plain ``python scripts/...`` child can import
+    ``igc`` (running a script by path does not add the repo root to ``sys.path``).
+    """
+    env = {**os.environ, "KMP_DUPLICATE_LIB_OK": "TRUE", "OMP_NUM_THREADS": "1",
+           "PYTHONPATH": _REPO_ROOT + os.pathsep + os.environ.get("PYTHONPATH", "")}
+    result = subprocess.run(cmd, cwd=_REPO_ROOT, capture_output=True, text=True, env=env)
+    return result.stdout + result.stderr
+
+
+def build_snapshot(coverage_json_path: Optional[str]) -> Dict:
+    """Assemble the metrics snapshot for the current commit.
+
+    :param coverage_json_path: optional ``coverage.json`` path for the coverage percent.
+    :return: the snapshot dict.
+    """
+    collected = _run([sys.executable, "-m", "pytest", "--co", "-q"])
+    bench = _run([sys.executable, "scripts/bench_hot_paths.py", "--section", "rl"])
+    return {
+        "commit": _git("rev-parse", "HEAD"),
+        "commit_short": _git("rev-parse", "--short", "HEAD"),
+        "commit_date": _git("show", "-s", "--format=%cI", "HEAD"),
+        "num_tests": parse_collected(collected),
+        "coverage_pct": read_coverage(coverage_json_path),
+        "hot_paths_sec": parse_bench_table(bench),
+    }
+
+
+def to_markdown(snapshot: Dict) -> str:
+    """Render a snapshot as a short markdown summary (for the CI run summary).
+
+    :param snapshot: a snapshot dict from :func:`build_snapshot`.
+    :return: markdown string.
+    """
+    lines = [
+        f"### Metrics @ `{snapshot['commit_short']}`",
+        "",
+        f"- tests: **{snapshot['num_tests']}**",
+        f"- coverage: **{snapshot['coverage_pct']}%**" if snapshot["coverage_pct"] is not None
+        else "- coverage: (not measured)",
+        "",
+        "| hot path | seconds |",
+        "|---|---|",
+    ]
+    for stage, seconds in snapshot["hot_paths_sec"].items():
+        lines.append(f"| {stage} | {seconds:.4f} |")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """CLI: build the snapshot, write JSON, print the markdown summary."""
+    parser = argparse.ArgumentParser(description="Emit a per-commit metrics snapshot.")
+    parser.add_argument("--coverage-json", default="coverage.json")
+    parser.add_argument("--out", default="metrics.json")
+    args = parser.parse_args()
+
+    snapshot = build_snapshot(args.coverage_json)
+    with open(args.out, "w") as handle:
+        json.dump(snapshot, handle, indent=2, sort_keys=True)
+    print(to_markdown(snapshot))
+
+
+if __name__ == "__main__":
+    main()
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/test_metrics_snapshot.py
+++ b/tests/test_metrics_snapshot.py
@@ -1,0 +1,68 @@
+"""
+Offline tests for the metrics-snapshot parsers.
+
+Pins the pure parsers that turn tool output into a comparable snapshot: the pytest collected
+count, the bench_hot_paths timing table, the coverage.json percent, and the markdown summary.
+The subprocess-driving build is exercised in CI, not here. Pure stdlib + tmp_path.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import json
+from pathlib import Path
+
+from scripts.metrics_snapshot import (
+    parse_bench_table,
+    parse_collected,
+    read_coverage,
+    to_markdown,
+)
+
+
+def test_parse_collected_from_summary():
+    """The '<n> tests collected' summary line is parsed."""
+    assert parse_collected("igc/x.py::test_a\n\n566 tests collected in 1.2s\n") == 566
+
+
+def test_parse_collected_falls_back_to_node_ids():
+    """Without a summary line, count lines carrying a '::' node id."""
+    out = "tests/a.py::test_one\ntests/a.py::test_two\nnoise\n"
+    assert parse_collected(out) == 2
+
+
+def test_parse_bench_table():
+    """Only 'label  seconds' rows are parsed; the header is ignored."""
+    out = ("corpus=synthetic\nstage                     seconds\n"
+           "q_learning_target [B,N]   0.0003\n"
+           "pointer forward, naive    0.1926\n")
+    table = parse_bench_table(out)
+    assert table["q_learning_target [B,N]"] == 0.0003
+    assert table["pointer forward, naive"] == 0.1926
+    assert "stage" not in table
+
+
+def test_read_coverage(tmp_path: Path):
+    """Coverage percent comes from totals.percent_covered, rounded; None when absent."""
+    path = tmp_path / "coverage.json"
+    path.write_text(json.dumps({"totals": {"percent_covered": 47.5137}}))
+    assert read_coverage(str(path)) == 47.51
+    assert read_coverage(str(tmp_path / "missing.json")) is None
+    assert read_coverage(None) is None
+
+
+def test_to_markdown_includes_tests_coverage_and_paths():
+    """The summary shows the commit, test count, coverage, and each hot-path row."""
+    md = to_markdown({"commit_short": "abc1234", "num_tests": 566, "coverage_pct": 47.5,
+                      "hot_paths_sec": {"neighbors": 0.001}})
+    assert "abc1234" in md and "566" in md and "47.5%" in md and "neighbors" in md
+
+
+def test_to_markdown_handles_missing_coverage():
+    """A snapshot without coverage renders without crashing."""
+    md = to_markdown({"commit_short": "abc1234", "num_tests": 10, "coverage_pct": None,
+                      "hot_paths_sec": {}})
+    assert "not measured" in md
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
So the growing codebase can be compared across history instead of re-derived each time.

- **scripts/metrics_snapshot.py** — emits `{commit, num_tests, coverage_pct, hot_paths_sec}` as `metrics.json`, plus a markdown summary. Pure parsers unit-tested (6 tests); the subprocess build runs in CI. (Fixed a real bug on first run: the bench child couldn't `import igc` without repo root on `PYTHONPATH`.)
- **CI gate** now runs `pytest --cov=igc` (term + xml + json), writes the snapshot, echoes the table into the run **summary page**, and uploads `coverage.xml` + `coverage.json` + `metrics.json` as the `metrics-<sha>` artifact (90-day retention). "Did coverage drop / a hot path get slower since last week?" = diff two runs' `metrics.json`.
- **make coverage** / **make metrics** for the same locally; documented in HOW_TO_PROFILE.md. Generated reports gitignored.

Sample snapshot (RL section) on this branch: 596 tests collected, 8 hot-path timings incl. the D-002 51× win visible (naive 0.247s vs cached 0.007s).

Gate: full offline suite 575 passed / 0 failed; ruff clean; CI YAML actionlint-clean.