### PR TITLE
Move resumed optimizer state to the trainer device

### DIFF
--- a/igc/modules/base/igc_base_module.py
+++ b/igc/modules/base/igc_base_module.py
@@ -30,6 +30,7 @@ from ...ds import ds_utils as igc_util
 from ...ds.redfish_dataset import JSONDataset
 from ...modules.base.igc_abstract_logger import AbstractLogger
 from ...shared.modules_typing import SaveStrategy
+from ...shared.shared_torch_utils import move_optimizer_state_to_device
 
 BatchItem = namedtuple('BatchItem', ['prompt', 'goal'])
 
@@ -725,6 +726,9 @@ class IgcModule(IgcBaseState):
                     warnings.warn("Optimizer does not have load_state_dict method. ")
                     return CheckpointState(0, None, 0, float('-inf'), 0)
                 self.optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
+                # relocate the resumed momentum buffers to the trainer device so the
+                # first step() does not mix cpu state with cuda params (fused Adam).
+                move_optimizer_state_to_device(self.optimizer, self.device)
 
                 if lr is not None:
                     self.logger.info(f"Resting learning rate to {lr}")

--- a/igc/shared/shared_torch_utils.py
+++ b/igc/shared/shared_torch_utils.py
@@ -447,3 +447,21 @@ def stack_tensors(list_of_tensor_iterators: List) -> Tuple[torch.Tensor]:
     :return:
     """
     return tuple(torch.stack(tensors, 0) for tensors in zip(*list_of_tensor_iterators))
+
+
+def move_optimizer_state_to_device(optimizer, device) -> None:
+    """Move an optimizer's per-parameter state tensors onto ``device`` in place.
+
+    A resumed optimizer loads its momentum/variance buffers on whatever device
+    the checkpoint was mapped to (cpu by default), while the model params sit on
+    the training device — so the first ``optimizer.step()`` mixes cpu and cuda
+    tensors (fused Adam raises a device-mismatch RuntimeError). Call this after
+    ``load_state_dict`` + the model is on its device.
+
+    :param optimizer: the optimizer whose state should be relocated.
+    :param device: the target device (the trainer's device).
+    """
+    for state in optimizer.state.values():
+        for key, value in state.items():
+            if isinstance(value, torch.Tensor):
+                state[key] = value.to(device)

--- a/tests/shared/test_optimizer_device_move.py
+++ b/tests/shared/test_optimizer_device_move.py
@@ -1,0 +1,47 @@
+"""Offline regression for moving resumed optimizer state across devices.
+
+On resume the optimizer's momentum buffers load on the checkpoint's device
+(cpu) while the model params are on the trainer device, so the first
+``optimizer.step()`` mixes cpu and cuda tensors (fused Adam raises). The
+``meta`` device stands in for a distinct target so the move is verifiable with
+no GPU. CPU-only.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import torch
+
+from igc.shared.shared_torch_utils import move_optimizer_state_to_device
+
+
+def _stepped_optimizer():
+    """An SGD-with-momentum whose state holds a real cpu tensor after a step."""
+    model = torch.nn.Linear(3, 3)
+    opt = torch.optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
+    model(torch.ones(2, 3)).sum().backward()
+    opt.step()  # populates momentum_buffer state tensors
+    return opt
+
+
+def test_state_tensors_move_to_target_device():
+    """Every state tensor is relocated to the requested device."""
+    opt = _stepped_optimizer()
+    assert any(
+        isinstance(v, torch.Tensor) and v.device.type == "cpu"
+        for s in opt.state.values() for v in s.values()
+    )
+
+    move_optimizer_state_to_device(opt, torch.device("meta"))
+
+    for state in opt.state.values():
+        for value in state.values():
+            if isinstance(value, torch.Tensor):
+                assert value.device.type == "meta"
+
+
+def test_no_state_is_a_noop():
+    """A fresh optimizer with no state does not raise."""
+    model = torch.nn.Linear(2, 2)
+    opt = torch.optim.Adam(model.parameters())
+    move_optimizer_state_to_device(opt, torch.device("cpu"))  # must not raise


### PR DESCRIPTION
Found by the R2 resume gate on the GB300: resume detection works (the autoencoder loaded state_autoencoder_epoch_1.pt, epoch 1), but the first optimizer.step() crashed with 'exp_avgs is on cpu, different from other tensors on cuda:0' — load_checkpoint restored Adam's momentum on cpu while params were on cuda. A move_optimizer_state_to_device helper relocates the state right after load_state_dict; meta-device regression pins the move with no GPU. Gate: 571 passed (pipefail); ruff clean (pre-existing pynvml findings untouched).