### PR TITLE
D-002: metadata-hygiene correction (73% of the Dell dump is schema/metric registry)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -379,6 +379,17 @@ graph-neighborhood features**, the learned **M1 encoder** (vs the frozen trigram
 the trained **TD/HER pointer** (vs pure representation similarity). Reproduce:
 `python scripts/exp_d002_bc_ranking.py --holdout datasets/orig/<dell-host>`.
 
+**Data-hygiene correction (same day).** The Dell walk is a full "entire dump": **~73% of its 2352
+nodes are the Redfish schema/metric registry** (`JsonSchemaFile`, `/Schemas`, `MetricDefinition`) —
+metadata an agent never navigates to. Re-running on the OPERATIONAL graph only (`--filter`, 625 nodes)
+lifts the large-host held-out score from **0.324 to 0.680** (baseline 0.145 -> 0.389). So the raw NO-GO
+was largely a **data artifact of the unsanitized dump**, not a fundamental ranking failure. It remains
+NO-GO (0.680 < 0.80) at the frozen-trigram + v1 floor, but the residual gap is now concentrated in
+genuine near-identical siblings — dozens of firmware-inventory, sensor, and slot resources — exactly
+the case the v2 graph-neighborhood features target. **Data-pipeline implication:** the schema/metric
+registry should be filtered from the action space upstream (it is not operational). Reproduce:
+`... --holdout datasets/orig/<dell-host> --filter`.
+
 ---
 
 ## D-001 — M6 action-selection objective: hybrid pointer + argument decoder (2026-07-11)

--- a/scripts/exp_d002_bc_ranking.py
+++ b/scripts/exp_d002_bc_ranking.py
@@ -32,15 +32,35 @@ from igc.modules.eval.zero_shot_ranking import candidate_text, trigram_embed
 SUPERMICRO = "idrac_ctl/tests/supermicro_fixtures"
 HPE = "idrac_ctl/tests/hpe_fixtures"
 
+# Non-operational metadata: the Redfish JSON-schema store, message/attribute registries, and metric
+# DEFINITIONS. An agent never navigates to these; a full "entire dump" walk is dominated by them and
+# they distort the ranking metric (they are the near-identical sibling leaves that fill top-k).
+_META_URL = ("/jsonschemas/", "/schemas/", "/schemastore/", "/registries/",
+             "/metricdefinitions/", "/messageregistry")
+_META_TYPE = {"jsonschemafile", "metricdefinition", "metricreportdefinition",
+              "messageregistryfile", "attributeregistry", "schemafile"}
 
-def load_corpus(corpus_dir: str, dim: int = 512) -> Dict:
+
+def _is_metadata(rec) -> bool:
+    """True for schema/registry/metric-definition resources (not part of the action space)."""
+    if any(seg in rec.url.lower() for seg in _META_URL):
+        return True
+    body = rec.response if isinstance(rec.response, dict) else {}
+    t = str(body.get("@odata.type", "")).split(".")[0].lstrip("#").lower()
+    return t in _META_TYPE
+
+
+def load_corpus(corpus_dir: str, dim: int = 512, filter_metadata: bool = False) -> Dict:
     """Load a fixture corpus into frozen state/candidate embeddings + truth masks.
 
     :param corpus_dir: fixture directory of captured Redfish JSON.
     :param dim: trigram embedding dimensionality.
+    :param filter_metadata: drop the schema/registry/metric-definition dump before building the graph.
     :return: dict with S (states x dim), C (candidates x dim), and boolean pos/self masks.
     """
     records = list(RedfishFixtureSource(corpus_dir, "exp", TrustLevel.REAL))
+    if filter_metadata:
+        records = [r for r in records if not _is_metadata(r)]
     graph = RedfishResourceGraph.from_records(records)
     candidates = list(build_candidate_cache(graph).values())
     cand_urls = [c["url"] for c in candidates]
@@ -140,15 +160,17 @@ def main() -> None:
     ap.add_argument("--l2i", type=float, default=0.1, help="||W-I||^2 anchor (0 = free-form W)")
     ap.add_argument("--k", type=int, default=5)
     ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--filter", action="store_true",
+                    help="drop the schema/registry/metric-definition metadata dump (operational graph only)")
     args = ap.parse_args()
     bar, k = 0.80, args.k
 
     train_dirs = [d for d in args.train.split(",") if d]
     holdout_dirs = [d for d in args.holdout.split(",") if d]
 
-    print("loading corpora (frozen trigram embeddings)...")
-    train = [load_corpus(d) for d in train_dirs]
-    holdout = [load_corpus(d) for d in holdout_dirs]
+    print(f"loading corpora (frozen trigram embeddings; filter_metadata={args.filter})...")
+    train = [load_corpus(d, filter_metadata=args.filter) for d in train_dirs]
+    holdout = [load_corpus(d, filter_metadata=args.filter) for d in holdout_dirs]
     for d, h in zip(train_dirs, train):
         print(f"  TRAIN   {d:45s} states={h['n_state']:5d} candidates={h['n_cand']}")
     for d, h in zip(holdout_dirs, holdout):


### PR DESCRIPTION
The large-held-out Dell NO-GO was largely a **data artifact**. The full Dell walk is an 'entire dump' where **~73% of nodes are the Redfish schema/metric registry** (JsonSchemaFile / /Schemas / MetricDefinition) — metadata no agent navigates to. Adds `--filter` to drop it; on the operational graph only (2352 -> 625 nodes) the held-out top-5 rises **0.324 -> 0.680** (baseline 0.145 -> 0.389). Still NO-GO at the frozen-trigram + v1 floor, but the residual gap is now genuine near-identical firmware/sensor/slot siblings — the v2 graph-neighborhood case. Data-pipeline implication recorded in D-002: the schema/metric registry should be filtered from the action space upstream. No host IPs committed.