### PR TITLE
Ignore local .mcp.json MCP server config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,6 +191,11 @@ CLAUDE_PATCH.diff
 .claude/
 .internal/
 
+# Local MCP server config — carries internal Brain/fleet URLs (nv72-brain), never commit
+.mcp.json
+.mcp.local.json
+mcp.json
+
 # Internal docs — operational/private: cluster topology, node IPs/hosts, runbooks,
 # private endpoints, secrets-adjacent notes. External (public-safe) docs live in docs/
 # and ARE committed; anything internal goes here and is never committed.


### PR DESCRIPTION
Adds `.mcp.json` / `.mcp.local.json` / `mcp.json` to `.gitignore`. A project-scoped MCP server config carries machine-local internal service URLs in its `env` block, so it must stay out of git — this guard ensures it can never be accidentally committed from any clone.

Ignore-patterns only; no behavior change, no internal content in the diff.