### PR TITLE
Drop stale GPT2Tokenizer monkeypatch from tokenizer tests

### DIFF
--- a/tests/test_dataset_tokenizer_model_type.py
+++ b/tests/test_dataset_tokenizer_model_type.py
@@ -65,13 +65,7 @@ def test_default_tokenize_builds_backbone_tokenizer_without_gpt2_overwrite(
                 pad_token_id=pad_token_id,
             )
 
-    class FailingGPT2Tokenizer:
-        @staticmethod
-        def from_pretrained(name_or_path):
-            raise AssertionError(f"unexpected GPT2 fallback for {name_or_path}")
-
     monkeypatch.setattr(redfish_dataset, "AutoTokenizer", FakeAutoTokenizer)
-    monkeypatch.setattr(redfish_dataset, "GPT2Tokenizer", FailingGPT2Tokenizer)
     monkeypatch.setattr(JSONDataset, "_build_tokenizer", lambda self: None)
 
     dataset = JSONDataset(
@@ -102,7 +96,6 @@ def test_injected_tokenizer_skips_backbone_factory(
             raise AssertionError(f"unexpected tokenizer factory call for {name_or_path}")
 
     monkeypatch.setattr(redfish_dataset, "AutoTokenizer", FailingTokenizerFactory)
-    monkeypatch.setattr(redfish_dataset, "GPT2Tokenizer", FailingTokenizerFactory)
 
     dataset = JSONDataset(
         dataset_dir=str(tmp_path / "dataset"),


### PR DESCRIPTION
main was RED: backbone-decouple (#51) removed the GPT2Tokenizer import from redfish_dataset, but two tests still monkeypatched redfish_dataset.GPT2Tokenizer -> AttributeError. Two independently-green PRs left main red. Removed the obsolete monkeypatch (and unused FailingGPT2Tokenizer class); the gpt2 fallback no longer exists to patch. Gate back to green.