### PR TITLE
Rebuild the tokenizer for the backbone on --recreate_dataset

### DIFF
--- a/igc/ds/redfish_dataset.py
+++ b/igc/ds/redfish_dataset.py
@@ -312,8 +312,13 @@ class JSONDataset(
         """
         self.logger.info(f"Loading tokenizer from {self.tokenizer_dir()}")
         try:
-            # we do this only if tokenizer dir not present, and we are skipping download.
-            if not os.path.exists(self.tokenizer_dir()) and self._skip_download:
+            # Build the igc tokenizer from the current --model_type when the cache is
+            # absent (and offline), OR when rebuilding: --recreate_dataset must retokenize
+            # for the new backbone, otherwise a stale cache (e.g. gpt2) silently wins over
+            # a Qwen/DeepSeek run.
+            build = self._recreate_dataset or (
+                not os.path.exists(self.tokenizer_dir()) and self._skip_download)
+            if build:
                 self.tokenizer = AutoTokenizer.from_pretrained(self._default_tokenize_name)
                 self.logger.info(f"Creating backbone tokenizer: {self.tokenizer.name_or_path}")
                 self._build_tokenizer()
@@ -827,7 +832,8 @@ class JSONDataset(
         except Exception as e:
             self.logger.error(f"Error loading dataset spec: {e}")
         # outside the try so a provenance conflict is NOT swallowed by the log-only except
-        if self.tokenizer is not None:
+        if self.tokenizer is not None and not self._recreate_dataset:
+            # a rebuild supersedes the recorded provenance; only gate prebuilt loads.
             self.check_tokenizer_provenance(
                 tokenizer_spec, len(self.tokenizer), self._default_tokenize_name)
 

--- a/tests/ds/test_tokenizer_provenance.py
+++ b/tests/ds/test_tokenizer_provenance.py
@@ -131,3 +131,46 @@ def test_tarball_check_still_fails_on_real_value_mismatch(tmp_path):
     ds._resources = [("igc.tar.gz", "deadbeef" * 4, "x")]  # wrong but present
     with pytest.raises(DatasetConsistencyError):
         ds._check_tarball_hash()
+
+
+def test_provenance_check_skipped_on_recreate(tmp_path, monkeypatch):
+    """--recreate_dataset bypasses the provenance gate (the rebuild rewrites it)."""
+    import loguru
+    ds = JSONDataset.__new__(JSONDataset)
+    ds.logger = loguru.logger
+    ds._recreate_dataset = True
+    ds._default_tokenize_name = "Qwen/Qwen2.5-3B-Instruct"
+    ds._dataset_root_dir = str(tmp_path)
+    ds._default_dataset_spec = "dataset.json"
+
+    class _Tok:
+        def __len__(self):
+            return 151936
+    ds.tokenizer = _Tok()
+
+    # a gpt2 spec that WOULD mismatch — must not raise because recreate is set
+    (tmp_path / "dataset.json").write_text(
+        '{"mirrors": [], "resources": [], "tokenizer": {"num_tokens": 55664, "model_type": "gpt2"}}')
+    ds._load_dataset_spec()  # no ValueError
+
+
+def test_provenance_check_still_gates_prebuilt_loads(tmp_path):
+    """Without recreate, a real backbone mismatch still raises."""
+    import loguru
+    import pytest
+    ds = JSONDataset.__new__(JSONDataset)
+    ds.logger = loguru.logger
+    ds._recreate_dataset = False
+    ds._default_tokenize_name = "Qwen/Qwen2.5-3B-Instruct"
+    ds._dataset_root_dir = str(tmp_path)
+    ds._default_dataset_spec = "dataset.json"
+
+    class _Tok:
+        def __len__(self):
+            return 151936
+    ds.tokenizer = _Tok()
+
+    (tmp_path / "dataset.json").write_text(
+        '{"mirrors": [], "resources": [], "tokenizer": {"num_tokens": 55664, "model_type": "gpt2"}}')
+    with pytest.raises(ValueError, match="Rebuild with --recreate_dataset"):
+        ds._load_dataset_spec()


### PR DESCRIPTION
R3 (Qwen2.5-3B) finding — my provenance guard fired correctly ('caches built for gpt2 but run uses Qwen') but exposed the root gap: --recreate_dataset rebuilt the dataset while _load_tokenizer kept loading the stale gpt2 tokenizer dir (55664 tokens, not Qwen's 151936), so no run could ever switch backbones. On --recreate_dataset the igc tokenizer is now rebuilt from the current --model_type and the provenance gate is skipped (the rebuild rewrites the spec). +2 tests (skip-on-recreate, still-gates-prebuilt). Gate: 577 passed (pipefail).