### PR TITLE
Add docs/use_cases: IGC end-to-end use-case doc set

### DIFF
--- a/docs/use_cases/README.md
+++ b/docs/use_cases/README.md
@@ -1,0 +1,92 @@
+# IGC use cases — what the agent does, end to end
+
+This directory is the **product north-star for IGC**: a concrete, human-readable picture of what the
+Infrastructure Goal-Condition Reinforce Learner *does in the real world* once trained — the goals we
+want it to reach, how an operator drives it, and why it is a **reinforcement-learning agent** rather
+than a chatbot wrapped around an API.
+
+Read the whole set and you should have one clear mental model: **you hand IGC a goal, and it finds
+and executes the shortest safe sequence of real REST operations that provably reaches that goal on
+*this specific* piece of hardware — discovering the action space, learning from experience, and
+never inventing a call that does not exist.**
+
+> **Status — read this first.** This is the **target** end-to-end behavior. Today the codebase is at
+> "Phase 0": a Redfish MDP shell (mock REST env + state encoder + a goal-conditioned DQN/HER trainer)
+> plus the module-by-module plan to make it real. The *mechanism* every page relies on — legal
+> candidate actions, verified success, HER, multi-vendor transfer — is grounded in the current
+> architecture: see [`../ARCHITECTURE.md`](../ARCHITECTURE.md) for the current-vs-target map and
+> [`../DECISIONS.md`](../DECISIONS.md) for the accepted design decisions (D-001 action selection,
+> D-002 candidate representation). Where a page describes a surface that does not exist yet (a UI, a
+> daemon), it says so explicitly. Nothing here is a claim that a metric was hit — that is what the
+> offline gate and [`../MATH_CHECKS.md`](../MATH_CHECKS.md) are for.
+
+## The one-paragraph version
+
+Cloud and datacenter hardware exposes itself over the **Redfish REST API** — a self-describing tree
+of resources (systems, BIOS, storage, firmware, power, logs) where each resource advertises the HTTP
+methods it legally allows. IGC treats operating that hardware as a **Markov Decision Process**: the
+*observation* is what a Redfish `GET` returns, the *actions* are the REST operations the API actually
+permits from here, and the *goal* is a machine-checkable target state. A goal-conditioned RL policy
+learns, from real captured Redfish data, to pick the action sequence that reaches the goal in the
+fewest, safest steps — and, because it is scored against structurally-encoded endpoints rather than
+memorized ids, it carries that skill to **vendors and machines it has never seen** (Dell iDRAC,
+Supermicro, HPE iLO, generic DMTF).
+
+## Why this matters (the short version — full argument in the next file)
+
+A modern LLM, prompted "power this server on via Redfish," will happily emit a URL and a JSON body.
+On real hardware that is a **liability**: it does not know *this* host's actual resource tree, it can
+invent an endpoint or method that does not exist, it cannot tell you whether the action *worked*, it
+has no notion of the *shortest* or *safest* path, and it does not get better the next time. IGC is
+built to remove every one of those failure modes by construction. That is the whole point, and it is
+the subject of [`why-rl-not-an-llm.md`](why-rl-not-an-llm.md).
+
+## How to read this directory
+
+Start with the two conceptual pages, then pick the scenarios relevant to you:
+
+| File | What it gives you |
+| --- | --- |
+| [`why-rl-not-an-llm.md`](why-rl-not-an-llm.md) | The core argument: what a prompted LLM cannot do here, and the five properties IGC guarantees instead. **Start here for the "aha".** |
+| [`anatomy-of-an-episode.md`](anatomy-of-an-episode.md) | One goal, followed step by step through the MDP loop — observation, legal candidates, scored choice, guarded execution, verified reward. Makes the mechanism concrete. |
+| [`consumption-surfaces.md`](consumption-surfaces.md) | How you actually drive IGC: terminal / CLI, UI dashboard, programmatic SDK + GitOps, and an autonomous fleet reconciler. Each with a worked interaction and an implemented-vs-target label. |
+| [`uc-01-power-and-boot.md`](uc-01-power-and-boot.md) | Power on / off and one-shot boot override (e.g. PXE-boot once, then normal). The simplest end-to-end goal. |
+| [`uc-02-bios-attribute-convergence.md`](uc-02-bios-attribute-convergence.md) | Drive BIOS/BMC attributes to a target state, handling *pending vs current* settings and apply-at-reboot. |
+| [`uc-03-firmware-update.md`](uc-03-firmware-update.md) | A long-running task: push an update, then monitor the job/task phase to real completion. |
+| [`uc-04-inventory-and-health.md`](uc-04-inventory-and-health.md) | The safe, read-only lane: crawl to a structured inventory + health roll-up, no mutation. |
+| [`uc-05-storage-and-virtual-media.md`](uc-05-storage-and-virtual-media.md) | Multi-step configuration: mount virtual media / create a volume, verifying each precondition. |
+| [`uc-06-fleet-remediation-multivendor.md`](uc-06-fleet-remediation-multivendor.md) | The transfer payoff: bring a *heterogeneous* fleet (Dell + Supermicro + HPE) to one desired state with a single policy. |
+| [`uc-07-log-and-telemetry-triage.md`](uc-07-log-and-telemetry-triage.md) | Collect/clear service logs and read telemetry — bounded, auditable operational hygiene. |
+
+## Who this is for
+
+- **Operators / SREs** deciding whether to trust an autonomous agent against real BMCs — the guarded
+  execution and verified-success model is designed for exactly that scrutiny.
+- **ML / RL engineers** who want the problem framing (MDP, goal-conditioning, action space) before
+  the module details in `ARCHITECTURE.md`.
+- **Reviewers and newcomers** who want, in fifteen minutes, a true picture of where IGC is going and
+  why the RL framing is load-bearing rather than decorative.
+
+## The vocabulary these pages share
+
+The first time each term appears in a page it is expanded, but here is the shared spine so nothing is
+mysterious:
+
+- **Goal** — a natural-language `instruction`, a machine-checkable `spec` (the success condition an
+  evaluator can *verify*), optional `constraints`, and an optional ordered `plan`. Defined in
+  `igc/core/types.py`.
+- **Observation** — the structured result of a Redfish read (`GET`/`HEAD`): the resource body, its
+  type, its links, its allowed methods, and freshness metadata.
+- **Legal action catalog** — the *dynamic* set of actions available from the current state: an
+  endpoint from the walked resource tree paired with an HTTP method that endpoint actually allows
+  (its `allowed_methods`), plus optional typed argument slots. The policy only ever chooses from
+  this set (D-001).
+- **Evaluator** — the component that checks the observation against the goal's `spec` and returns
+  success / a reward. Success is *measured*, never self-reported.
+- **HER (Hindsight Experience Replay)** — the mechanism that turns a trajectory that missed its goal
+  into useful learning by relabeling it with the goal it *did* reach.
+- **Guardrail** — the `dry-run → approval → execute` path that stands between a chosen action and a
+  real write to hardware.
+
+Author:
+Mus mbayramo@stanford.edu

--- a/docs/use_cases/anatomy-of-an-episode.md
+++ b/docs/use_cases/anatomy-of-an-episode.md
@@ -1,0 +1,147 @@
+# Anatomy of an episode — one goal, followed through the loop
+
+The other pages tell you *what* IGC does. This one shows *how*, by walking a single goal through the
+Markov Decision Process step by step. Read it once and the words "observation", "legal candidate",
+"reward", and "guardrail" stop being abstract.
+
+The example goal: **"PXE-boot this server once, then power it on."** It is deliberately small — two
+real changes — so the loop is visible without drowning in detail.
+
+> The transcript below is illustrative of the **target** decision loop described in
+> [`../ARCHITECTURE.md`](../ARCHITECTURE.md). URLs and bodies follow standard Redfish/DMTF schemas;
+> exact ids differ per vendor, which is precisely the point of step 1.
+
+## The setup
+
+```
+goal = Goal(
+    instruction = "PXE-boot this server once, then power it on",
+    spec        = { "boot.override_target": "Pxe",
+                    "boot.override_enabled": "Once",
+                    "power_state": "On" },
+    constraints = [ "no firmware changes", "at most one reset" ],
+)
+```
+
+The `spec` is the contract the **evaluator** will check against reality at the end — three facts that
+must be true of the actual hardware for the episode to count as success. The agent never gets to
+"decide" it succeeded; the `spec` decides.
+
+## Step 0 — Observe (a real read, not a memory)
+
+The episode starts by reading the service root and the systems collection. The **observation** is
+what comes back — here, that the machine's system member is `/redfish/v1/Systems/Self` (not `/1` — a
+prompt would have guessed wrong):
+
+```
+GET /redfish/v1/Systems
+→ 200  { "Members": [ { "@odata.id": "/redfish/v1/Systems/Self" } ] }
+GET /redfish/v1/Systems/Self
+→ 200  { "@odata.type": "#ComputerSystem.v1_20_0.ComputerSystem",
+         "PowerState": "Off",
+         "Boot": { "BootSourceOverrideTarget": "None", "BootSourceOverrideEnabled": "Disabled" },
+         "Actions": { "#ComputerSystem.Reset": { "target": ".../Actions/ComputerSystem.Reset",
+                                                 "ResetType@Redfish.AllowableValues": ["On","ForceOff","GracefulRestart"] } },
+         "@odata.id": "/redfish/v1/Systems/Self" }
+```
+
+The state encoder turns this into a compact, goal-conditioned latent. Nothing has been changed yet.
+
+## Step 1 — Enumerate the *legal* action catalog
+
+From this observation the environment builds the **legal action catalog** — every (endpoint, method)
+the API actually permits from here, discovered from the walked tree and each resource's
+`allowed_methods`. Abbreviated:
+
+| # | Endpoint | Method | Why it is legal |
+| --- | --- | --- | --- |
+| a | `/Systems/Self` | `PATCH` | resource allows PATCH; carries the `Boot` object |
+| b | `/Systems/Self/Actions/ComputerSystem.Reset` | `POST` | action target advertised in the body |
+| c | `/Systems/Self/BIOS` | `GET` | readable child resource |
+| d | `/Managers/Self` | `GET` | reachable via links |
+| … | … | … | … (tens to hundreds of entries) |
+
+The policy will choose **only from this table**. There is no row for "invent a new URL"; option (b)'s
+`ResetType` is constrained to the `AllowableValues` the resource itself published. This is property #1
+from [`why-rl-not-an-llm.md`](why-rl-not-an-llm.md), made literal.
+
+## Step 2 — Score and choose (the learned decision)
+
+The goal-conditioned state latent scores every candidate (a pointer over the encoded candidates, D-001
+/ D-002). The goal wants the boot override *set first*, then power on — and the learned value function
+has seen that powering on before staging the boot override wastes the "at most one reset" budget. So
+it ranks the `PATCH` to stage the boot override above the `Reset`:
+
+```
+chosen: (a) PATCH /Systems/Self   Boot={ BootSourceOverrideTarget: "Pxe", BootSourceOverrideEnabled: "Once" }
+```
+
+The argument stage fills the typed slots (`Pxe`, `Once`) from the resource's allowable values — again,
+not free-text, but a choice among what the schema permits.
+
+## Step 3 — Guardrail: dry-run → approval → execute
+
+Before anything touches the BMC, the chosen action passes the **guardrail**. In dry-run it renders
+exactly what would be sent and what it expects to change; depending on the configured mode it either
+auto-proceeds (read-only or explicitly trusted) or waits for operator approval on a mutating call:
+
+```
+DRY-RUN  PATCH /redfish/v1/Systems/Self
+         Boot.BootSourceOverrideTarget: None → Pxe
+         Boot.BootSourceOverrideEnabled: Disabled → Once
+         risk: low (no power change, reversible)   approve? [y/N]
+```
+
+This is the seam that makes IGC safe to point at real hardware: a consequential action is always
+inspectable, and can always require a human "yes", before it executes.
+
+## Step 4 — Act, then observe again
+
+On approval the call is sent and the **next observation** is read back — the loop's ground truth:
+
+```
+PATCH /redfish/v1/Systems/Self → 200
+GET   /redfish/v1/Systems/Self → 200  { "Boot": { "BootSourceOverrideTarget": "Pxe",
+                                                   "BootSourceOverrideEnabled": "Once" },
+                                        "PowerState": "Off", … }
+```
+
+## Step 5 — Evaluate (measured reward, not self-report)
+
+The evaluator checks the new observation against the `spec`. Two of three facts now hold
+(`override_target=Pxe`, `override_enabled=Once`); `power_state` is still `Off`. That is real, partial
+progress → a shaped reward, goal **not yet** reached, episode continues.
+
+## Steps 6–8 — The second action, the same loop
+
+The catalog is rebuilt from the new state; the policy now ranks the `Reset` action highest (the boot
+override is staged, so powering on satisfies the last fact within the one-reset budget); the guardrail
+shows a **higher-risk** power change and asks for approval; on approval:
+
+```
+POST /Systems/Self/Actions/ComputerSystem.Reset  { "ResetType": "On" } → 204
+GET  /Systems/Self → 200  { "PowerState": "On", "Boot": { …"Pxe","Once" } }
+```
+
+The evaluator re-checks: all three `spec` facts now hold → **goal reached, verified**. The episode
+terminates with success, having used exactly one reset — honoring the constraint.
+
+## What the agent learned from this one episode
+
+- The full trajectory (states, chosen actions, rewards, the achieved goal) goes into the replay
+  buffer. If the agent had, say, reset *before* staging the boot override and blown the reset budget,
+  **HER** would relabel that trajectory with the goal it *did* achieve ("power on") so the failure
+  still teaches something.
+- Because the endpoints were encoded structurally, what it learned here ("stage the pending boot
+  setting before the reset") transfers to a Dell or HPE machine whose URLs and ids differ — the
+  subject of [`uc-06-fleet-remediation-multivendor.md`](uc-06-fleet-remediation-multivendor.md).
+
+## The loop, in one breath
+
+**Observe → enumerate legal actions → score & choose → dry-run/approve → execute → observe →
+evaluate → (repeat until the spec is verifiably satisfied) → learn from the whole trajectory.** Every
+scenario in this directory is this same loop with a different goal and a different slice of the
+Redfish tree.
+
+Author:
+Mus mbayramo@stanford.edu

--- a/docs/use_cases/consumption-surfaces.md
+++ b/docs/use_cases/consumption-surfaces.md
@@ -1,0 +1,138 @@
+# Consumption surfaces — how you actually drive IGC
+
+One agent, several front doors. The same goal-conditioned policy sits behind all of them; what
+changes is who is holding the goal and how much they want to watch. This page shows each surface with
+a worked interaction, and is explicit about what exists **today** versus what is **target**.
+
+> **Where the code is today.** The only surface that runs now is the **training / evaluation CLI**
+> (entry scripts `igc_main.py` and `igc_ctl.py`, argument groups in `igc/shared/shared_arg_parser.py`)
+> — you train and evaluate the policy offline against the mock REST environment. The *goal-driven*
+> surfaces below (interactive terminal, UI, SDK, daemon) are the **target product** built on the
+> Phase-0 agent described in [`../ARCHITECTURE.md`](../ARCHITECTURE.md). Each is labelled so you never
+> mistake a mock-up for a shipped feature.
+
+## Surface 0 — Training & evaluation CLI  ·  **implemented today**
+
+Before there is an agent to drive, you train and gate it. This is the real, current surface:
+
+```bash
+# Train the goal-conditioned policy offline against the mock REST env (CPU smoke path).
+python igc_main.py --action_trainer agent --head pointer --model_type gpt2 ...
+
+# Default offline gate — no GPU, no network, no live host.
+pytest -q
+```
+
+`--action_trainer` selects what is trained (`agent`, `llm`, `all`), `--head` selects the action head
+(`pointer` per D-001, or the legacy `onehot`). Everything downstream assumes a policy produced here.
+
+## Surface 1 — Interactive terminal / CLI  ·  **target**
+
+The operator's default. You type a goal in plain language; the agent runs the
+observe→choose→dry-run→execute→verify loop from [`anatomy-of-an-episode.md`](anatomy-of-an-episode.md),
+pausing for approval on anything that mutates hardware:
+
+```
+$ igc run --host bmc-a --goal "PXE-boot once, then power on" --approve mutating
+
+  ↳ discovered: ComputerSystem = /redfish/v1/Systems/Self  (Supermicro, BMC fw 1.4)
+  ↳ plan (learned, 2 steps):
+      1. PATCH  Boot → {Pxe, Once}         risk: low
+      2. POST   ComputerSystem.Reset {On}  risk: HIGH (power change)
+
+  step 1/2  DRY-RUN  PATCH /Systems/Self  Boot: None→Pxe, Disabled→Once
+            apply? [y/N] y
+            ✓ applied · verified Boot.override_target=Pxe
+
+  step 2/2  DRY-RUN  POST /Systems/Self/Actions/ComputerSystem.Reset {ResetType: On}
+            apply? [y/N] y
+            ✓ applied · verified PowerState=On
+
+  GOAL REACHED ✓  (spec satisfied: 3/3 · 1 reset used · 2 actions · 0 hallucinated calls)
+```
+
+Flags that matter: `--approve read-only|mutating|all` sets where the guardrail pauses; `--dry-run`
+runs the whole trajectory without executing; `--explain` prints the candidate scores behind each
+choice; `--host` / a hosts file targets one or many controllers. Credentials come from the
+environment, never the command line.
+
+## Surface 2 — UI dashboard  ·  **target**
+
+The same run, for an operator who wants to *watch* the fleet and click the approvals. Text wireframe:
+
+```
+┌ IGC ─ goal ───────────────────────────────────────────────┐
+│ Goal:  [ PXE-boot once, then power on            ] [ Run ] │
+│ Hosts: ◉ bmc-a (Supermicro)  ◉ bmc-b (Dell)  ○ bmc-c (HPE) │
+├ live trajectory ── bmc-a ──────────────────────────────────┤
+│  ● observe   /Systems/Self  PowerState: Off                │
+│  ● choose    PATCH Boot {Pxe, Once}      score ▓▓▓▓▓▓░ 0.86 │
+│  ⧗ approve   [ Dry-run ▾ ]  risk: low     [ Approve ][ Skip]│
+│  ○ execute   …                                             │
+│  ○ verify    spec 2/3                                      │
+├ why this action ───────────────────────────────────────────┤
+│  top candidates:  PATCH Boot 0.86 · GET BIOS 0.41 · Reset  │
+│  0.38  — staging the pending boot setting before the reset │
+│  keeps the 1-reset budget (learned)                        │
+└────────────────────────────────────────────────────────────┘
+```
+
+The UI's job is exactly the three things a chatbot cannot give an operator: **a live, real trajectory**
+(not a generated story), **the candidate scores** behind each decision (auditable "why"), and **an
+approval gate** on every mutation. Success is a green check because the evaluator re-read the resource,
+not because a model said so.
+
+## Surface 3 — Programmatic SDK + GitOps / desired-state  ·  **target**
+
+For automation. Embed the agent, or express infrastructure as a desired **goal spec** in version
+control and let the agent reconcile reality to it:
+
+```python
+from igc import Agent, Goal
+
+agent = Agent.load("policy.ckpt")          # a trained policy
+result = agent.reach(
+    host="bmc-a",
+    goal=Goal(instruction="set boot to PXE once and power on",
+              spec={"boot.override_target": "Pxe", "power_state": "On"}),
+    approve="mutating",                    # or a callback / auto for trusted lanes
+)
+assert result.verified                     # measured against the spec, not self-reported
+print(result.actions, result.rewards)      # the exact trajectory, for the audit log
+```
+
+```yaml
+# desired-state.yaml — checked into git, reconciled by IGC in CI
+- host: bmc-a
+  goal: { instruction: "boot PXE once, power on",
+          spec: { boot.override_target: Pxe, power_state: On } }
+```
+
+Because the outcome is **verifiable**, this composes with GitOps the way a chatbot never could: the
+pipeline can *gate* on `result.verified`, and a run that could not reach the spec fails loudly instead
+of reporting a confident, unchecked "done".
+
+## Surface 4 — Autonomous fleet reconciler  ·  **target**
+
+The end state: a daemon that continuously drives a heterogeneous fleet toward a set of goals, opening
+an approval only when a mutation crosses a configured risk threshold, and logging every verified
+transition. This is [`uc-06-fleet-remediation-multivendor.md`](uc-06-fleet-remediation-multivendor.md)
+running on a schedule. It is only trustworthy *because* of the properties the other pages establish —
+grounded actions, verified success, guarded execution — which is why this surface is the last to
+build, not the first.
+
+## The through-line
+
+| Surface | Who holds the goal | What they watch | Status |
+| --- | --- | --- | --- |
+| Training/eval CLI | ML engineer | metrics, the offline gate | **today** |
+| Interactive terminal | operator | the live run, approves inline | target |
+| UI dashboard | operator / team | trajectories + scores + approvals | target |
+| SDK / GitOps | automation | `result.verified`, the audit trail | target |
+| Autonomous reconciler | the fleet, on a schedule | risk-gated approvals, logs | target |
+
+Every surface rests on the same guarantee: **a goal in, a *verified* real-world outcome out, with
+every consequential step inspectable.** The surface is just how close you want to stand.
+
+Author:
+Mus mbayramo@stanford.edu

--- a/docs/use_cases/uc-01-power-and-boot.md
+++ b/docs/use_cases/uc-01-power-and-boot.md
@@ -1,0 +1,116 @@
+# UC-01 — Power & boot orchestration
+
+> **Target loop, not shipped code.** This page describes the intended end-to-end IGC agent loop, grounded in `docs/ARCHITECTURE.md` (target interaction model) and `docs/DECISIONS.md` (D-001/D-002 action-candidate design). Today the code is a Phase-0 Redfish MDP shell: a mock server replays captured responses and a legacy one-hot policy runs a smoke DQN/HER loop. The behavior below is where that shell is going.
+
+## The goal (in the operator's words, and the machine-checkable spec)
+
+An operator does not say "PATCH `BootSourceOverrideTarget` then POST `ComputerSystem.Reset`." They say: *"Boot this node from PXE once, then power it on."* IGC takes that instruction and pins it to a spec it can verify by re-reading the machine — no interpretation left to chance.
+
+```python
+Goal(
+    instruction="Boot the node from PXE one time, then bring it up.",
+    spec={
+        "Boot.BootSourceOverrideTarget": "Pxe",
+        "Boot.BootSourceOverrideEnabled": "Once",   # one-shot, not sticky
+        "PowerState": "On",
+    },
+    constraints={
+        "prefer": "graceful",        # avoid ForceOff/ForceRestart unless required
+        "no_data_loss": True,        # a running OS must be shut down cleanly
+        "idempotent": True,          # re-running an already-satisfied goal is a no-op
+    },
+    plan=None,   # discovered from the walked tree, not hard-coded
+)
+```
+
+The spec is the contract. Every field is a Redfish property IGC can GET back and compare. Nothing here says *how* — the "how" is discovered from the resource tree and the endpoint's own allowed methods.
+
+## Why a script or a chatbot struggles here
+
+A shell script hard-codes one vendor's URL and one `ResetType`, and cheerfully sends `On` to a node that is already on — or `GracefulShutdown` to a node that is already off, then waits forever for a state change that will never come. A chatbot will happily invent `ResetType: "Reboot"` or `BootSourceOverrideTarget: "Network"` — plausible strings that no schema on that box accepts. Neither one *checks* the box afterward: both report success from having sent the request, not from the machine reaching the state. Power and boot look trivial until idempotence, the right graceful-vs-forced reset, and vendor enum drift all bite at once.
+
+## Observation and the legal actions
+
+The observation is a Redfish GET of the ComputerSystem resource — `PowerState`, the `Boot` object, `Actions`, and the `@Redfish.AllowableValues` annotations the box itself publishes:
+
+```jsonc
+// GET /redfish/v1/Systems/{id}
+{
+  "@odata.type": "#ComputerSystem.v1_x_x.ComputerSystem",
+  "PowerState": "Off",
+  "Boot": {
+    "BootSourceOverrideTarget": "None",
+    "BootSourceOverrideEnabled": "Disabled",
+    "BootSourceOverrideTarget@Redfish.AllowableValues": ["None","Pxe","Hdd","Cd","BiosSetup"]
+  },
+  "Actions": {
+    "#ComputerSystem.Reset": {
+      "target": "/redfish/v1/Systems/{id}/Actions/ComputerSystem.Reset",
+      "ResetType@Redfish.AllowableValues": ["On","ForceOff","GracefulShutdown","GracefulRestart","ForceRestart"]
+    }
+  }
+}
+```
+
+The legal action catalog is the cross-product of **endpoints from the walked tree** and **methods that endpoint actually allows** (`allowed_methods_mapping` from the `rest_api_map.npy` contract). Argument values come only from the box's own allowable-values list — the agent cannot name a `ResetType` the machine did not advertise.
+
+| Endpoint | Method | Legal argument (from box) | Effect |
+|---|---|---|---|
+| `/redfish/v1/Systems/{id}` | `GET` | — | read PowerState + Boot (observation) |
+| `/redfish/v1/Systems/{id}` | `PATCH` | `Boot.BootSourceOverrideTarget ∈ {Pxe,Hdd,Cd,BiosSetup}` | set boot override |
+| `/redfish/v1/Systems/{id}` | `PATCH` | `Boot.BootSourceOverrideEnabled ∈ {Once,Continuous,Disabled}` | one-shot vs sticky |
+| `/redfish/v1/Systems/{id}/Actions/ComputerSystem.Reset` | `POST` | `ResetType ∈ AllowableValues` | power/reset transition |
+
+`Pxe` + `Once` = "next boot only, then revert." `Continuous` would make PXE sticky across every boot — a different goal, and the spec's `Once` is what the evaluator will hold IGC to.
+
+## The trajectory
+
+**Observe.** `GET /redfish/v1/Systems/{id}` → `PowerState: "Off"`, `BootSourceOverrideTarget: "None"`.
+
+**Idempotence check (up front).** The evaluator diffs the current observation against `spec` *before* any mutation. If every field already matched, the goal is done and the trajectory is empty — a verified no-op, not a re-issued reset. Here two fields are unsatisfied, so IGC plans.
+
+**Choose (boot override).** From the legal catalog, the pointer policy selects `PATCH /redfish/v1/Systems/{id}`; the argument decoder fills slots only from the box's allowable values.
+
+```http
+PATCH /redfish/v1/Systems/{id}
+{ "Boot": { "BootSourceOverrideTarget": "Pxe", "BootSourceOverrideEnabled": "Once" } }
+```
+
+**Dry-run → approve → execute.** This mutates hardware, so the guardrail intercepts: it renders the exact request, shows the predicted diff (`Boot: None/Disabled → Pxe/Once`), and pauses for approval. On approval the PATCH executes; a read-only GET would have auto-proceeded with no pause.
+
+**Observe.** `GET` again → `BootSourceOverrideTarget: "Pxe"`, `BootSourceOverrideEnabled: "Once"`. Boot half satisfied.
+
+**Choose (power).** The node is `Off`, so the correct transition to reach `PowerState: On` is `ResetType: "On"` — *not* `GracefulRestart` (there is no OS to restart) and *not* `ForceOff` (wrong direction). The `constraints.prefer = graceful` bias only kicks in when the machine is already `On` and must come down: then IGC picks `GracefulShutdown` over `ForceOff`, and `GracefulRestart` over `ForceRestart`, unless a constraint or a stuck state forces the hard variant.
+
+```http
+POST /redfish/v1/Systems/{id}/Actions/ComputerSystem.Reset
+{ "ResetType": "On" }
+```
+
+**Dry-run → approve → execute → observe.** Guardrail pauses (mutation), approval, POST, then poll `GET` until `PowerState: "On"`.
+
+**Evaluate.** All three spec fields now measured true against the re-read state → goal reached.
+
+## What "done" means
+
+Done is a measurement, never a claim. The evaluator re-reads `GET /redfish/v1/Systems/{id}` and asserts each spec field against the fresh body:
+
+- `PowerState == "On"` — read back from the resource, not inferred from "the POST returned 204."
+- `Boot.BootSourceOverrideTarget == "Pxe"` and `BootSourceOverrideEnabled == "Once"`.
+
+A `2xx` on the Reset action means *accepted*, not *reached*; the box may still be transitioning. IGC keeps observing until the observed state equals the spec (or a timeout ends the episode as failure). Success is defined by the world, not by the agent's confidence.
+
+## Constraints, risk, and the guardrail
+
+Every action here except the GETs is a **mutation** — a `PATCH` to `Boot` and a `POST` to `ComputerSystem.Reset`. A `ForceOff` or `ForceRestart` on a running node can lose in-flight work, so those carry the highest risk weight and the `no_data_loss` constraint steers away from them.
+
+The guardrail is fixed: **dry-run → approval → execute** for anything that changes state. It renders the concrete request and the predicted state diff, then blocks until an operator approves. Read-only lanes (the observation GETs, the idempotence pre-check) auto-proceed with no pause. Approval is per-mutation, so a plan that flips a sticky `Continuous` override or issues a hard reset cannot slip through as a side effect of a "just power it on" instruction.
+
+## What transfers / what it learned
+
+The same trajectory, run on Dell iDRAC, Supermicro, HPE iLO, or a generic DMTF service, differs only in the enum sets and OEM extras each box advertises — which is exactly why IGC reads `@Redfish.AllowableValues` off the resource instead of hard-coding a table. The action *shape* (`ComputerSystem.Reset` POST, `Boot` PATCH on the ComputerSystem) is standard schema and transfers unchanged; the *values* are drawn per-box, so a vendor that omits `Pxe` or adds an OEM reset type is handled without a code edit.
+
+From HER, even a run that overshot teaches: an episode that ended in `PowerState: On` with a `Continuous` override — wrong for *this* goal — is relabeled as a successful trajectory for the goal it *did* reach, so the failed rollout still yields gradient. Over many episodes the policy converges on the **shortest safe path**: skip already-satisfied fields (idempotence), pick the minimal-risk `ResetType` that reaches the target power state, and set the override in the same PATCH rather than two round-trips. The simplest goal is the one that teaches the loop its spine — verify first, act only on the delta, prove it by re-reading.
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/docs/use_cases/uc-02-bios-attribute-convergence.md
+++ b/docs/use_cases/uc-02-bios-attribute-convergence.md
@@ -1,0 +1,124 @@
+# UC-02 — BIOS / attribute convergence
+
+> Target loop, grounded in `docs/ARCHITECTURE.md` + `docs/DECISIONS.md`. Today the code is a Phase-0 Redfish MDP shell (captured-replay env, one-hot actions); the observe → choose → guard → verify loop below is the behavior we are building toward, not what ships in Phase 0.
+
+## The goal (in the operator's words, and the machine-checkable spec)
+
+An operator wants a node's firmware settings brought to a known-good baseline: boot mode UEFI, virtualization and IOMMU on, and — because these are performance nodes — hyper-threading disabled. In natural language: *"Make sure this box's BIOS matches our compute baseline, and reboot it once if you have to."*
+
+```python
+Goal(
+    instruction="Bring BIOS attributes to the compute baseline; one reset permitted.",
+    spec={
+        # machine-checkable: read back from /Systems/{id}/Bios .Attributes
+        "current_attributes_equal": {
+            "BootMode": "Uefi",
+            "ProcVirtualization": "Enabled",
+            "Iommu": "Enabled",
+            "LogicalProc": "Disabled",   # hyper-threading off
+        },
+        "pending_settings_empty": True,   # nothing left staged after apply
+    },
+    constraints=[
+        "at_most_one_reset",
+        "reset_only_after_settings_staged",
+        "no_power_action_while_task_running",
+    ],
+    plan=None,  # discovered from the walked resource tree, not hand-authored
+)
+```
+
+The spec is deliberately written against **current** attributes, not the settings object. That single choice is what keeps the agent honest.
+
+## Why a script or a chatbot struggles here
+
+BIOS on Redfish is not a live register — writing an attribute does not change it. A PATCH lands in a *pending* settings buffer and only takes effect on the next qualifying reset. A naive script (or an LLM told "set LogicalProc=Disabled") PATCHes the resource, gets `200 OK`, and reports success — while the running machine is unchanged. The trap is a **false Markov collapse**: the agent treats the acknowledgement as the new state, so its model of the world and the actual firmware diverge silently until someone reboots weeks later and gets a surprise. Getting this right needs staging, exactly-one reset, and a re-read *after apply* — a sequence, not a call.
+
+## Observation and the legal actions
+
+The agent's observation is a Redfish GET of the Bios resource. What it reads:
+
+- `Attributes` — the **current** effective values.
+- `@Redfish.Settings` — the annotation whose `SettingsObject.@odata.id` points at the pending settings resource, plus `SupportedApplyTimes` and any prior-apply `Messages`.
+- On the settings object: `@Redfish.SettingsApplyTime` (or the `ApplyTime` in the payload you PATCH), typically `OnReset` for BIOS.
+
+Actions are drawn only from the **legal catalog**: an endpoint that actually appeared in the walked tree, paired with a method that endpoint's `allowed_methods` (from HTTP `Allow` / the resource's advertised operations) permits. Nothing is invented.
+
+| Endpoint (from the walk) | Method | Why it is legal here |
+|---|---|---|
+| `/redfish/v1/Systems/{id}/Bios` | `GET` | read current `Attributes` + `@Redfish.Settings` |
+| `/redfish/v1/Systems/{id}/Bios/Settings` | `PATCH` | settings object advertises PATCH; stage pending values |
+| `/redfish/v1/Systems/{id}` | `POST` (`ComputerSystem.Reset`) | `Actions` target present; applies OnReset settings |
+| `/redfish/v1/Systems/{id}/Bios/Settings` | `GET` | confirm pending buffer state after apply |
+
+`GET`s are read-only lanes (auto-proceed). The `PATCH` and the `Reset` `POST` are mutations and each must clear the guardrail.
+
+## The trajectory
+
+Abbreviated observe → choose → dry-run/approve → execute → observe → evaluate loop, with real standard Redfish calls:
+
+1. **Observe.** `GET /redfish/v1/Systems/{id}/Bios`. Current `Attributes` show `LogicalProc: "Enabled"`, `BootMode: "Uefi"` already correct, `Iommu: "Disabled"`. The `@Redfish.Settings` annotation resolves the settings object to `/redfish/v1/Systems/{id}/Bios/Settings`; `SupportedApplyTimes` includes `OnReset`.
+
+2. **Choose.** Spec ≠ current on two attributes. The only legal way to change them is a PATCH to the settings object. The agent selects `(…/Bios/Settings, PATCH)` from the catalog.
+
+3. **Dry-run.** The guardrail renders the exact request and diff without sending it:
+
+   ```http
+   PATCH /redfish/v1/Systems/{id}/Bios/Settings
+   Content-Type: application/json
+
+   {
+     "@Redfish.SettingsApplyTime": {
+       "@odata.type": "#Settings.v1_3_5.PreferredApplyTime",
+       "ApplyTime": "OnReset"
+     },
+     "Attributes": {
+       "Iommu": "Enabled",
+       "LogicalProc": "Disabled"
+     }
+   }
+   ```
+   Dry-run summary: *stages 2 attributes, ApplyTime OnReset, no immediate effect, requires 1 reset.*
+
+4. **Approve → execute.** Operator approves the stage. PATCH returns `200`/`202`; the buffer now holds the two pending values.
+
+5. **Observe (mid-flight).** `GET …/Bios` again. **Current `Attributes` are still `Iommu: Disabled`, `LogicalProc: Enabled`.** This is the exact point where a naive agent declares victory. The evaluator does not — current ≠ target, and the settings object now shows a non-empty pending set. Not done.
+
+6. **Choose the reset.** Constraint `reset_only_after_settings_staged` is satisfied, `at_most_one_reset` still has budget. Legal action: `(…/Systems/{id}, POST ComputerSystem.Reset)`.
+
+7. **Dry-run → approve → execute** the single reset:
+
+   ```http
+   POST /redfish/v1/Systems/{id}/Actions/ComputerSystem.Reset
+   { "ResetType": "GracefulRestart" }
+   ```
+   Guardrail flags this as a higher-risk power action; operator approves. One reset spent; budget now zero.
+
+8. **Observe after apply.** Poll the reset `Task` to completion (`no_power_action_while_task_running` blocks any further mutation until then), then `GET …/Bios` once more.
+
+9. **Evaluate.** Against the *re-read* current state — see below.
+
+## What "done" means
+
+The Evaluator verifies the spec against freshly re-read state, never against the PATCH acknowledgement or the agent's own claim:
+
+- `GET /redfish/v1/Systems/{id}/Bios` → assert **current** `Attributes` now equal every value in `current_attributes_equal` (`BootMode: Uefi`, `ProcVirtualization: Enabled`, `Iommu: Enabled`, `LogicalProc: Disabled`).
+- `GET /redfish/v1/Systems/{id}/Bios/Settings` → assert the pending `Attributes` set is empty (or its post-apply `Messages` report success), satisfying `pending_settings_empty`.
+
+Only when both hold — measured, after reset — does the episode terminate as success. If current attributes still lag, the buffer is consumed but wrong, or a second reset would be required, it is a failure, not a partial credit. Success is never self-reported; the read-back is the reward signal.
+
+## Constraints, risk, and the guardrail
+
+- **Mutations and their risk.** The `Bios/Settings` PATCH is low/medium risk (staged, reversible by re-PATCHing before apply, no immediate effect). The `ComputerSystem.Reset` is the real risk: it interrupts the running workload. Both pause at **dry-run → approval → execute**; the reset is surfaced as the higher-severity gate.
+- **Where approval pauses.** Every write stops before it leaves the agent. The operator sees the rendered request and diff, not a summary the model wrote about itself.
+- **Budget as a hard rail.** `at_most_one_reset` is enforced by the catalog/guard, not by hoping the policy learned restraint — a second reset action is simply illegal once the budget is spent, which also defends the BMC from a reset-storm.
+- **Ordering.** `reset_only_after_settings_staged` prevents the classic waste: rebooting before anything is staged, burning the one reset for nothing.
+
+## What transfers / what it learned
+
+The convergence shape here — **stage → apply-via-reset → verify current** — is a reusable skill, and HER is what makes the failures pay. An episode that PATCHed the wrong attribute, or rebooted before staging, gets relabeled: *the trajectory that produced the state it actually reached becomes an optimal demonstration for that (accidental) goal.* The agent thereby learns the shortest safe path — one PATCH, one reset, one verify — instead of the flailing PATCH-reboot-PATCH-reboot loop a fresh policy tends toward.
+
+The transferable lesson is vendor-independent because the mechanism is DMTF-standard: `@Redfish.Settings` + a SettingsObject + `ApplyTime: OnReset` is how BIOS convergence works on Dell iDRAC, Supermicro, HPE iLO, and generic DMTF implementations alike. Attribute *names* differ across vendors (a Dell `LogicalProc` is not spelled the same everywhere), but those names come from the walked tree and the goal spec, never from a hardcoded map — so the same policy that converges BIOS on one vendor converges it on the next with no retraining of the loop, only the per-vendor attribute vocabulary discovered at observe time. And the anti-pattern it internalizes — *never trust the write, verify the re-read* — is exactly the false-Markov-collapse defense that generalizes to every pending-settings resource in Redfish (NIC, storage, manager config), not just BIOS.
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/docs/use_cases/uc-03-firmware-update.md
+++ b/docs/use_cases/uc-03-firmware-update.md
@@ -1,0 +1,141 @@
+# UC-03 — Firmware update workflow
+
+> Target loop, grounded in `docs/ARCHITECTURE.md` + `docs/DECISIONS.md`. Today the code is a Phase-0 Redfish MDP shell (captured-data replay, one-hot actions); the behavior below is the end-to-end loop IGC is being built to run.
+
+## The goal (in the operator's words, and the machine-checkable spec)
+
+An operator does not want to babysit a firmware flash. They want to say what version should be running and walk away — and be sure that when the agent claims "done," the component is actually running that build and nothing else moved.
+
+```python
+Goal(
+    instruction="Update the BMC firmware to build 7.10.30 on this system, and nothing else.",
+    spec={
+        "target_component": "BMC",                 # SoftwareInventory member for the manager
+        "target_version": "7.10.30",               # exact Version string after update
+        "task_terminal_state": "Completed",        # UpdateService task must reach Completed
+    },
+    constraints=[
+        "single_component",                        # exactly one inventory member changes
+        "no_reset_of_unrelated_targets",           # do not touch other Managers/Systems
+        "no_config_writes",                        # firmware only; no BIOS attribute / boot changes
+        "mutation_requires_approval",              # SimpleUpdate pauses for human OK
+    ],
+    plan=[
+        "read UpdateService + FirmwareInventory to confirm current version and update capability",
+        "submit SimpleUpdate for exactly the target component",
+        "monitor the returned Task to a terminal state",
+        "re-read SoftwareInventory and verify the running Version equals the target",
+    ],
+)
+```
+
+The spec is the contract. Every clause is machine-checkable against a re-read of the box — not against what the update service reported at submit time.
+
+## Why a script or a chatbot struggles here
+
+A shell script that POSTs `SimpleUpdate` and prints the HTTP 202 has done the *easy* 5% — it declares victory at submit, before a single byte is flashed. The hard part is the long tail: the update is asynchronous and multi-phase (staged → verified → applied → sometimes a controller reset), it can sit at `Running` for many minutes, and it can fail *after* accepting the job with a `TaskState: Exception`. A chatbot that "sounds confident" has no way to distinguish a job that completed from one that stalled at 60% or silently rolled back — and no notion that flashing the *wrong* target, or resetting a neighbor, violated the goal.
+
+## Observation and the legal actions
+
+The agent observes Redfish `GET` results and never invents an endpoint or a verb. Every candidate action is a pair — an endpoint from the walked resource tree, and a method advertised by that endpoint's `Allow` header or `@Redfish.ActionInfo`. First reads:
+
+- `GET /redfish/v1/UpdateService` — is `SimpleUpdate` in `Actions`? What `TransferProtocol` values does `@Redfish.ActionInfo` allow?
+- `GET /redfish/v1/UpdateService/FirmwareInventory` → the `SoftwareInventory` member for the BMC, to read its current `Version`.
+
+From that walk, the legal action catalog for this goal:
+
+| Endpoint | Method | Redfish meaning | Lane |
+|---|---|---|---|
+| `/redfish/v1/UpdateService` | GET | read update capability + action info | read-only |
+| `/redfish/v1/UpdateService/FirmwareInventory/BMC` | GET | read current firmware `Version` | read-only |
+| `/redfish/v1/UpdateService/Actions/UpdateService.SimpleUpdate` | POST | stage + apply an image (mutation) | **guarded** |
+| `/redfish/v1/TaskService/Tasks/{id}` | GET | poll `TaskState` / `PercentComplete` | read-only |
+| `/redfish/v1/UpdateService/FirmwareInventory/BMC` | GET | re-read `Version` after apply | read-only |
+
+Note what is *absent*: no `ComputerSystem.Reset`, no `Bios` `SettingsObject` write. Those endpoints exist in the walk but are not in this goal's catalog, so the policy cannot select them.
+
+## The trajectory
+
+Abbreviated observe → choose → dry-run/approve → execute → observe → evaluate loop with real standard Redfish calls.
+
+**1. Observe (read-only, auto-proceed).** Confirm the service supports the action and read the baseline version.
+
+```http
+GET /redfish/v1/UpdateService/FirmwareInventory/BMC
+→ 200 { "@odata.type": "#SoftwareInventory.v1_x.SoftwareInventory",
+        "Id": "BMC", "Version": "7.10.06", "Updateable": true }
+```
+
+Baseline `7.10.06` ≠ target `7.10.30`, and `Updateable: true`. The goal is not yet satisfied, and it is achievable.
+
+**2. Choose.** The policy scores the catalog against the goal and selects `SimpleUpdate` on exactly the BMC target. Because it is a `POST` that mutates hardware, it enters the guardrail rather than executing.
+
+**3. Dry-run → approval.** The agent renders the exact request it intends to send and pauses:
+
+```http
+POST /redfish/v1/UpdateService/Actions/UpdateService.SimpleUpdate
+{
+  "ImageURI": "<operator-supplied image reference>",
+  "TransferProtocol": "HTTPS",
+  "Targets": [ "/redfish/v1/UpdateService/FirmwareInventory/BMC" ]
+}
+```
+
+The dry-run shows a single-element `Targets` list — the guardrail's `single_component` check passes — and no reset action bundled in. The operator approves.
+
+**4. Execute.** The service accepts the job and returns a Task, not a result:
+
+```http
+→ 202 Accepted
+   Location: /redfish/v1/TaskService/Tasks/42
+   { "@odata.type": "#Task.v1_x.Task", "Id": "42", "TaskState": "New" }
+```
+
+**5. Observe the long-running task (read-only poll loop).** The agent does **not** stop here. It polls until a terminal state, treating `New`/`Running` as "keep observing":
+
+```http
+GET /redfish/v1/TaskService/Tasks/42
+→ { "TaskState": "Running", "PercentComplete": 35 }
+   ... "Running", 72 ...
+   ... "Running", 100 ...
+→ { "TaskState": "Completed", "PercentComplete": 100,
+    "TaskStatus": "OK" }
+```
+
+**The Exception path.** If a poll returns `TaskState: Exception` (or `Killed`), the agent does not retry blindly and never reports success. It reads the Task `Messages[]` for the failure detail, marks the goal unmet, and surfaces the failure for the operator — a failed flash is a terminal outcome to report, not to paper over.
+
+**6. Re-read and evaluate.** Reaching `Completed` is necessary but not sufficient. The agent re-reads the inventory:
+
+```http
+GET /redfish/v1/UpdateService/FirmwareInventory/BMC
+→ 200 { "Id": "BMC", "Version": "7.10.30" }
+```
+
+## What "done" means
+
+The Evaluator verifies the spec against freshly-read state — never against the submit response or the agent's own narration:
+
+- **Task terminality:** the polled `Task` reached `TaskState == "Completed"` (an `Exception`/`Killed` terminal state fails the goal outright).
+- **Version match:** the re-read `SoftwareInventory` member for the BMC reports `Version == "7.10.30"`. A job that "completed" but left the old build running is a **failure**, and only this re-read catches it.
+- **Single-component:** a diff of `FirmwareInventory` versions before vs. after shows exactly one member changed. Any second version delta violates `single_component`.
+- **No collateral:** no unrelated `Reset` or config write was issued (the catalog made those unselectable, and the evaluator confirms nothing else in scope moved).
+
+Only when all clauses hold does the episode terminate as success. "Completed" from the update service is one input to that judgment, not the judgment itself.
+
+## Constraints, risk, and the guardrail
+
+Firmware flashing is among the highest-risk Redfish mutations: a bad image or an interrupted apply can brick a management controller, and a stray controller reset can drop a live host. So:
+
+- **`SimpleUpdate` is a guarded mutation.** It always runs dry-run → approval → execute. The dry-run exposes the literal `ImageURI`, `TransferProtocol`, and `Targets` for human inspection; approval is where the operator catches a wrong image or a fat-fingered target *before* anything is written.
+- **Read lanes auto-proceed.** The `UpdateService`/`FirmwareInventory` reads and the whole `TaskService/Tasks/{id}` poll loop carry no approval cost, so monitoring is free and continuous.
+- **Scope is fenced by the catalog, not by good intentions.** `ComputerSystem.Reset` and BIOS `SettingsObject` writes are out of this goal's action set, so the policy structurally cannot bundle them into a firmware job.
+- Credentials and image references are operator-supplied at run time — never baked into the goal, the policy, or logs.
+
+## What transfers / what it learned
+
+**HER turns the slow path into a lesson.** A firmware episode is long and mostly waiting. When a run overshoots — extra redundant `GET`s, a poll interval that was too eager, or an abandoned attempt that landed on a *different* valid version — Hindsight Experience Replay relabels that trajectory with the goal it *did* achieve ("reached version X, one component, task Completed"). The agent extracts a clean, near-shortest recipe (read capability → submit once → poll to terminal → verify) from otherwise wasted episodes, and stops padding the path with unnecessary reads.
+
+**The shape is vendor-portable.** The pattern — `UpdateService.SimpleUpdate` returns a `Task`, poll `TaskState`/`PercentComplete` to a terminal state, then verify a `SoftwareInventory.Version` — is standard DMTF Redfish. Only the concrete endpoints and inventory member ids differ across Dell iDRAC, Supermicro, HPE iLO, and generic DMTF implementations. Because the agent discovers the catalog from each machine's own walked tree rather than hardcoding paths, the "submit → monitor to Completed → verify version" competency transfers to a new vendor's controller with little or no retraining — the async-task discipline is the reusable skill, not any one URL.
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/docs/use_cases/uc-04-inventory-and-health.md
+++ b/docs/use_cases/uc-04-inventory-and-health.md
@@ -1,0 +1,139 @@
+# UC-04 — Inventory & health discovery
+
+> Target loop, grounded in `docs/ARCHITECTURE.md` and `docs/DECISIONS.md`. Today the code is a Phase-0 Redfish MDP shell; the read-only crawl, evaluator, and guardrail described here are the target behavior the shell is being built toward.
+
+This is the on-ramp. Before IGC is ever allowed to change a machine, it earns trust by *reading* one completely — every reachable component, every health field — and proving to an evaluator that it saw the whole box and nothing is on fire. Every legal action in this scenario is a `GET` or `HEAD`, so the guardrail auto-proceeds: no approvals, no risk, no writes. It is the safest possible way to watch an RL agent learn to navigate a real Redfish tree.
+
+## The goal (in the operator's words, and the machine-checkable spec)
+
+The operator says: "Walk this machine and give me a full inventory and a health summary — tell me if anything is Critical."
+
+That becomes a `Goal` whose spec is a **completeness + health assertion**, not a free-text report:
+
+```python
+Goal(
+    instruction="Discover full inventory and roll up component health for this system.",
+    spec={
+        # completeness: every reachable component class was actually read
+        "read_component_classes": [
+            "Chassis", "Systems", "Managers",
+            "Processors", "Memory",
+            "Storage", "Drives",
+            "EthernetInterfaces", "NetworkAdapters",
+            "Power", "Thermal",
+        ],
+        "all_reachable_resources_read": True,   # no @odata.id link left unvisited
+        # health: rolled up from Status.Health on every resource read
+        "max_health_severity": "Warning",       # PASS iff no component reports "Critical"
+        "require_status_present": True,          # every component exposes Status.State/Health
+    },
+    constraints={
+        "methods_allowed": ["GET", "HEAD"],      # read-only lane — mutation is out of scope
+        "rate_limit_rps": 4,                     # pace the BMC; a naive crawl has knocked one offline
+        "max_requests": 2000,
+    },
+    plan=None,   # discovery is breadth-first over the hypermedia graph, not a fixed script
+)
+```
+
+The spec is machine-checkable: "all reachable resources read" and "no Critical health" are things the evaluator can *measure* against the crawled tree, not claims the agent gets to assert about itself.
+
+## Why a script or a chatbot struggles here
+
+A hand-written crawler hard-codes today's tree shape — add an NVMe drive, a second NIC, a vendor OEM subtree, and it silently walks past the new `@odata.id` it never learned about. A chatbot will happily *narrate* a healthy-looking summary from the first page it read and call it done, with no guarantee it reached `Storage/Drives` at all. Redfish is a hypermedia graph, not a fixed API: the only correct traversal is "follow every link you actually find," and the only honest health claim is one backed by having read every node. Both the brittle script and the confident chatbot fail the same way — they report completeness they never verified.
+
+## Observation and the legal actions
+
+The agent's observation is a Redfish `GET` result: the resource body, its `@odata.type`, the `@odata.id` links it exposes, and its `Status` block. From each observed resource, the **legal action catalog** is built by construction — the endpoint comes from a link that was actually present in the walked tree, and the method comes from that endpoint's own `Allow` header (`allowed_methods_mapping`). The agent cannot invent a URL or a verb; it can only pick a `(endpoint, method)` pair that Redfish already advertised. In this scenario every advertised legal action on the frontier is read-only:
+
+| Endpoint (from a walked link) | Method | Why it is legal | Lane |
+| --- | --- | --- | --- |
+| `/redfish/v1/Systems/<id>` | `GET` | `@odata.id` from the `Systems` collection | read-only |
+| `/redfish/v1/Systems/<id>/Processors` | `GET` | link in the System body | read-only |
+| `/redfish/v1/Systems/<id>/Memory` | `GET` | link in the System body | read-only |
+| `/redfish/v1/Systems/<id>/Storage` | `GET` | link in the System body | read-only |
+| `/redfish/v1/Chassis/<id>/Thermal` | `GET` | link in the Chassis body | read-only |
+| `/redfish/v1/Chassis/<id>/Power` | `GET` | link in the Chassis body | read-only |
+| `/redfish/v1/Managers/<id>` | `HEAD` | reachability probe before a full read | read-only |
+
+There is no mutating candidate on the frontier — the goal's `methods_allowed` filters the catalog to `GET`/`HEAD`, so the policy's entire action space is safe reads.
+
+## The trajectory
+
+Observe → choose → (dry-run is trivial for reads) → execute → observe → evaluate, iterated breadth-first until the reachable graph is exhausted.
+
+1. **Observe the root.** `GET /redfish/v1/` → the service root, exposing the `Systems`, `Chassis`, and `Managers` collections as `@odata.id` links.
+
+2. **Choose from the legal catalog.** The policy scores the read-only candidates and picks the `Systems` collection.
+   ```http
+   GET /redfish/v1/Systems
+   ```
+   ```json
+   {
+     "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+     "Members": [ { "@odata.id": "/redfish/v1/Systems/Self" } ]
+   }
+   ```
+
+3. **Dry-run auto-passes.** The guardrail classifies `GET` as read-only, so the dry-run → approval → execute pipeline collapses to immediate execution — no human pause.
+   ```http
+   GET /redfish/v1/Systems/Self
+   ```
+   ```json
+   {
+     "@odata.type": "#ComputerSystem.v1_20_0.ComputerSystem",
+     "Status": { "State": "Enabled", "Health": "OK" },
+     "Processors":  { "@odata.id": "/redfish/v1/Systems/Self/Processors" },
+     "Memory":      { "@odata.id": "/redfish/v1/Systems/Self/Memory" },
+     "Storage":     { "@odata.id": "/redfish/v1/Systems/Self/Storage" },
+     "EthernetInterfaces": { "@odata.id": "/redfish/v1/Systems/Self/EthernetInterfaces" }
+   }
+   ```
+
+4. **Expand the frontier.** Each newly seen `@odata.id` becomes a legal candidate. The agent descends into member resources:
+   ```http
+   GET /redfish/v1/Systems/Self/Processors/CPU1
+   ```
+   ```json
+   {
+     "@odata.type": "#Processor.v1_16_0.Processor",
+     "Status": { "State": "Enabled", "Health": "OK" }
+   }
+   ```
+   ```http
+   GET /redfish/v1/Systems/Self/Storage/Ctrl0/Drives/Disk0
+   ```
+   ```json
+   {
+     "@odata.type": "#Drive.v1_18_0.Drive",
+     "Status": { "State": "Enabled", "Health": "Warning" }
+   }
+   ```
+
+5. **Cross to the physical view.** `Chassis` links carry `Power` and `Thermal` (`#Power.Power`, `#Thermal.Thermal`), whose sensor entries also expose `Status.State`/`Status.Health`. These are folded into the same health roll-up.
+
+6. **Terminate on graph exhaustion.** When every reachable `@odata.id` has been read and no unread link remains on the frontier, the episode ends and control passes to the evaluator. Rate limiting (`rate_limit_rps`) paces the whole walk so the BMC is never hammered.
+
+## What "done" means
+
+Done is measured, never self-reported. The `Evaluator` re-derives the answer from the crawled tree and checks it against the spec:
+
+- **Completeness** — every class in `read_component_classes` has at least one resource in the visited set, and `all_reachable_resources_read` holds iff the set of visited `@odata.id`s equals the set of links discovered (the frontier drained to empty). A missed subtree leaves a link unvisited and the assertion fails.
+- **Health roll-up** — the evaluator aggregates `Status.Health` across every visited resource and computes the worst severity. `max_health_severity: "Warning"` passes only if no component reported `Critical`. The `Warning` drive above keeps the run PASS-but-flagged; a single `Critical` fan or drive would fail the health assertion and surface exactly which resource caused it.
+- **Status presence** — `require_status_present` fails the run if any component lacked a `Status` block, catching partial or malformed reads rather than scoring them as healthy.
+
+The output is a structured inventory (components keyed by canonical URI and `@odata.type`) plus a health summary with the worst-severity component named — both reconstructed from observations, both auditable.
+
+## Constraints, risk, and the guardrail
+
+Risk level: **none**. Every mutation count in this scenario is zero. The guardrail's dry-run → approval → execute path exists to pause on writes; here the goal constrains `methods_allowed` to `GET`/`HEAD`, so the legal catalog contains no mutating action and the guardrail auto-proceeds on every step. The only operational hazard is *volume* — an unpaced recursive crawl has knocked a live BMC offline — so `rate_limit_rps` and `max_requests` are the real safety controls, and they cap request rate, not blast radius. This is precisely why inventory-and-health is the trust-building on-ramp: an operator can watch IGC drive a real controller end-to-end, verify the evaluator's completeness math, and build confidence in the loop *before* a single mutating use case is ever enabled.
+
+## What transfers / what it learned
+
+The read-only crawl is where IGC learns the **shape of a machine** cheaply and safely, and that knowledge is exactly what mutation scenarios reuse. Two angles:
+
+- **HER.** Even a "failed" crawl is a labelled success for the state it *did* reach. If the agent stops early having read only the compute subtree, HER relabels that trajectory as "achieve inventory-of-Systems" — a goal it did satisfy — so partial walks still yield gradient. Over episodes the policy learns the **shortest safe traversal** that drains the reachable graph without redundant re-reads, guided by the completeness reward rather than a hand-tuned crawl order.
+- **Cross-vendor generalization.** Because candidates are built from `@odata.type`, containment relation, and the presence of an action target — never from vendor-specific URL tokens (see `docs/DECISIONS.md`, D-002) — a policy trained to walk Dell iDRAC trees transfers to Supermicro, HPE iLO, and generic DMTF stacks. Every conformant implementation exposes `Chassis`/`Systems`/`Managers` and `Status.State`/`Status.Health`; the standard schema *is* the transfer surface. The inventory learned here becomes the walked tree that later, riskier use cases draw their legal action catalog from — read first, mutate never before you have.
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/docs/use_cases/uc-05-storage-and-virtual-media.md
+++ b/docs/use_cases/uc-05-storage-and-virtual-media.md
@@ -1,0 +1,169 @@
+# UC-05 — Storage & virtual media
+
+> Target-loop description, grounded in `docs/ARCHITECTURE.md` + `docs/DECISIONS.md`. Today the code is a Phase-0 Redfish MDP shell (captured-replay env, one-hot actions); the observe → choose → dry-run → execute → evaluate loop below is the target behavior those documents commit to, not what the current trainer emits.
+
+## The goal (in the operator's words, and the machine-checkable spec)
+
+An operator wants a node prepped to reinstall: mount the install ISO as virtual media, and make sure
+the OS has a mirrored data volume to land on. Two mutating sub-goals, both gated on real hardware
+preconditions.
+
+```python
+Goal(
+    instruction="Mount the install ISO as virtual CD, and ensure a RAID1 data volume exists.",
+    spec={
+        # sub-goal A: virtual media
+        "virtual_media.image_attached": True,
+        "virtual_media.inserted": True,
+        "virtual_media.write_protected": True,
+        # sub-goal B: storage volume
+        "volume.raid_type": "RAID1",
+        "volume.min_capacity_bytes": 900_000_000_000,   # ~900 GB usable
+        "volume.member_drive_count": 2,
+    },
+    constraints=[
+        "no_existing_media_eject",        # never eject media already mounted by someone else
+        "only_unconfigured_drives",       # never consume a drive already in a volume
+        "no_destructive_reinit",          # no controller reset / drive secure-erase
+        "idempotent",                     # re-running must not create a second volume
+    ],
+    plan=None,   # the agent discovers the ordering from the walked tree
+)
+```
+
+The spec is machine-checkable: every key is a field the Evaluator can re-read from Redfish and
+compare. Nothing here is "looks done."
+
+## Why a script or a chatbot struggles here
+
+A shell script `POST`s the `InsertMedia` action and the `Volumes` collection in a fixed order, then
+exits 0 — it never notices the slot already had an ISO mounted, or that the two "spare" drives are
+already members of another volume, so it either clobbers a peer's media or gets a 400 it can't
+interpret. A chatbot will happily *narrate* a create-volume call with a plausible-looking body and a
+drive URI it invented, because it has no walked action catalog to constrain it. Neither one verifies
+capacity or configuration state *before* the mutating call, and neither re-reads the tree afterward to
+prove the volume actually materialized.
+
+## Observation and the legal actions
+
+The agent's Observation is a Redfish GET result — here, the `Storage` subtree and the manager's
+`VirtualMedia` collection, plus the `Drives` members with their `CapacityBytes`, `MediaType`, and
+`Links.Volumes` (empty ⇒ unconfigured). Actions are never free-form: each candidate is an endpoint
+harvested from the walked resource tree paired with a method drawn from *that* endpoint's
+`allowed_methods` (the `Allow` header / `@Redfish.ActionInfo`). The legal catalog for this goal:
+
+| Endpoint (walked)                                            | Method | What it does                              |
+|-------------------------------------------------------------|--------|-------------------------------------------|
+| `/redfish/v1/Managers/{id}/VirtualMedia/{slot}`             | GET    | read `Inserted`, `Image`, `MediaTypes`    |
+| `.../VirtualMedia/{slot}/Actions/VirtualMedia.InsertMedia`  | POST   | attach ISO (`Image`, `Inserted`, `WriteProtected`) |
+| `.../VirtualMedia/{slot}/Actions/VirtualMedia.EjectMedia`   | POST   | detach media (guarded — constraint blocks)|
+| `/redfish/v1/Systems/{id}/Storage/{ctrl}`                   | GET    | read controller + `Drives` links          |
+| `/redfish/v1/Systems/{id}/Storage/{ctrl}/Drives/{d}`        | GET    | read `CapacityBytes`, `Links.Volumes`     |
+| `/redfish/v1/Systems/{id}/Storage/{ctrl}/Volumes`           | GET    | list existing volumes (idempotency check) |
+| `/redfish/v1/Systems/{id}/Storage/{ctrl}/Volumes`           | POST   | create Volume (`RAIDType`, `Drives`)      |
+
+If `POST` is not in a collection's advertised methods, the create candidate simply is not in the
+catalog — the agent cannot select an action the endpoint does not permit. No hallucinated URIs, no
+invented action names.
+
+## The trajectory
+
+**1 — Observe (virtual media slot).** GET the slot; check the precondition, not just try-and-catch.
+
+```json
+GET /redfish/v1/Managers/1/VirtualMedia/CD
+{ "Inserted": false, "Image": null, "MediaTypes": ["CD", "DVD"],
+  "ConnectedVia": "NotConnected", "WriteProtected": true }
+```
+
+`Inserted: false` satisfies `no_existing_media_eject`. Precondition met → proceed.
+
+**2 — Choose + dry-run (InsertMedia).** The chosen mutating action renders to a concrete body first,
+executed in dry-run (no write) so the guardrail and operator see exactly what will hit the hardware:
+
+```http
+POST /redfish/v1/Managers/1/VirtualMedia/CD/Actions/VirtualMedia.InsertMedia
+{ "Image": "https://images.example/os/install.iso",
+  "Inserted": true, "WriteProtected": true }
+```
+
+**3 — Approve → execute.** Mutation on a management controller → the guardrail pauses for approval,
+then issues the real POST. Response `204 No Content` (or a `Task` reference to poll).
+
+**4 — Observe (storage preconditions) — and adapt when one fails.** Before any volume POST, GET the
+drive members:
+
+```json
+GET /redfish/v1/Systems/System.Embedded.1/Storage/RAID.0/Drives/Disk.0
+{ "CapacityBytes": 960197124096, "MediaType": "SSD",
+  "Links": { "Volumes": [] } }               // unconfigured, ~960 GB  → eligible
+GET .../Drives/Disk.1
+{ "CapacityBytes": 960197124096, "MediaType": "SSD",
+  "Links": { "Volumes": [ {"@odata.id": ".../Volumes/Volume.1"} ] } }   // already a member
+```
+
+`Disk.1` violates `only_unconfigured_drives`. The agent does **not** POST with a bad member set. It
+re-scans the walked `Drives` list for another unconfigured member of sufficient `CapacityBytes`; if
+it finds `Disk.2` (empty `Links.Volumes`, ≥ `min_capacity_bytes`) it pairs `Disk.0` + `Disk.2`. If no
+second eligible drive exists, it refuses sub-goal B and reports `precondition_unmet` rather than
+building a degraded or wrong-capacity volume.
+
+**5 — Idempotency check, then create.** GET `Volumes`; if a `RAID1` volume over the target drives
+already exists, sub-goal B is already satisfied — skip the POST. Otherwise dry-run → approve →
+execute:
+
+```http
+POST /redfish/v1/Systems/System.Embedded.1/Storage/RAID.0/Volumes
+{ "RAIDType": "RAID1",
+  "Drives": [ {"@odata.id": ".../Drives/Disk.0"},
+              {"@odata.id": ".../Drives/Disk.2"} ] }
+```
+
+Response `202 Accepted` with a `@odata.id` to a `Task` — the agent polls `TaskState` until
+`Completed`.
+
+**6 — Observe again & evaluate.** Re-read both subtrees and hand the fresh state to the Evaluator.
+
+## What "done" means
+
+The Evaluator never trusts the action's return code as success. It re-reads state and measures each
+spec key against it:
+
+- `virtual_media.image_attached` / `inserted` / `write_protected` ← re-GET the slot: `Inserted == true`,
+  `Image` equals the requested URI, `WriteProtected == true`, `ConnectedVia != "NotConnected"`.
+- `volume.raid_type == "RAID1"`, `volume.member_drive_count == 2`, and the new volume's
+  `CapacityBytes >= min_capacity_bytes` ← re-GET the `Volumes` collection and the created Volume.
+
+All keys pass against the re-read state ⇒ terminal success. A `204`/`202` with a volume that never
+appears, or a mirror whose capacity falls short, is a **failure** — measured, not self-reported.
+
+## Constraints, risk, and the guardrail
+
+Both sub-goals are **mutating and physically consequential**: `InsertMedia` changes what the node
+boots from; volume creation writes controller metadata and can wipe member drives if aimed wrong. So
+every POST here runs the full lane: **dry-run → approval pause → execute**. The guardrail pauses at
+each rendered mutating body, showing the exact `Image` URI or drive member set an operator is
+authorizing. The read-only lane — every GET that gathers preconditions and every re-read the
+Evaluator does — auto-proceeds without a pause. Constraints are hard filters, not hints:
+`only_unconfigured_drives` removes any candidate member with a non-empty `Links.Volumes` from the
+selectable set, and `no_existing_media_eject` removes the `EjectMedia` candidate whenever a slot is
+already `Inserted` by someone else.
+
+## What transfers / what it learned
+
+The first time, the agent may reach a valid volume the long way — probing several drives, or trying an
+`InsertMedia` on an already-occupied slot and being blocked. HER relabels those detours: the failed
+"insert into occupied slot" transition becomes a labeled example that *checking `Inserted` first* is
+the shorter safe path, and the drive-precondition scan becomes the learned prefix to any volume
+create. Over episodes the policy converges on the shortest safe ordering — precondition GETs, then the
+single correct POST — instead of trial-and-error.
+
+The transfer angle is structural, not hardcoded: `Volume` with `RAIDType` + `Drives` members, and
+`VirtualMedia` with `InsertMedia`/`EjectMedia`, are **standard DMTF schema**. The agent keys off
+resource types and advertised actions discovered in the walked tree, so the same policy drives Dell
+iDRAC, Supermicro, HPE iLO, and generic DMTF controllers — the endpoint ids and OEM extensions differ,
+but the legal-catalog + precondition + evaluator loop is identical. What it learned about *mirror this
+node safely* carries to hardware it has never seen.
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/docs/use_cases/uc-06-fleet-remediation-multivendor.md
+++ b/docs/use_cases/uc-06-fleet-remediation-multivendor.md
@@ -1,0 +1,200 @@
+# UC-06 — Fleet remediation across vendors
+
+> Target-loop status: this describes IGC's end-to-end target behavior, grounded in
+> `docs/ARCHITECTURE.md` and `docs/DECISIONS.md` (esp. D-002). Today the code is a Phase-0
+> Redfish MDP shell — captured-data replay, a legacy one-hot action space, and smoke-only
+> DQN/HER metrics. The transfer result below is the design's central bet, and its go/no-go
+> experiment is honest (see the last section).
+
+## The goal (in the operator's words, and the machine-checkable spec)
+
+You have a rack of machines from several vendors and one desired state: every node reimages from
+the network on its next boot, and every node is powered on. You do not want to write a Dell
+script, a Supermicro script, an HPE script, and a "generic" script — you want to state the target
+once.
+
+```python
+Goal(
+    instruction="Bring every node to a reimage-ready state: persistent PXE boot, powered on.",
+    spec={
+        # machine-checkable, per ComputerSystem member, re-read after acting
+        "Boot.BootSourceOverrideTarget":  "Pxe",
+        "Boot.BootSourceOverrideEnabled": "Continuous",
+        "PowerState":                     "On",
+    },
+    constraints=[
+        "one ComputerSystem member per node (do not touch peers)",
+        "no firmware update, no BIOS attribute writes, no virtual media",
+        "BootSourceOverrideMode must stay a value the node advertises as allowable",
+        "at most one power action per node",
+    ],
+    plan=None,  # the policy discovers the path per vendor; it is not scripted here
+)
+```
+
+The spec is the contract. It is not "run these calls" — it is a set of predicates the Evaluator
+re-reads from the live tree. The same three predicates apply to a Dell iDRAC node and to a generic
+DMTF node whose trees do not look alike.
+
+## Why a script or a chatbot struggles here
+
+A per-vendor script hard-codes the one thing that differs most: the ComputerSystem member id —
+`/redfish/v1/Systems/System.Embedded.1` on one box, `/redfish/v1/Systems/1` on another,
+`/redfish/v1/Systems/Self` on a generic DMTF service, a bare UUID on a fourth. One new vendor, or
+one node that enumerates its systems differently, and the script silently patches nothing or
+patches the wrong member. A chatbot will happily emit a `BootSourceOverrideTarget` value or an
+`Oem` field the node never advertised — a plausible string that the BMC rejects, or worse,
+accepts into a stuck pending state. Neither one *verifies*: both report "done" from having issued
+a call, not from re-reading that the state took.
+
+## Observation and the legal actions
+
+The agent's observation is a Redfish GET result, structured (`RedfishStateV0`): resource identity
+(`@odata.id`, `@odata.type`, schema version), the `Boot` object, `PowerState`,
+`Status.State`/`Status.Health`, the action surface (`Actions[*].target`, allowed methods,
+`*@Redfish.AllowableValues`), and pending-vs-current settings.
+
+The action is chosen only from the **legal catalog**: an endpoint that actually exists in the
+walked tree, paired with a method that endpoint's own `allowed_methods` permits. There is no free
+text — the agent cannot name an endpoint that was never walked or a method the resource forbids.
+For a Supermicro node (`/Systems/1`) the catalog around this goal is:
+
+| endpoint (walked)                                  | method | resource_type            | why it is legal                          |
+|----------------------------------------------------|--------|--------------------------|------------------------------------------|
+| `/redfish/v1/Systems`                              | GET    | `ComputerSystemCollection` | read-only lane, auto-proceeds          |
+| `/redfish/v1/Systems/1`                            | GET    | `ComputerSystem`         | read-only lane, auto-proceeds            |
+| `/redfish/v1/Systems/1`                            | PATCH  | `ComputerSystem`         | `Boot` is a writable property            |
+| `/redfish/v1/Systems/1/Actions/ComputerSystem.Reset` | POST | `ComputerSystem`         | body carries `Actions[*].target`         |
+
+Each candidate is encoded **structurally**, per D-002 v1: `endpoint_path_tokens` (ids normalized
+but kept as trailing tokens), `http_method`, `resource_type` from `@odata.type`,
+`child_relation_name` (the link that made the endpoint reachable), and `has_action_target` (the
+Reset row is the only `True` here — sparse, so discriminative). Nothing in that encoding is the
+literal member id `1`. That is the whole point of the next sections.
+
+## The trajectory
+
+Observe → choose → dry-run/approve → execute → observe → evaluate, abbreviated. Read lanes
+auto-proceed; the two writes each stop at the guardrail.
+
+**1. Observe the collection (read, auto).**
+
+```
+GET /redfish/v1/Systems
+→ 200  { "Members": [ { "@odata.id": "/redfish/v1/Systems/1" } ] }
+```
+
+**2. Observe the member (read, auto).** The agent reads current state and the allowable set it
+must stay inside.
+
+```
+GET /redfish/v1/Systems/1
+→ 200  {
+    "@odata.type": "#ComputerSystem.v1_20_0.ComputerSystem",
+    "PowerState": "Off",
+    "Boot": {
+      "BootSourceOverrideEnabled": "Disabled",
+      "BootSourceOverrideTarget":  "None",
+      "BootSourceOverrideTarget@Redfish.AllowableValues": ["None","Pxe","Hdd","Cd","BiosSetup"]
+    },
+    "Actions": { "#ComputerSystem.Reset": {
+      "target": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+      "ResetType@Redfish.AllowableValues": ["On","ForceOff","GracefulRestart"] } }
+  }
+```
+
+`Pxe` is in the allowable set — the argument stage may legally fill it. Two predicates are unmet
+(`Boot` target and `PowerState`), so two actions are needed.
+
+**3. Choose the Boot PATCH → dry-run → approve → execute (mutating).**
+
+```
+# dry-run (no call issued): the rendered body the agent WILL send
+PATCH /redfish/v1/Systems/1
+{ "Boot": { "BootSourceOverrideEnabled": "Continuous", "BootSourceOverrideTarget": "Pxe" } }
+--- guardrail: mutation on ComputerSystem, pauses for approval ---
+# on approval, execute
+→ 200  (settings accepted)
+```
+
+**4. Choose the power action → dry-run → approve → execute (mutating).**
+
+```
+POST /redfish/v1/Systems/1/Actions/ComputerSystem.Reset
+{ "ResetType": "On" }
+--- guardrail: mutation, pauses for approval ---
+→ 204
+```
+
+**5. Re-observe and evaluate.**
+
+```
+GET /redfish/v1/Systems/1
+→ 200  { "PowerState": "On",
+         "Boot": { "BootSourceOverrideEnabled": "Continuous",
+                   "BootSourceOverrideTarget": "Pxe" } }
+```
+
+Now the second vendor, **same spec, different tree** — a generic DMTF service exposing its system
+as `/redfish/v1/Systems/Self`, already powered on:
+
+```
+GET  /redfish/v1/Systems           → { "Members":[{"@odata.id":"/redfish/v1/Systems/Self"}] }
+GET  /redfish/v1/Systems/Self      → PowerState "On"; Boot target "None"
+PATCH /redfish/v1/Systems/Self     { "Boot": { "BootSourceOverrideEnabled":"Continuous",
+                                                "BootSourceOverrideTarget":"Pxe" } }   # approve → 200
+# PowerState already "On" → no Reset issued; the shorter path is the correct path
+GET  /redfish/v1/Systems/Self      → Boot target "Pxe", PowerState "On"
+```
+
+Different member id, different starting state, different number of steps — one policy, one spec.
+Dell iDRAC (`.../Systems/System.Embedded.1`, `Oem/Dell` present) and HPE iLO (`.../Systems/1`,
+`Oem/Hpe` present) resolve the same way; the `Oem` sections are observed but never keyed on
+(D-002 deliberately keeps vendor namespace out of the candidate features).
+
+## What "done" means
+
+The Evaluator does not trust that a PATCH returned 200 or that Reset returned 204. It re-reads the
+ComputerSystem member and checks each predicate against the fresh body:
+`Boot.BootSourceOverrideTarget == "Pxe"`, `Boot.BootSourceOverrideEnabled == "Continuous"`,
+`PowerState == "On"`. A node is `done` only when all three hold on the re-read; a node whose PATCH
+landed in a *pending* settings resource but has not applied is **not** done — the structured state
+separates current from pending exactly so this cannot be self-reported away. Success is a measured
+property of the tree, per node, or it did not happen.
+
+## Constraints, risk, and the guardrail
+
+Both writes are mutating and both pause. The `Boot` PATCH is low-to-moderate risk (it changes next
+boot behavior, not firmware or BIOS attributes — those are excluded by constraint). The
+`ComputerSystem.Reset` is higher risk: it changes the power state of a physical machine. So every
+mutation runs the guardrail in order — **dry-run** renders the exact endpoint, method, and body;
+**approval** is where the operator sees that body before any call touches the BMC; **execute**
+only then. Read lanes (`GET /Systems`, the member GET, the re-read) carry no such pause and
+auto-proceed. The `at most one power action per node` constraint bounds blast radius: a policy that
+tries to Reset a node twice is illegal before it is ever risky.
+
+## What transfers / what it learned
+
+The transfer payoff is the reason this is RL and not four scripts. Because a candidate is encoded
+by its **structure** — `path_tokens`, `method`, `resource_type`, `child_relation`,
+`has_action_target` (D-002) — and *not* by a memorized member id, a `PATCH` on an unseen vendor's
+`/Systems/<UUID>` lands near the `PATCH` on `/Systems/1` and `/Systems/Self` the policy already
+knows: same `resource_type` (`ComputerSystem`), same method, same reachability relation. The
+Evaluator's per-node verdict then feeds **HER**: a run that overshot (issued a Reset on a node that
+was already On, or PATCHed a mode the node did not advertise) is relabeled by its *achieved* state,
+so the policy is rewarded toward the shortest safe path — the `/Systems/Self` node above learns the
+one-write solution rather than blindly replaying the two-write one.
+
+Honest bar (D-002): structural similarity alone is **not** enough. The zero-shot go/no-go — a
+frozen encoder with no learned projection, ranking each state's true graph neighbors — measured
+**k=5 = 0.293 on the 1,499-node Supermicro corpus and 0.754 on the 167-node HPE iLO corpus**, both
+under the ≥0.80 top-5 bar (NO-GO), though ~30× over random. The read: on a large host, global text
+similarity fills the top-5 with look-alike sibling sensor leaves rather than true transitions. The
+conclusion the repo commits to is that the **learned bilinear projection `sᵀ W c` is load-bearing,
+not optional** — the transfer above is real only once `W` is behavior-cloning-trained on in-domain
+(Supermicro) graph transitions and then re-passes this same harness zero-shot on held-out HPE. The
+multi-vendor fixture corpora (`idrac`/`supermicro`/`hpe`/`generic`) shipped in the repo are exactly
+the material for that go/no-go, and it is the gate before any RL training spend.
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/docs/use_cases/uc-07-log-and-telemetry-triage.md
+++ b/docs/use_cases/uc-07-log-and-telemetry-triage.md
@@ -1,0 +1,136 @@
+# UC-07 — Log & telemetry triage
+
+> Target end-to-end loop, grounded in `docs/ARCHITECTURE.md` + `docs/DECISIONS.md`. Today the code is a Phase-0 Redfish MDP shell: the environment, the walked action catalog, and the guardrail scaffolding exist; the learned policy and evaluator described here are the target behavior, not yet the shipped one.
+
+Operational hygiene is the friendliest place to meet an RL agent that acts on real hardware, because the blast radius is small and the audit trail is everything. This scenario is almost entirely READ — pull the event log, snapshot a few sensors — wrapped around exactly **one** gated mutation: clearing the log. That single `ClearLog` is where dry-run → approval → execute earns its keep, and where a verified, replayable trajectory beats a human clicking through a BMC UI.
+
+## The goal (in the operator's words, and the machine-checkable spec)
+
+The operator says: *"Before we hand this node back, capture everything the System Event Log has recorded since the maintenance window opened, then clear the log so the next run starts clean — but don't clear it until the entries are safely archived."*
+
+```python
+Goal(
+    instruction="Archive all SEL entries created since T0, then clear the System Event Log.",
+    spec={
+        "sel_entries_since_T0.archived": True,       # every entry with Created >= T0 written to the run artifact
+        "sel_entries_since_T0.count_matches": True,   # archived count == entries observed at collection time
+        "log_service.cleared": True,                  # post-clear re-read shows the log emptied
+        "thermal.snapshot_captured": True,            # Temperatures readings recorded for the record
+        "power.snapshot_captured": True,              # PowerControl reading recorded for the record
+    },
+    constraints=[
+        "no ClearLog until the SEL collection is archived and counted",
+        "exactly one mutating call in the whole trajectory (ClearLog)",
+        "ClearLog requires explicit human approval",
+        "read-only sensor + log reads auto-proceed",
+    ],
+    plan=None,  # the agent learns the ordering; it is not scripted here
+)
+```
+
+`T0` is a constraint the operator supplies; the agent does not invent a cutoff.
+
+## Why a script or a chatbot struggles here
+
+A hard-coded script assumes one vendor's SEL lives at one fixed path and one fixed `ClearLog` target — point it at a different BMC and it either 404s or, worse, clears the wrong log. A chatbot will happily *say* "the log is cleared" without ever re-reading it, and will paste a `ClearLog` POST with no gate between "collect" and "destroy." Neither one guarantees the ordering constraint — archive *before* clear — because neither verifies state; they narrate intent. And neither leaves an artifact you could hand to an auditor: what was on the log, at what timestamps, who approved the wipe, and proof the wipe took. The whole value here is a machine that refuses to report success until the re-read proves it.
+
+## Observation and the legal actions
+
+The observation is a Redfish GET result. The agent starts from the service root and the walked resource tree, then reads the LogService that owns the SEL and its `Entries` collection. It never guesses a URL: every candidate action is a pair — an endpoint from the walked tree, and a method drawn from that endpoint's advertised `allowed_methods`. Nothing outside that catalog is selectable — that is the no-hallucination guarantee. If a host does not expose a `TelemetryService`, that row simply is not in the catalog, and the agent falls back to the `Thermal` / `Power` reads that are; it cannot select an endpoint the walk never found.
+
+A few legal candidates for this scenario:
+
+| Endpoint (from the walked tree) | Method | Kind | In catalog because |
+| --- | --- | --- | --- |
+| `/redfish/v1/Managers/{id}/LogServices/SEL` | `GET` | read | LogService resource, `GET` allowed |
+| `/redfish/v1/Managers/{id}/LogServices/SEL/Entries` | `GET` | read | LogEntryCollection, `GET` allowed |
+| `/redfish/v1/Chassis/{id}/Thermal` | `GET` | read | Thermal (`Temperatures[]`), `GET` allowed |
+| `/redfish/v1/Chassis/{id}/Power` | `GET` | read | Power (`PowerControl[]`), `GET` allowed |
+| `/redfish/v1/TelemetryService/MetricReports/{id}` | `GET` | read | MetricReport, `GET` allowed |
+| `.../LogServices/SEL/Actions/LogService.ClearLog` | `POST` | **mutate** | `#LogService.ClearLog` advertised in `Actions` |
+
+Only the last row is a mutation. Everything above it is an auto-proceed read lane.
+
+Two properties of the catalog are worth naming:
+
+- **The method is the resource's, not the agent's.** `POST` appears next to `ClearLog` only because that endpoint's `allowed_methods` advertises it. The agent cannot conjure a `DELETE` on a collection that forbids it.
+- **The catalog is host-specific.** It is rebuilt from *this* controller's walk every run, so a policy trained against one vendor's tree does not carry a stale URL into another's — it re-derives the legal set on the machine in front of it.
+
+## The trajectory
+
+Abbreviated observe → choose → (dry-run / approve) → execute → observe → evaluate, with real standard Redfish calls.
+
+1. **Observe** the LogService so we know the SEL exists and where its clear action lives.
+   ```http
+   GET /redfish/v1/Managers/{id}/LogServices/SEL
+   ```
+   ```jsonc
+   {
+     "@odata.type": "#LogService.v1_x_x.LogService",
+     "Id": "SEL",
+     "OverWritePolicy": "WrapsWhenFull",
+     "Entries": { "@odata.id": "/redfish/v1/Managers/{id}/LogServices/SEL/Entries" },
+     "Actions": {
+       "#LogService.ClearLog": {
+         "target": "/redfish/v1/Managers/{id}/LogServices/SEL/Actions/LogService.ClearLog"
+       }
+     }
+   }
+   ```
+
+2. **Observe + archive** the entries collection (paged via `Members` / `Members@odata.nextLink`), keeping only `Created >= T0`.
+   ```http
+   GET /redfish/v1/Managers/{id}/LogServices/SEL/Entries
+   ```
+   Each `LogEntry` carries the fields the archive needs — `Created`, `Severity`, `MessageId`, `Message`, `EntryType`, `SensorType`. The agent writes them to the run artifact and records the observed count `N`.
+
+3. **Observe** the sensor snapshots the spec asks for (read lane, auto-proceeds):
+   ```http
+   GET /redfish/v1/Chassis/{id}/Thermal   # -> Temperatures[].ReadingCelsius
+   GET /redfish/v1/Chassis/{id}/Power     # -> PowerControl[].PowerConsumedWatts
+   ```
+
+4. **Choose** the one mutation — `POST` to the `ClearLog` target — but only after the archive constraint is satisfied. The agent will not select `ClearLog` while `sel_entries_since_T0.archived` is still false; the ordering is learned, not hard-coded.
+
+5. **Dry-run** the mutation: resolve the target, confirm `POST` is in that endpoint's `allowed_methods`, render the exact request, and surface it for approval — no bytes sent yet.
+   ```http
+   POST /redfish/v1/Managers/{id}/LogServices/SEL/Actions/LogService.ClearLog
+   Content-Type: application/json
+
+   {}
+   ```
+
+6. **Approve** — a human okays the single destructive step. Only then does the agent **execute** the `POST` (a compliant BMC returns `204 No Content` or a task/`200`).
+
+7. **Observe again** — re-read the collection to see the effect:
+   ```http
+   GET /redfish/v1/Managers/{id}/LogServices/SEL/Entries
+   ```
+
+8. **Evaluate** against the spec (next section).
+
+## What "done" means
+
+Done is measured, never self-reported. The **evaluator** re-reads state and checks each spec key against it:
+
+- `sel_entries_since_T0.archived` / `count_matches` — the run artifact contains every entry whose `Created >= T0` that was observed in step 2, and the archived count equals the observed `N`.
+- `log_service.cleared` — the step-7 re-read of `.../Entries` shows the log emptied: `Members@odata.count == 0` (or the vendor's post-clear state, e.g. a single "log cleared" marker entry — the evaluator checks the re-read, not the POST's return code).
+- `thermal.snapshot_captured` / `power.snapshot_captured` — `Temperatures[].ReadingCelsius` and `PowerControl[].PowerConsumedWatts` are present in the artifact.
+- ordering — the archive write and its count precede the `ClearLog` timestamp in the trajectory; a run that cleared first fails the constraint even if the log is now empty.
+
+If any key is false — say the clear returned `204` but the re-read still lists entries — the goal is **not** done, regardless of what the action reported. This split matters: the POST's return code is what the *controller claims*; the step-7 GET is what the *controller shows*. The evaluator trusts the second, always. A green trajectory is one it confirmed by GET, so the run is auditable end to end: every read, the archived entries, the dry-run, the human approval, and the verified post-state are in the record, in order.
+
+## Constraints, risk, and the guardrail
+
+Risk is deliberately lopsided. The reads (`LogService`, `Entries`, `Thermal`, `Power`, `MetricReports`) are **read-only** and auto-proceed — no pause, no approval. The one mutation, `LogService.ClearLog`, is **destructive-but-bounded**: it erases the event history on that controller, which is unrecoverable if the archive step was skipped — exactly why the ordering constraint and the gate exist. Every mutating action passes the guardrail — **dry-run → approval → execute** — and this scenario has precisely one, so approval pauses exactly once, right before the log is cleared. That is the entire human-in-the-loop surface for the run.
+
+## What transfers / what it learned
+
+**HER** turns a run that stopped early — collected and snapshotted but never got approval to clear — into a labeled trajectory for the sub-goal it *did* reach ("SEL archived and sensors captured"). The agent learns the collect-then-clear ordering and the shortest safe path to it from both full and partial runs, instead of only from clean successes.
+
+It also learns the negative: that selecting `ClearLog` before the archive key flips true is a dead end the evaluator will reject, so the optimal path it converges on is the *shortest* one that still satisfies every constraint — collect, snapshot, clear, verify — with no wasted reads and no premature mutation.
+
+**Cross-vendor** is where the walked catalog pays off. `LogService`, its `Entries` collection, the `#LogService.ClearLog` action, `Thermal`, and `Power` are DMTF-standard types, but their exact placement differs — SEL under `/Managers/{id}/LogServices` on one platform, an event log under `/Systems/{id}/LogServices` on another; the clear-action target path is vendor-shaped. Because the agent selects the action *type* and resolves the concrete `target` from that host's own walked tree and `allowed_methods`, the same learned policy triages a Dell iDRAC, a Supermicro BMC, an HPE iLO, or a generic DMTF implementation without a per-vendor script — the schema is the interface, and the guardrail is the same everywhere.
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/docs/use_cases/why-rl-not-an-llm.md
+++ b/docs/use_cases/why-rl-not-an-llm.md
@@ -1,0 +1,127 @@
+# Why an RL agent, and not "just prompt an LLM"
+
+This is the single most important page in the set. If IGC were something a good prompt could do, it
+would not be worth building. It is worth building because the thing operators actually need —
+**reach a goal on real hardware, provably, in the fewest safe steps, and get better at it** — is
+exactly the thing a language model, used as a language model, cannot give you.
+
+To be clear up front: **IGC contains an LLM.** The backbone that encodes Redfish responses and helps
+plan is a language model, and that is on purpose — nothing understands a messy JSON API body like a
+model trained on language and code. The argument here is not "LLMs are bad." It is: **an LLM is the
+right *prior* and the wrong *decision-maker*.** IGC uses the model for understanding and constrains
+every *decision* to a reinforcement-learning agent operating in a real environment.
+
+## The concrete failure: prompt a chatbot to run Redfish
+
+Ask a strong model, with no tools: *"Power on the server at this BMC and set it to PXE-boot once."*
+It will confidently produce something like:
+
+```
+POST /redfish/v1/Systems/1/Actions/ComputerSystem.Reset
+{ "ResetType": "On" }
+PATCH /redfish/v1/Systems/1
+{ "Boot": { "BootSourceOverrideTarget": "Pxe", "BootSourceOverrideEnabled": "Once" } }
+```
+
+That looks right. On a specific machine it may be **wrong in ways that matter**, and the model has no
+way to know:
+
+- The system member may not be `/Systems/1`. On Supermicro or HPE it is frequently a different id
+  (`/Systems/Self`, a UUID); the model **guessed** the URL.
+- `ComputerSystem.Reset` may not allow `POST` from the current power state, or the resource may not
+  advertise that action at all on this firmware. The model cannot see the host's actual
+  `allowed_methods`.
+- `BootSourceOverrideEnabled: "Once"` may need to be applied at the next reboot as a *pending*
+  setting, not a live one — patching the live resource silently no-ops on some vendors.
+- After sending both calls, the model has **no idea whether the server is actually powering on**. It
+  will tell you "Done!" whether it worked or not.
+
+None of these are prompt-engineering problems. They are structural: the model is reasoning about a
+*generic* Redfish from training data, not about *this* controller's *current* state. Every extra bit
+of confidence makes it more dangerous, because a wrong write to a BMC can knock real hardware
+offline.
+
+## The three ways to solve it, compared
+
+| Property | Prompt an LLM | Hand-written script / runbook | **IGC (RL agent)** |
+| --- | --- | --- | --- |
+| Knows *this* host's real resource tree | No — reasons from a generic prior | Only what the author hard-coded | **Yes** — the observation *is* the live `GET` |
+| Can invent a non-existent endpoint/method | **Yes, routinely** | No (but brittle if the API differs) | **No** — chooses only from the legal action catalog |
+| Handles a new vendor / unseen machine | Guesses, often wrong | Breaks until someone rewrites it | **Yes** — endpoints scored by structure, not memorized ids |
+| Finds the *shortest / safest* path | No notion of cost | The author's fixed path, optimal or not | **Yes** — learned value over whole trajectories |
+| Knows whether it *succeeded* | Self-reports, unverifiable | Only what the author asserted | **Yes** — an evaluator checks the goal `spec` against the new state |
+| Recovers from a failed step | No memory across attempts | Only pre-written error branches | **Yes** — learns ret/recovery from experience (HER) |
+| Gets better over time | No | No | **Yes** — every episode is training signal |
+| Safe to point at real hardware | No | Depends entirely on the author | **By design** — `dry-run → approval → execute` guardrail |
+
+A hand-written script is honest but frozen: it encodes one operator's path for one vendor, and it
+rots the moment the API, the firmware, or the vendor changes. An LLM is flexible but ungrounded. IGC
+is built to be **both grounded and adaptive** — which is the combination the job actually requires.
+
+## The five properties IGC guarantees (and why each kills a failure mode)
+
+### 1. A grounded action space — it cannot hallucinate a call
+At every state the environment exposes a **dynamic catalog of legal actions**: an endpoint drawn from
+the *walked* Redfish resource tree, paired with an HTTP method from *that endpoint's* advertised
+`allowed_methods`, plus optional typed argument slots. The policy scores and picks **only from this
+set** — it has no way to emit a URL or method that the API did not offer. This is a deliberate design
+decision (see [`../DECISIONS.md`](../DECISIONS.md), D-001): the alternative of "let the LLM generate
+the action" was considered and **rejected**, both because it re-introduces hallucination and because
+it breaks the offline TD/HER learning the agent depends on. Hallucinated endpoints are not filtered
+out after the fact — they are **impossible to express**.
+
+### 2. Verified success — the reward is measured, not self-reported
+A goal carries a machine-checkable `spec` (`igc/core/types.py`). After each action, an **evaluator**
+compares the new observation to that spec and returns success/reward. "Did the power state become
+`On`?" is answered by *reading the resource*, not by asking the model how it thinks it did. This is
+the anti-hallucination property that matters most operationally: **IGC's notion of "done" is a fact
+about the hardware, not an opinion about the transcript.**
+
+### 3. An optimal strategy — learned value over trajectories, not a greedy guess
+Reaching a goal is usually multi-step (discover the system, check the current boot config, stage the
+change, trigger the reset, confirm). IGC learns a **value function over whole trajectories** (DQN-style
+targets), so it prefers the sequence that reaches the goal in the fewest, least-risky steps — and it
+can tell that a locally-tempting action leads to a dead end. A prompt has no cost model; a script has
+the author's fixed path whether or not it is optimal.
+
+### 4. It learns *in the environment*, including from failure
+Most attempts on real systems don't go perfectly the first time. **Hindsight Experience Replay**
+turns a trajectory that missed its intended goal into training signal for the goal it actually
+reached — so failed or partial episodes still make the agent better. This is learning *from the
+consequences of real actions*, which is precisely what a stateless prompt cannot do.
+
+### 5. It transfers — one policy, many vendors and machines
+Because candidates are encoded by their **structure** (path tokens, HTTP method, resource type,
+how the endpoint is reached, whether it carries an action target — see D-002) rather than by a
+memorized id, a Supermicro or HPE URL the agent has never seen lands near the Dell URLs it has. IGC's
+own go/no-go experiment is *zero-shot on a held-out vendor* over the repo's multi-vendor fixture
+corpora. Generalization is the target being measured, not a hope. (That same experiment is honest
+about the bar: representation similarity alone is not enough — the *learned* scoring is load-bearing,
+which is exactly why this is trained RL and not a clever embedding lookup. See D-002's recorded
+result.)
+
+## Where the LLM still earns its place
+
+The model is doing real work — just not the deciding:
+
+- **Understanding** the observation: turning a nested, vendor-specific JSON body into a state the
+  policy can use is a language/code problem the backbone is good at.
+- **Planning / decomposition**: mapping a high-level `instruction` into ordered sub-goals (the
+  planned M3 layer in `ARCHITECTURE.md`) is where the model's world knowledge helps.
+- **Argument values**: choosing enum values for an action's typed slots draws on the model's grasp of
+  what the fields mean.
+
+The division of labor is the whole design: **LLM for language, RL for consequential decisions,
+the real API for ground truth, an evaluator for the verdict.** Take any one of those away and you are
+back to a confident guess. Keep all four and you have an agent an operator can actually turn loose on
+hardware.
+
+## The one-sentence takeaway
+
+A prompted LLM answers *"what call would plausibly do this?"*; IGC answers *"what is the shortest,
+verifiable, allowed sequence that provably reaches this goal on the machine in front of me — and how
+do I do it better next time?"* Those are different questions, and only the second one is safe to
+automate.
+
+Author:
+Mus mbayramo@stanford.edu


### PR DESCRIPTION
Lands the use-case documentation set (UC-01 power/boot, UC-02 BIOS convergence, UC-03 firmware, UC-04 inventory/health, UC-05 storage/virtual-media, UC-06 fleet remediation multivendor, UC-07 log/telemetry triage) plus README, anatomy-of-an-episode, consumption-surfaces, and why-rl-not-an-llm. Each page grounds itself in docs/ARCHITECTURE.md + docs/DECISIONS.md and carries the project author tag. Purely additive (11 new files under docs/use_cases/), no code touched; offline gate 592 passed. Cherry-picked onto current main from claude/use-cases-docs (was 12 commits behind).