### PR TITLE
Docstrings: say where each module is used and why (reviewer test)

### DIFF
--- a/igc/ds/corpus_dataset.py
+++ b/igc/ds/corpus_dataset.py
@@ -12,6 +12,11 @@ The class duck-types the surface the trainer touches on ``MaskedJSONDataset``:
 ``tokenizer``/``load_tokenizer`` plus the masking-method hooks, which are no-ops here
 because a written corpus trains the plain causal-LM (NO_MASK) objective.
 
+Used by ``IgcMain.dataset`` (``igc/modules/igc_main.py``): when the ``--corpus_dir`` CLI flag
+is set, a run loads this class instead of rebuilding ``MaskedJSONDataset`` from
+``~/.json_responses``, so it trains on the pre-written trust-tier corpus. The trainer also
+reads ``run_manifest_fields`` to stamp the corpus hash / eval split into the run report.
+
 Author:
 Mus mbayramo@stanford.edu
 """

--- a/igc/ds/sources/candidate_features.py
+++ b/igc/ds/sources/candidate_features.py
@@ -1,6 +1,11 @@
 """
 D-002 v1 action-candidate featurizer with a static per-host cache.
 
+Used by ``scripts/bench_hot_paths.py`` (the candidate-cache benchmark stage), feeding
+``igc/modules/eval/zero_shot_ranking.py``. The candidate dict emitted here is a schema
+contract with that ranker's ``candidate_text`` / ``embed_candidates`` — renaming a field
+silently breaks ranking.
+
 Turns graph nodes into the accepted candidate schema — path tokens, HTTP method, resource
 type, child-relation name, action-target flag — for the D-001 pointer. Per D-002, every
 field is static per host: the cache is built once from the walked tree and only *filtered*

--- a/igc/ds/sources/corpus_io.py
+++ b/igc/ds/sources/corpus_io.py
@@ -5,6 +5,11 @@ Writes :class:`TrainingExample` objects as JSONL (one ``to_dict()`` per line) wi
 :class:`DataManifest` sidecar, and reads them back as dicts. Offline only — this is the seam
 between the source/mixer/normalizer pipeline and a training run that consumes a fixed corpus.
 
+The read side (``iter_examples`` / ``read_manifest``) is used by ``CorpusJSONLDataset.__init__``
+(``igc/ds/corpus_dataset.py``), which ``IgcMain`` instantiates when ``--corpus_dir`` is set — so
+a run loads this corpus instead of rebuilding from raw captures. The write side is exercised by
+the data-build pipeline and its tests.
+
 Author:
 Mus mbayramo@stanford.edu
 """

--- a/igc/ds/sources/mixer.py
+++ b/igc/ds/sources/mixer.py
@@ -9,6 +9,11 @@ a stable hash of each resource URL rather than an RNG — so it reproduces acros
 stable as the corpus grows, and a serializable :class:`DataManifest` records the mix (for the
 training run manifest and as a fair-comparison key).
 
+The ``DataManifest`` produced here is serialized by ``corpus_io.write_corpus`` as the
+``manifest.json`` sidecar and read back by ``CorpusJSONLDataset.run_manifest_fields``
+(``igc/ds/corpus_dataset.py``) to stamp each run report's ``data_manifest`` / ``eval_split``
+fair-comparison keys — reached in production when ``--corpus_dir`` is set.
+
 Author:
 Mus mbayramo@stanford.edu
 """

--- a/igc/ds/sources/resource_graph.py
+++ b/igc/ds/sources/resource_graph.py
@@ -9,6 +9,11 @@ node carries the D-002 structural fields: resource type (from ``@odata.type``), 
 child-relation name by which it is reachable, and whether its body exposes an invokable
 action target. The graph is static per host and safe to build from a partial crawl.
 
+Used by ``candidate_features.build_candidate_cache``, which walks ``graph.nodes`` to emit the
+static per-host candidate cache, and by ``scripts/bench_hot_paths.py`` as a benchmarked
+hot-path stage. Without this typed tree the D-002 candidate cache — and the D-001 ranking
+that filters it — cannot be built.
+
 Author:
 Mus mbayramo@stanford.edu
 """

--- a/igc/ds/sources/training_object.py
+++ b/igc/ds/sources/training_object.py
@@ -6,6 +6,11 @@ Each SourceRecord carries a full Redfish response body, provenance metadata, and
 This module compacts the resource representation for the state graph, constructs the
 (state, action, next_state, semantics) tuple, and preserves provenance end-to-end.
 
+Consumers live inside ``igc.ds.sources``, not the model code: ``corpus_io.write_corpus``
+serializes each ``TrainingExample.to_dict()`` to ``examples.jsonl``, and
+``redfish_enum_space.normalize_enriched`` calls ``normalize_record``. That corpus reaches M1
+training one hop downstream via ``CorpusJSONLDataset`` (the ``--corpus_dir`` path).
+
 Author:
 Mus mbayramo@stanford.edu
 """

--- a/igc/modules/eval/zero_shot_ranking.py
+++ b/igc/modules/eval/zero_shot_ranking.py
@@ -8,6 +8,11 @@ graph neighbors (the walked tree's real transitions) appear in the top-k. No tra
 torch, no randomness — numpy and the standard library only. Go/no-go per D-001: top-5 hit
 rate >= 0.80 on a held-out vendor.
 
+Not wired into any training or eval runtime: consumed only by ``scripts/bench_hot_paths.py``
+(the embed + rank benchmark stages) and its unit/perf tests. This is a standalone one-off
+feasibility gate whose >= 0.80 top-5 number decides whether a zero-cost frozen encoder can
+recover true Redfish transitions before the D-001/D-002 ranking head is built.
+
 Author:
 Mus mbayramo@stanford.edu
 """

--- a/igc/modules/train/emit.py
+++ b/igc/modules/train/emit.py
@@ -1,6 +1,11 @@
 """
 Run-report emission: turn a finished training run into a ResultBundle on disk.
 
+Called only from ``LlmEmbeddingsTrainer._train`` (``igc/modules/llm_train_state_encoder.py``)
+at end of run, on rank zero, inside a broad try/except so a report failure only warns and
+never fails a finished training run. It exists so every run leaves a machine-readable
+``report.json`` for the comparison tooling.
+
 The trainer calls :func:`build_run_bundle` with its parsed spec and end-of-run stats,
 then :func:`emit_run_report` writes ``report.json`` into the run's output directory —
 making every run self-describing (model, adapter, data manifest, environment, final


### PR DESCRIPTION
Fixes the reviewer gap flagged on `corpus_dataset.py` (and 7 sibling modules): the docstrings explained *what* the code does but not *where it is used* or *why it exists*, so a reviewer had to read the whole codebase to place the file.

A grep-verified doc-critic pass over all 8 new modules found every one `missing_where`. Each now carries a concise (2-4 line) **Used by** block naming the concrete consumer — file + function + trigger:

- `corpus_dataset.py` → `IgcMain.dataset` when `--corpus_dir` is set
- `resource_graph.py` / `candidate_features.py` → the D-002 cache + `bench_hot_paths.py`
- `zero_shot_ranking.py` → flagged as an **offline-only feasibility gate**, not wired into runtime
- `emit.py` → `_train` end-of-run, on rank zero, in a try/except
- `mixer.py` / `corpus_io.py` / `training_object.py` → the corpus-write/read path to `--corpus_dir`

The critic also caught that `training_object.py` **misstated** its consumers ("the model code") — corrected to the real `igc.ds.sources` pipeline.

Docs-only change (no behavior). ruff clean on all 8; ds/eval/train tests pass.