### PR TITLE
Cast backbone hidden states to the autoencoder dtype

### DIFF
--- a/igc/modules/igc_train_auto_state_encoder.py
+++ b/igc/modules/igc_train_auto_state_encoder.py
@@ -177,7 +177,7 @@ class AutoencoderTrainer(IgcModule):
 
         with torch.no_grad():
             for batch in test_data:
-                batch = batch.to(self.device)
+                batch = self._to_autoencoder_dtype(batch.to(self.device))
                 reconstructed = self.model_autoencoder(batch)
                 batch = batch.view(batch.shape[0], -1)
                 loss = F.mse_loss(batch, reconstructed, reduction="mean")
@@ -185,6 +185,19 @@ class AutoencoderTrainer(IgcModule):
 
         average_loss = total_loss / len(test_data)
         return average_loss
+
+    def _to_autoencoder_dtype(self, tensor):
+        """Cast backbone hidden states to the autoencoder's parameter dtype.
+
+        A bf16 backbone (``--llm_torch_dtype bfloat16``) emits bf16 hidden
+        states, but the autoencoder is fp32, so feeding them directly raises
+        ``Input type (BFloat16) and bias type (float) should be the same``.
+
+        :param tensor: hidden-state tensor from the backbone.
+        :return: the tensor cast to the autoencoder's dtype.
+        """
+        param = next(self.model_autoencoder.parameters(), None)
+        return tensor if param is None else tensor.to(param.dtype)
 
     def train(self):
         """
@@ -233,6 +246,7 @@ class AutoencoderTrainer(IgcModule):
                 batch = {k: v.to(self.device) for k, v in batch.items()}
                 with torch.no_grad():
                     output = self._encoder_model(**batch).last_hidden_state.to(self.device)
+                output = self._to_autoencoder_dtype(output)
                 reconstructed = self.model_autoencoder(output)
                 output = output.view(output.shape[0], -1)
                 loss = F.mse_loss(output, reconstructed, reduction="none")

--- a/tests/modules/test_autoencoder_dtype.py
+++ b/tests/modules/test_autoencoder_dtype.py
@@ -1,0 +1,36 @@
+"""Offline regression for the autoencoder dtype cast (bf16 backbone path).
+
+A bf16 backbone emits bf16 hidden states while the autoencoder stays fp32, so
+feeding them directly raised 'Input type (BFloat16) and bias type (float)
+should be the same' — seen live on the GB300 with --llm_torch_dtype bfloat16.
+_to_autoencoder_dtype casts to the autoencoder's parameter dtype. CPU-only.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import torch
+
+from igc.modules.igc_train_auto_state_encoder import AutoencoderTrainer
+
+
+def _trainer_with_fp32_autoencoder():
+    t = AutoencoderTrainer.__new__(AutoencoderTrainer)
+    t.model_autoencoder = torch.nn.Linear(4, 4)  # fp32 by default
+    return t
+
+
+def test_bf16_hidden_states_cast_to_autoencoder_dtype():
+    """A bf16 tensor is cast to the fp32 autoencoder dtype (no runtime mismatch)."""
+    t = _trainer_with_fp32_autoencoder()
+    out = t._to_autoencoder_dtype(torch.zeros(2, 4, dtype=torch.bfloat16))
+    assert out.dtype == torch.float32
+    # and it now feeds the autoencoder without a dtype error
+    t.model_autoencoder(out)
+
+
+def test_matching_dtype_is_untouched():
+    """An fp32 tensor stays fp32 (no needless copy path errors)."""
+    t = _trainer_with_fp32_autoencoder()
+    out = t._to_autoencoder_dtype(torch.zeros(2, 4, dtype=torch.float32))
+    assert out.dtype == torch.float32


### PR DESCRIPTION
R3 (Qwen2.5-3B) finding — the modern-backbone path now gets all the way through: Qwen tokenizer rebuilt cleanly, LLM state encoder trained ~6 min, then the autoencoder crashed with 'Input type (BFloat16) and bias type (float) should be the same' because a bf16 backbone emits bf16 hidden states while the autoencoder is fp32. Cast to the autoencoder's parameter dtype at both feed sites (train loop + measure_reconstruction). +2 regressions. Gate: 582 passed (pipefail).