### PR TITLE
Save final checkpoint collectively under FSDP2 (fix 4-GPU shutdown hang)

### DIFF
--- a/igc/modules/base/igc_base_module.py
+++ b/igc/modules/base/igc_base_module.py
@@ -501,7 +501,7 @@ class IgcModule(IgcBaseState):
 
         return model, epoch, last_model_path
 
-    def save_model(self, checkpoint_dir, model=None):
+    def save_model(self, checkpoint_dir, model=None, model_state_dict=None):
         """
 
         Save model, after we're done training,
@@ -511,6 +511,12 @@ class IgcModule(IgcBaseState):
         Dataset need pull this.
 
         :param checkpoint_dir:
+        :param model: optional model whose weights to persist instead of self.model.
+        :param model_state_dict: optional pre-gathered state dict. Sharded runs
+            (ZeRO-3/FSDP) must pass the dict from ``accelerator.get_state_dict`` — a
+            COLLECTIVE every rank participated in — because calling ``state_dict()``
+            on rank 0 alone under sharding re-enters that gather with no peers and
+            deadlocks. Left ``None`` on the plain path, where ``state_dict()`` is local.
         :return:
         """
         if self.is_rank_zero():
@@ -519,7 +525,10 @@ class IgcModule(IgcBaseState):
             _model = model if model is not None else self.model
             checkpoint_file = self._model_file(checkpoint_dir)
             torch.save({
-                'model_state_dict': _model.state_dict(),
+                # Prefer the pre-gathered state dict on the sharded path; only fall
+                # back to a local state_dict() when no gather happened (plain run).
+                'model_state_dict':
+                    model_state_dict if model_state_dict is not None else _model.state_dict(),
                 'is_trained': True,
             }, checkpoint_file)
 

--- a/igc/modules/base/igc_llm_base_module.py
+++ b/igc/modules/base/igc_llm_base_module.py
@@ -110,9 +110,15 @@ class LlmModule(IgcModule):
         """
         return f"{self._module_checkpoint_dir}/fine_tuned"
 
-    def save_finetuned(self):
+    def save_finetuned(self, model_state_dict=None):
         """
         Save the fine-tuned model and tokenizer. This huggingface format.
+
+        :param model_state_dict: optional pre-gathered state dict. On the sharded
+            path (ZeRO-3/FSDP) pass the dict from ``accelerator.get_state_dict`` —
+            a COLLECTIVE every rank already ran — so ``save_pretrained`` writes it
+            directly instead of calling ``state_dict()`` on rank 0 alone, which
+            under sharding re-enters the gather with no peers and deadlocks.
         :return: None
         """
         if not self.is_rank_zero():
@@ -121,7 +127,9 @@ class LlmModule(IgcModule):
         fine_tuned = self.finetuned_dir()
         if not os.path.exists(fine_tuned):
             os.makedirs(fine_tuned)
-        save_pretrained_default(fine_tuned, self.model, self.tokenizer)
+        save_pretrained_default(
+            fine_tuned, self.model, self.tokenizer,
+            model_state_dict=model_state_dict)
 
     def load_finetuned(self, device_map="auto"):
         """

--- a/igc/modules/llm_train_state_encoder.py
+++ b/igc/modules/llm_train_state_encoder.py
@@ -425,6 +425,35 @@ class LlmEmbeddingsTrainer(LlmModule):
             self.dataset.disable_masking()
             self._current_mask_method_counter = 0
 
+    def _save_final_checkpoint(self):
+        """Persist the trained model once at end-of-train, collective-safe.
+
+        Under ZeRO-3/FSDP the state-dict gather is a COLLECTIVE: every rank must
+        reach ``accelerator.get_state_dict`` together. The previous end-of-train
+        path called ``save_model`` -> ``state_dict()`` behind ``is_rank_zero``, so
+        rank 0 entered the gather alone and deadlocked while ranks 1..N ran ahead
+        through ``save_finetuned`` and returned — the 4-GPU end-of-train hang where
+        only 3 of 4 ranks print "training complete". Gather on ALL ranks first,
+        hand the pre-gathered weights to the rank-0 writers, then barrier so no
+        rank tears down its process group mid-write. Mirrors the per-epoch save.
+        """
+        final_state = None
+        if self.is_accelerator:
+            # Collective — must run on EVERY rank, before any is_rank_zero gate.
+            # Gather on the still-wrapped model, exactly as the per-epoch save does.
+            if self._module_checkpoint_dir is not None:
+                final_state = self.accelerator.get_state_dict(self.model)
+            self.model = self.accelerator.unwrap_model(self.model)
+
+        # Rank-0 writers consume the pre-gathered dict (no second rank-0-only
+        # state_dict() collective); the plain path passes None and saves locally.
+        self.save_model(self._module_checkpoint_dir, model_state_dict=final_state)
+        self.save_finetuned(model_state_dict=final_state)
+
+        if self.is_accelerator:
+            # No rank returns (and drops its NCCL group) until every rank is done.
+            self.accelerator.wait_for_everyone()
+
     def _train(
             self,
             mask_type: List[Union[MaskingOption, MaskingType]] = None
@@ -728,10 +757,7 @@ class LlmEmbeddingsTrainer(LlmModule):
         if self._is_quantize:
             self.model = convert(self.model)
 
-        if self.is_accelerator:
-            self.model = self.accelerator.unwrap_model(self.model)
-        self.save_model(self._module_checkpoint_dir)
-        self.save_finetuned()
+        self._save_final_checkpoint()
 
         # Emit the self-describing run report (report.json) next to the checkpoint so
         # every run is comparable through igc.modules.train.report.compare(). Emission

--- a/igc/modules/shared/llm_shared.py
+++ b/igc/modules/shared/llm_shared.py
@@ -235,7 +235,8 @@ def save_pretrained_default(
         huggingface_dir,
         model: PreTrainedModel,
         tokenizer: PreTrainedTokenizer,
-        only_tokenizer=False
+        only_tokenizer=False,
+        model_state_dict=None,
 ):
     """
       Save the default GPT2 model and tokenizer.
@@ -244,6 +245,11 @@ def save_pretrained_default(
     :param model: fine-tuned model
     :param tokenizer: tokenizer
     :param only_tokenizer:  will save only tokenizer
+    :param model_state_dict: optional pre-gathered state dict. On a sharded
+        (ZeRO-3/FSDP) run pass the dict from ``accelerator.get_state_dict`` — a
+        COLLECTIVE every rank already ran — so ``save_pretrained`` serializes it
+        directly. Without it ``save_pretrained`` calls ``model.state_dict()``
+        itself, which under sharding on rank 0 alone deadlocks in the gather.
     :return:
     """
 
@@ -257,7 +263,10 @@ def save_pretrained_default(
             model.config.pad_token_id = tokenizer.pad_token_id
             model.config.pad_token = tokenizer.pad_token
 
-            model.save_pretrained(huggingface_dir)
+            if model_state_dict is not None:
+                model.save_pretrained(huggingface_dir, state_dict=model_state_dict)
+            else:
+                model.save_pretrained(huggingface_dir)
             tokenizer.save_pretrained(huggingface_dir)
         return True
     except Exception as e:

--- a/tests/gpu/test_m1_train_step_live.py
+++ b/tests/gpu/test_m1_train_step_live.py
@@ -40,18 +40,27 @@ class _EmptyDataset:
 
 
 class _Recorder:
-    """Records whether save hooks were reached."""
+    """Records whether save hooks were reached.
+
+    The signatures mirror the real ``IgcModule.save_model`` /
+    ``LlmModule.save_finetuned`` (which gained a ``model_state_dict`` kwarg for
+    the sharded gather), so the double stays faithful. The plain path passes
+    ``model_state_dict=None`` — captured here so the offline test pins that no
+    ``get_state_dict`` gather leaks onto the non-accelerator path.
+    """
 
     def __init__(self):
         """Initialize counters for save assertions."""
         self.save_model_calls = 0
         self.save_finetuned_calls = 0
+        self.model_state_dicts_seen = []
 
-    def save_model(self, checkpoint_dir):
-        """Record a save_model call."""
+    def save_model(self, checkpoint_dir, model=None, model_state_dict=None):
+        """Record a save_model call and the state-dict override it was handed."""
         self.save_model_calls += 1
+        self.model_state_dicts_seen.append(model_state_dict)
 
-    def save_finetuned(self):
+    def save_finetuned(self, model_state_dict=None):
         """Record a save_finetuned call."""
         self.save_finetuned_calls += 1
 
@@ -184,6 +193,9 @@ def test_plain_end_of_train_skips_accelerator_unwrap(tmp_path, monkeypatch):
     assert trainer._accelerator is None
     assert recorder.save_model_calls == 1
     assert recorder.save_finetuned_calls == 1
+    # Plain path takes no collective gather: save_model receives no pre-gathered
+    # state dict, so it serializes the model locally as before.
+    assert recorder.model_state_dicts_seen == [None]
 
 
 @pytest.mark.gpu

--- a/tests/modules/test_sharded_save.py
+++ b/tests/modules/test_sharded_save.py
@@ -3,10 +3,13 @@
 Under ZeRO-3/FSDP a rank-0-only ``unwrap_model().state_dict()`` deadlocks (the
 gather is collective) or writes shards. The trainer now gathers via
 ``accelerator.get_state_dict`` on every rank behind a rank-0 verdict made
-uniform by ``broadcast_flag``, and ``IgcModule.save_checkpoint`` accepts the
-pre-gathered ``model_state_dict`` instead of re-calling ``state_dict()``.
-CPU-only; single-process behavior plus the saver override are pinned here —
-the true multi-rank path runs on the cluster rung (gpu-marked).
+uniform by ``broadcast_flag``, and ``IgcModule.save_checkpoint`` /
+``IgcModule.save_model`` accept the pre-gathered ``model_state_dict`` instead of
+re-calling ``state_dict()``. The end-of-train save (``_save_final_checkpoint``)
+runs that gather + a final barrier on EVERY rank so rank 0 never enters the
+collective alone. CPU-only; single-process behavior plus these structural
+guarantees are pinned here — the true multi-rank path runs on the cluster rung
+(gpu-marked).
 
 Author:
 Mus mbayramo@stanford.edu
@@ -18,6 +21,7 @@ import loguru
 import torch
 
 from igc.modules.base.igc_base_module import IgcModule
+from igc.modules.llm_train_state_encoder import LlmEmbeddingsTrainer
 from igc.shared.shared_accelerator import broadcast_flag
 
 
@@ -63,6 +67,129 @@ def test_save_checkpoint_falls_back_to_model_state(tmp_path):
     path = module.save_checkpoint(str(tmp_path), epoch=1)
     checkpoint = torch.load(path, weights_only=True)
     assert set(checkpoint["model_state_dict"]) == {"weight", "bias"}
+
+
+def test_save_model_uses_pregathered_state_dict(tmp_path):
+    """save_model writes the provided gather verbatim — no rank-0-only state_dict().
+
+    This is the exact call the end-of-train deadlock lived in: under FSDP the
+    final ``save_model`` must serialize the collective's result, not re-enter it.
+    """
+    module = _module(tmp_path)
+    gathered = {"weight": torch.ones(2, 2), "bias": torch.zeros(2)}
+
+    module.save_model(str(tmp_path), model_state_dict=gathered)
+    checkpoint = torch.load(module._model_file(str(tmp_path)), weights_only=True)
+
+    assert torch.equal(checkpoint["model_state_dict"]["weight"], torch.ones(2, 2))
+    assert checkpoint["is_trained"] is True
+
+
+def test_save_model_falls_back_to_model_state(tmp_path):
+    """Without the override save_model saves the model's own state (plain path)."""
+    module = _module(tmp_path)
+    module.save_model(str(tmp_path))
+    checkpoint = torch.load(module._model_file(str(tmp_path)), weights_only=True)
+    assert torch.equal(checkpoint["model_state_dict"]["weight"], module.model.weight)
+
+
+class _SpyModel(torch.nn.Linear):
+    """Linear that records direct ``state_dict()`` calls.
+
+    On the sharded end-of-train path rank 0 must NEVER call ``state_dict()``
+    itself — that is the collective it would enter alone. The gather goes through
+    the (mock) accelerator instead, so this counter must stay at zero.
+    """
+
+    def __init__(self):
+        super().__init__(2, 2)
+        self.state_dict_calls = 0
+
+    def state_dict(self, *args, **kwargs):  # noqa: D102
+        self.state_dict_calls += 1
+        return super().state_dict(*args, **kwargs)
+
+
+class _MockShardedAccelerator:
+    """Minimal FSDP-like accelerator recording the collective + barrier calls."""
+
+    num_processes = 4
+    # A fixed "gathered" dict distinct from the model's real init, so a saved
+    # checkpoint proves the gather (not a local state_dict) supplied the weights.
+    SENTINEL = {"weight": torch.ones(2, 2), "bias": torch.zeros(2)}
+
+    def __init__(self):
+        self.get_state_dict_calls = 0
+        self.unwrap_calls = 0
+        self.wait_calls = 0
+
+    def get_state_dict(self, model):
+        self.get_state_dict_calls += 1
+        return {k: v.clone() for k, v in self.SENTINEL.items()}
+
+    def unwrap_model(self, model):
+        self.unwrap_calls += 1
+        return model
+
+    def wait_for_everyone(self):
+        self.wait_calls += 1
+
+
+def _trainer(tmp_path, rank, accelerator):
+    trainer = LlmEmbeddingsTrainer.__new__(LlmEmbeddingsTrainer)
+    trainer.rank = rank
+    trainer.module_name = "state_encoder"
+    trainer.logger = loguru.logger
+    trainer.model = _SpyModel()
+    trainer.is_accelerator = True
+    trainer._accelerator = accelerator
+    trainer._module_checkpoint_dir = str(tmp_path)
+    return trainer
+
+
+def test_final_checkpoint_gathers_and_barriers_on_every_rank(tmp_path):
+    """Every rank runs the collective gather + barrier; rank 0 never calls state_dict.
+
+    The end-of-train hang was structural: ``get_state_dict`` ran only where rank 0
+    reached it, so peers exited while rank 0 blocked in the gather. Assert the
+    gather AND the final ``wait_for_everyone`` barrier fire on each of the four
+    ranks, and that rank 0 writes the gathered weights without a rank-0-only
+    ``model.state_dict()``.
+    """
+    for rank in (0, 1, 2, 3):
+        accelerator = _MockShardedAccelerator()
+        trainer = _trainer(tmp_path, rank, accelerator)
+        finetuned_seen = []
+        # Stub the HF-format save to record the dict it is handed (real
+        # save_pretrained needs a PreTrainedModel; the contract under test is
+        # that the pre-gathered dict is threaded through, not re-derived).
+        trainer.save_finetuned = lambda model_state_dict=None: finetuned_seen.append(
+            model_state_dict)
+
+        trainer._save_final_checkpoint()
+
+        # The collective and the barrier run on EVERY rank — this is the fix.
+        assert accelerator.get_state_dict_calls == 1, f"rank {rank} skipped gather"
+        assert accelerator.wait_calls == 1, f"rank {rank} skipped barrier"
+        # Rank 0 must not re-enter the gather via a local state_dict().
+        assert trainer.model.state_dict_calls == 0, f"rank {rank} called state_dict"
+        # The pre-gathered dict is threaded to the HF-format writer too.
+        assert len(finetuned_seen) == 1
+        assert finetuned_seen[0] is not None
+        assert torch.equal(finetuned_seen[0]["weight"], torch.ones(2, 2))
+
+
+def test_final_checkpoint_writes_gathered_weights_on_rank_zero(tmp_path):
+    """Rank 0 persists the gathered weights, not the model's untouched init."""
+    accelerator = _MockShardedAccelerator()
+    trainer = _trainer(tmp_path, rank=0, accelerator=accelerator)
+    trainer.save_finetuned = lambda model_state_dict=None: None
+
+    trainer._save_final_checkpoint()
+
+    checkpoint = torch.load(
+        trainer._model_file(str(tmp_path)), weights_only=True)
+    assert torch.equal(checkpoint["model_state_dict"]["weight"], torch.ones(2, 2))
 
 
 # Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
Lands the FSDP2 final-save fix that was uncommitted WIP in the gb300-perf working tree (operator/agent work, extracted + gated + preserved in a backup branch). Fixes the R4 shutdown hang: end-of-train save gathered the state dict on rank 0 alone (a collective), deadlocking while other ranks exited — the 3-of-4-ranks-complete symptom. All ranks now gather via accelerator.get_state_dict first, rank-0 writers take the pre-gathered dict (save_pretrained_default gains model_state_dict), then a barrier. +135 lines of sharded-save tests. Applies cleanly on main; gate 592 passed.