### PR TITLE
Keep internal cluster addresses out of the public repo

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -571,7 +571,7 @@ held-out-API trial's cards never leak across trials. Fields: `effective_signatur
 `@Redfish.ActionInfo` allowable values), `expected_response` (field → type, distilled
 from observed 2xx bodies), `error_taxonomy` (`retriable | fatal | precondition_unmet`,
 each citing ≥1 `Transition`), `preconditions`/`usage_tips`, `provenance`
-(`deepseek-v4-flash | stub`, evidence ids, `k_observed`), `grounding` (`status ∈
+(`llm | stub`, evidence ids, `k_observed`), `grounding` (`status ∈
 {provisional, grounded, contradicted}` + confirm/contradict + M4 counters), `version`,
 `content_hash` (blake2b of the canonical learned content — excludes the volatile
 grounding tallies so a counter tick does not churn the embedding cache), and

--- a/scripts/submit_train.sh
+++ b/scripts/submit_train.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Preflight + submit helper for igc training on the GB300 Slurm lab. Run this FROM a
-# cluster node (e.g. ssh nvidia@172.25.230.40). It checks the queue, finds a genuinely
+# cluster login node (see GPU_ACCESS.md for the address). It checks the queue, finds a genuinely
 # idle node that is NOT one of the hands-off nodes, warns if Flash is using its GPUs,
 # then submits scripts/train_igc.sbatch for the chosen stage. See GPU_ACCESS.md.
 #
@@ -8,7 +8,8 @@
 #   IGC_MODEL=<hf-id> IGC_USE_PEFT=1 EPOCHS=3 ./scripts/submit_train.sh m1
 #   ./scripts/submit_train.sh m6 -w gb300-poc1-slot7   # pin to a node where data is staged
 #
-# Never targets slot2 (Flash), slot15/.55 (Pro, TP=4 — busy), slot16 (down). slot1/.41 is also down.
+# Excludes the hands-off / model-serving / down nodes (the specific slots + why are in
+# GPU_ACCESS.md, gitignored); override EXCLUDE below if the fleet layout changes.
 
 set -euo pipefail
 
@@ -36,7 +37,7 @@ else
     echo "WARNING: IGC_SKIP_PREFLIGHT=1 — submitting without the fleet-health gate." >&2
 fi
 
-command -v sbatch >/dev/null || { echo "ERROR: sbatch not found — run this from a GB300 node (ssh nvidia@172.25.230.40)." >&2; exit 1; }
+command -v sbatch >/dev/null || { echo "ERROR: sbatch not found — run this from a GB300 login node (see GPU_ACCESS.md)." >&2; exit 1; }
 [ -f "${SBATCH_FILE}" ] || { echo "ERROR: ${SBATCH_FILE} not found." >&2; exit 1; }
 
 echo "== queue (empty = wide open) =="

--- a/tests/test_rest_trajectory_remap.py
+++ b/tests/test_rest_trajectory_remap.py
@@ -27,7 +27,7 @@ def _make_trajectory(tmp_path: Path, host: str) -> RestTrajectory:
 
 def test_remap_cross_machine_absolute_paths(tmp_path: Path) -> None:
     """Capture-machine absolute paths are re-rooted to /<host>/<file> here."""
-    host = "172.25.230.37"
+    host = "192.0.2.10"
     rt = _make_trajectory(tmp_path, host)
     rt._rest_map_data[host] = {
         "rest_api_map": {


### PR DESCRIPTION
The repo's origin is public GitHub, but three tracked files carried internal detail: submit_train.sh named the GB300 login-node IP and the slot->model-serving mapping in comments, docs/ARCHITECTURE.md named an internal model in a provenance enum, and a remap test hardcoded a lab BMC IP. Replaced the IPs with pointers to the gitignored GPU_ACCESS.md, genericized the model name to 'llm', and used an RFC 5737 documentation IP (192.0.2.10) in the test. Functional slot-exclude names kept (the script needs them). No behavior change; gate green.