### PR TITLE
Harden the device property against partial construction

### DIFF
--- a/igc/modules/base/igc_state.py
+++ b/igc/modules/base/igc_state.py
@@ -88,10 +88,12 @@ class IgcBaseState:
         """Return ether cuda or cpu device or accelerator device.
         :return:
         """
-        if self._accelerator:
+        # getattr guards partially-constructed instances (e.g. checkpoint helpers
+        # built via __new__): _accelerator/_device may be unset, and .device must
+        # not itself raise AttributeError.
+        if getattr(self, "_accelerator", None):
             return self.accelerator.device
-        else:
-            return self._device
+        return getattr(self, "_device", None)
 
     def _prepare_checkpoint_dir(self):
         """

--- a/tests/modules/test_igc_state_device.py
+++ b/tests/modules/test_igc_state_device.py
@@ -66,3 +66,10 @@ def test_non_namespace_spec_rejected(tmp_path):
 
 
 # Author: Mus mbayramo@stanford.edu
+
+
+def test_device_property_tolerates_partial_construction():
+    """A __new__-built instance (no _accelerator/_device) does not crash on .device."""
+    obj = IgcBaseState.__new__(IgcBaseState)
+    # neither _accelerator nor _device set — the property must return None, not raise.
+    assert obj.device is None


### PR DESCRIPTION
main went red after two independently-green PRs merged: #43 made load_checkpoint read self.device, whose property accessed self._accelerator unconditionally, and the checkpoint tests build modules via __new__ without it — 5 tests failed. Guard the property with getattr (partial instance returns None instead of raising); +1 regression. Gate: 577 passed (pipefail).