### PR TITLE
Stream training to W&B automatically, one run per job

### DIFF
--- a/igc/modules/base/metric_factory.py
+++ b/igc/modules/base/metric_factory.py
@@ -199,6 +199,30 @@ def _wandb_run_meta(kw: dict) -> dict:
     }
 
 
+class NullLogger(BaseLogger):
+    """No-op metric logger for non-main ranks.
+
+    Under multi-GPU (accelerate/torchrun) every rank constructs the
+    MetricLogger, so a network backend like W&B would open one run PER RANK
+    (four runs for a 4-GPU job). Non-main ranks get this no-op instead, so a
+    job produces exactly one clean W&B run driven by rank 0.
+    """
+
+    def log_scalar(self, tag: str, value: float, step: int):
+        pass
+
+
+def _is_main_process() -> bool:
+    """True on the main distributed rank (or a single-process run).
+
+    Reads ``RANK`` then ``LOCAL_RANK`` (set by accelerate/torchrun); absent =>
+    single process => main.
+
+    :return: whether this process should own the metric backend.
+    """
+    return int(os.environ.get("RANK") or os.environ.get("LOCAL_RANK") or 0) == 0
+
+
 def create_logger(report_to: str, **kwargs: Optional[str]):
     """
     Create logger
@@ -207,6 +231,9 @@ def create_logger(report_to: str, **kwargs: Optional[str]):
     :param kwargs:
     :return:
     """
+    # only the main rank owns the metric backend (one W&B run per job, not one per GPU).
+    if not _is_main_process():
+        return NullLogger()
     try:
         common_args = {key: kwargs[key] for key in [
             "api_key", "project_name", "workspace",

--- a/scripts/run_profile.sh
+++ b/scripts/run_profile.sh
@@ -23,6 +23,16 @@ DATA_DIR="${IGC_DATA_DIR:-$HOME/.json_responses}"
 OUT_DIR="${IGC_OUTPUT_DIR:-experiments/${PROFILE}}"
 METRIC_REPORT="${IGC_METRIC_REPORT:-wandb}"
 
+# Auto-load W&B credentials so the run streams to the dashboard with no manual export.
+# The env file is gitignored (creds never committed); override the path via IGC_WANDB_ENV.
+WANDB_ENV="${IGC_WANDB_ENV:-.internal/wandb.env}"
+if [ -f "$WANDB_ENV" ]; then
+    set -a; . "$WANDB_ENV"; set +a
+    echo "== W&B: streaming to \${WANDB_ENTITY:-?}/\${WANDB_PROJECT:-?} (real-time) =="
+elif [ "$METRIC_REPORT" = "wandb" ]; then
+    echo "== W&B: no \$WANDB_API_KEY and no $WANDB_ENV — set IGC_METRIC_REPORT=tensorboard or provide creds ==" >&2
+fi
+
 # Optional per-run overrides: IGC_SET="batch_size=16 lr=2e-4"
 SET_ARGS=()
 for kv in ${IGC_SET:-}; do SET_ARGS+=(--set "$kv"); done

--- a/scripts/train_igc.sbatch
+++ b/scripts/train_igc.sbatch
@@ -106,6 +106,8 @@ srun --container-image="${NGC_IMAGE}" \
      bash -lc '
         set -euo pipefail
         cd /workspace/igc
+        # auto-load W&B creds (gitignored env file) so the run streams live
+        [ -f .internal/wandb.env ] && { set -a; . .internal/wandb.env; set +a; }
         pip install --no-cache-dir -r docker/requirements-train.txt
         nvidia-smi -L
         # Shared curriculum root so later stages find earlier checkpoints (per-module subdirs).

--- a/tests/modules/test_metric_logger_rank_gate.py
+++ b/tests/modules/test_metric_logger_rank_gate.py
@@ -1,0 +1,49 @@
+"""Offline regression: metric backend is rank-gated to one run per job.
+
+Under multi-GPU every rank builds the MetricLogger, so a W&B backend would open
+one run per GPU. create_logger returns a no-op NullLogger on non-main ranks so
+a 4-GPU job produces exactly one W&B run (driven by rank 0). CPU-only; the rank
+is faked via the RANK/LOCAL_RANK env vars accelerate/torchrun set.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import pytest
+
+from igc.modules.base.metric_factory import NullLogger, create_logger
+
+
+def test_non_main_rank_gets_null_logger(monkeypatch):
+    """RANK != 0 yields a no-op logger regardless of the requested backend."""
+    monkeypatch.setenv("RANK", "2")
+    logger = create_logger("wandb")
+    assert isinstance(logger, NullLogger)
+    logger.log_scalar("train/loss", 1.0, 0)  # must be a silent no-op
+
+
+def test_local_rank_also_gates(monkeypatch):
+    """LOCAL_RANK is honored when RANK is absent."""
+    monkeypatch.delenv("RANK", raising=False)
+    monkeypatch.setenv("LOCAL_RANK", "1")
+    assert isinstance(create_logger("wandb"), NullLogger)
+
+
+def test_main_rank_builds_real_backend(monkeypatch, tmp_path):
+    """Rank 0 builds the real backend (tensorboard here — no network/creds)."""
+    monkeypatch.delenv("RANK", raising=False)
+    monkeypatch.delenv("LOCAL_RANK", raising=False)
+    logger = create_logger("tensorboard", output_dir=str(tmp_path))
+    assert not isinstance(logger, NullLogger)
+    assert logger is not None
+
+
+def test_single_process_is_main(monkeypatch, tmp_path):
+    """No RANK env (single-process run) counts as main."""
+    monkeypatch.delenv("RANK", raising=False)
+    monkeypatch.delenv("LOCAL_RANK", raising=False)
+    assert not isinstance(
+        create_logger("tensorboard", output_dir=str(tmp_path)), NullLogger)
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
Makes W&B the zero-touch, real-time source of truth for every run. Rank-gate: create_logger returns a no-op NullLogger on non-main ranks (RANK/LOCAL_RANK), so a 4-GPU job produces ONE clean W&B run driven by rank 0 instead of four (the audit's per-rank duplication). Auto-source the gitignored .internal/wandb.env in run_profile.sh and inside train_igc.sbatch's container step, so runs stream live with no manual export. wandb.log already streams in real time. +4 rank-gate regressions. Gate: 586 passed (pipefail).