### PR TITLE
Backbone decouple: load saved tokenizers via AutoTokenizer; correct D-003 status

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -39,6 +39,29 @@ silently degrade — any modern backbone.
 (`igc/rl.py`, also an untracked WIP file, hard-codes `GPT2LMHeadModel`/`GPT2Tokenizer` and belongs in
 the same sweep.)
 
+### Verified state on `main` (2026-07-11) — most of Phase 0 was already done
+
+A re-audit against the actual code (not the comments the census above was drawn from) found the
+decoupling **largely complete**, and corrects two overstatements in the census:
+
+- **`wpe` — already fixed.** `igc/modules/encoders/backbone_utils.py` (`backbone_module`,
+  `max_positions`, `emb_shape`) derives module + shapes from `config`; both encoders
+  (`base_encoder.py`, `rest_encoder.py`) use it and handle RoPE models with no positional table. The
+  census matched a *comment* that referenced the legacy behavior, not live `.wpe` access.
+- **The 1024 window and the tokenizer — already flags.** `igc_main.py` builds the dataset with
+  `default_tokenize=--model_type` (→ `AutoTokenizer`) and `max_len=--seq_len`; `_load_tokenizer`
+  rebuilds the cache on a backbone switch. So a modern long-context run is already
+  `--model_type <model> --seq_len <N> --recreate_dataset` — no refactor required.
+- **`AutoModelForCausalLM`** is the intended causal-LM track, already keyed on `--model_type`; not a
+  defect.
+
+**What genuinely remained (fixed in the follow-up PR):** the `JSONDataset.load_tokenizer` *classmethod*
+hard-coded `GPT2Tokenizer` on the saved-tokenizer reload path (wrong class for a non-GPT-2 saved
+tokenizer), one minor live fallback, and stale docstring examples — all moved to `AutoTokenizer`, with
+an offline regression test. The remaining GPT-2 literals are the untracked WIP files above and a
+standalone `chat_with_gpt2` demo helper. Net: Phase 0 is effectively closed; the open item is the
+Phase-1/2 model choice below.
+
 ### The open fork (the one decision still to make)
 
 | Track | Move | Cost |

--- a/igc/ds/redfish_dataset.py
+++ b/igc/ds/redfish_dataset.py
@@ -34,7 +34,7 @@ import torch
 import torch.nn.functional as F
 from huggingface_hub.utils import HFValidationError
 from tqdm import tqdm
-from transformers import AutoTokenizer, GPT2Tokenizer, PreTrainedTokenizer
+from transformers import AutoTokenizer, PreTrainedTokenizer
 
 from igc.interfaces.rest_mapping_interface import RestMappingInterface
 from igc.interfaces.rest_one_hot_interface import RestActionEncoderInterface
@@ -365,7 +365,10 @@ class JSONDataset(
         if not os.path.exists(tok_dir):
             raise ValueError(f"Tokenizer directory '{tok_dir}' does not exist.")
 
-        tokenizer = GPT2Tokenizer.from_pretrained(tok_dir)
+        # Load the saved tokenizer with AutoTokenizer so a non-GPT-2 backbone
+        # (Qwen/Llama/etc., built from --model_type by _load_tokenizer) round-trips
+        # with its own tokenizer class instead of being forced into GPT-2's.
+        tokenizer = AutoTokenizer.from_pretrained(tok_dir)
         tokenizer.pad_token = tokenizer.eos_token
         tokenizer.pad_token_id = tokenizer.eos_token_id
         return tokenizer
@@ -1176,7 +1179,7 @@ class JSONDataset(
 
         Usage:
             target_key = "@odata.id"
-            tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
+            tokenizer = AutoTokenizer.from_pretrained("gpt2")
             json_lines = json.dumps(j_data)
             attention_mask = mask_specific_key_and_value(json_lines,
             target_key, tokenizer=tokenizer, debug=True)
@@ -1226,7 +1229,7 @@ class JSONDataset(
 
         Usage:
             target_key = "@odata.id"
-            tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
+            tokenizer = AutoTokenizer.from_pretrained("gpt2")
             json_lines = json.dumps(j_data)
             attention_mask = mask_specific_key_and_value(json_lines,
             target_key, tokenizer=tokenizer, debug=True)
@@ -1238,7 +1241,7 @@ class JSONDataset(
         :return:
         """
         tokenizer = tokenizer if tokenizer is not None \
-            else GPT2Tokenizer.from_pretrained("gpt2")
+            else AutoTokenizer.from_pretrained("gpt2")
 
         if isinstance(json_data, str):
             try:

--- a/igc/ds/redfish_dataset.py
+++ b/igc/ds/redfish_dataset.py
@@ -896,7 +896,7 @@ class JSONDataset(
         self._masked_data = torch.load(self._dataset_masked_file_name)
         if 'train_data' not in self._masked_data:
             raise DatasetConsistencyError(
-                f"Loaded dataset has no mandatory key train_data")
+                "Loaded dataset has no mandatory key train_data")
 
         self._load_dicts_from_data()
         self._construct_action_space()
@@ -1999,7 +1999,7 @@ class JSONDataset(
                 raise FileNotFoundError(f"File does not exist: {ds_file}")
 
         if not self._is_tokenizer_consistency():
-            raise FileNotFoundError(f"Some tokenizer files not found.")
+            raise FileNotFoundError("Some tokenizer files not found.")
 
     @staticmethod
     def default_tokenizer_files():

--- a/tests/ds/test_redfish_tokenizer_backbone.py
+++ b/tests/ds/test_redfish_tokenizer_backbone.py
@@ -1,0 +1,59 @@
+"""Offline regression: the JSONDataset saved-tokenizer loader is backbone-agnostic.
+
+``JSONDataset.load_tokenizer`` (in ``igc/ds/redfish_dataset.py``) loads a *saved*
+tokenizer directory on the resume/inference path — it is called from
+``igc/modules/llm_train_state_encoder.py`` (``_load`` reload) and ``igc/ds/corpus_dataset.py``.
+That directory is written by ``_load_tokenizer`` from the current ``--model_type``, so it may
+hold a Qwen/Llama tokenizer, not GPT-2's. The loader must therefore go through
+``AutoTokenizer`` — loading a non-GPT-2 saved tokenizer with the GPT-2-only class silently
+returns the wrong tokenizer. These tests pin that on CPU with no network or download.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+import pytest
+
+import igc.ds.redfish_dataset as rd
+from igc.ds.redfish_dataset import JSONDataset
+
+
+class _FakeTok:
+    """Minimal stand-in for a tokenizer returned by ``from_pretrained``."""
+
+    def __init__(self, name: str):
+        self.name_or_path = name
+        self.eos_token = "<eos>"
+        self.eos_token_id = 0
+        self.pad_token = None
+        self.pad_token_id = None
+
+
+def test_load_tokenizer_uses_autotokenizer(tmp_path, monkeypatch):
+    """load_tokenizer loads the saved dir via AutoTokenizer, not a GPT-2-locked class."""
+    tok_dir = tmp_path / "tokenizer"
+    tok_dir.mkdir()
+
+    seen = {}
+
+    def fake_from_pretrained(path):
+        seen["path"] = str(path)
+        return _FakeTok(str(path))
+
+    monkeypatch.setattr(rd.AutoTokenizer, "from_pretrained", fake_from_pretrained)
+
+    tok = JSONDataset.load_tokenizer(str(tok_dir))
+
+    assert seen["path"] == str(tok_dir)      # the given directory was loaded
+    assert tok.pad_token == tok.eos_token    # pad token synthesized from eos
+    assert tok.pad_token_id == tok.eos_token_id
+    # Regression guard: the GPT-2-only tokenizer class must no longer be imported here.
+    assert not hasattr(rd, "GPT2Tokenizer")
+
+
+def test_load_tokenizer_missing_dir_raises(tmp_path):
+    """A missing tokenizer directory raises a clear ValueError (contract unchanged)."""
+    with pytest.raises(ValueError):
+        JSONDataset.load_tokenizer(str(tmp_path / "does_not_exist"))
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
Follow-up to D-003 (backbone migration). A re-audit against the real code found Phase 0 was **largely already done** on `main` — the `wpe` hack is abstracted via `backbone_utils`, and the 1024 window + tokenizer are already driven by `--seq_len` / `--model_type` (so a modern long-context run is `--model_type <model> --seq_len 8192 --recreate_dataset` today, no refactor).

**The one genuine remaining bug, fixed here:** `JSONDataset.load_tokenizer` (the saved-tokenizer reload path used on resume, e.g. `llm_train_state_encoder.py`) hard-coded `GPT2Tokenizer`, so a non-GPT-2 backbone built from `--model_type` round-tripped through the wrong tokenizer class. This PR:

- Switches `load_tokenizer`, the minor masking fallback, and the docstring examples to `AutoTokenizer`; drops the now-unused `GPT2Tokenizer` import.
- Adds an offline, CPU-only regression test (`tests/ds/test_redfish_tokenizer_backbone.py`) — including a guard that the GPT-2-only class stays unimported.
- Cleans up 2 pre-existing `F541` findings in the touched file (separate commit).
- Corrects the **D-003** record with the verified state (the census had overstated `wpe`/tokenizer as still-welded).

Gate: `tests/ds` 105 passed; ruff clean on touched files. Remaining GPT-2 literals are the untracked WIP files (`igc/rl.py`, `igc/ds/ds_pairs.py`) and the standalone `chat_with_gpt2` demo helper.