### PR TITLE
Harden on-node dataset build for multi-GPU + non-UTF-8 captures

### DIFF
--- a/igc/ds/igc_json_pipeline.py
+++ b/igc/ds/igc_json_pipeline.py
@@ -131,7 +131,11 @@ class JsonPipeline:
             """
             Process a JSON file.
             """
-            with open(_file_path, "r") as json_file:
+            # Captured Redfish responses can carry non-UTF-8 bytes (e.g. latin-1
+            # 0xa3 "£", 0xb0 "°" in vendor/sensor strings), which crash a strict
+            # UTF-8 read on the first on-node dataset build. Decode leniently:
+            # json.loads still parses the structure; only the stray byte is replaced.
+            with open(_file_path, "r", encoding="utf-8", errors="replace") as json_file:
                 json_lines = json_file.read()
                 json_data = json.loads(json_lines)
                 targets = {}

--- a/igc/ds/redfish_dataset.py
+++ b/igc/ds/redfish_dataset.py
@@ -444,7 +444,11 @@ class JSONDataset(
                 raise Exception(f"No JSON files found inside the directory {self._unprocessed}.")
 
             logging.debug(f"Copy all discovered data to {self._json_directory_path}")
-            shutil.copytree(self._unprocessed, f"{self._json_directory_path}/")
+            # dirs_exist_ok: the os.path.exists guard above is check-then-act, so under
+            # multi-GPU (FSDP/DDP) every rank passes it before any rank creates the dir,
+            # then all-but-one crash with FileExistsError. Tolerate a peer having created
+            # it (identical source content) instead of racing.
+            shutil.copytree(self._unprocessed, f"{self._json_directory_path}/", dirs_exist_ok=True)
 
     @staticmethod
     def _update_hash_values(json_file_path, data):

--- a/tests/ds/test_dataset_multigpu_robustness.py
+++ b/tests/ds/test_dataset_multigpu_robustness.py
@@ -1,0 +1,69 @@
+"""Offline regressions for the multi-GPU on-node dataset build.
+
+The first FSDP2 run on a fresh GB300 node exposed two build-path crashes that the
+local gate never hit (prebuilt caches bypass the build): a strict-UTF-8 read of a
+captured response carrying a latin-1 byte, and a check-then-act ``copytree`` race
+where every rank passed the ``os.path.exists`` guard before any rank created the
+directory, so all-but-one died with ``FileExistsError``. Both are driven directly
+here with class doubles over the real modules.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import os
+
+from igc.ds import redfish_dataset
+from igc.ds.igc_json_pipeline import JsonPipeline
+from igc.ds.redfish_dataset import JSONDataset
+
+
+def test_load_json_files_tolerates_non_utf8_bytes(tmp_path):
+    """A captured .json with a latin-1 byte (0xa3) loads without UnicodeDecodeError."""
+    (tmp_path / "sensor.json").write_bytes(
+        b'{"Name": "Inlet \xa3 sensor", "ReadingCelsius": 42}'
+    )
+
+    pipeline = JsonPipeline.__new__(JsonPipeline)
+    pipeline._json_directory_path = str(tmp_path)
+    # extract_recursive touches these when it meets action/target keys; the payload
+    # above has none, but initialise them so the walk cannot AttributeError.
+    pipeline._json_target = {}
+    pipeline._action_to_rest = {}
+    pipeline._target_names = set()
+
+    # Must not raise; the stray byte is replaced, the JSON still parses.
+    pipeline.load_json_files()
+
+
+def test_copy_json_responses_survives_concurrent_dir_creation(tmp_path, monkeypatch):
+    """Simulate the multi-rank TOCTOU: the exist-guard says 'absent' but a peer rank
+    already created the destination before copytree — must merge, not FileExistsError.
+    """
+    src = tmp_path / "unprocessed"
+    src.mkdir()
+    (src / "a.json").write_text('{"x": 1}')
+    dst = tmp_path / "orig"
+    dst.mkdir()  # a peer rank already made it
+
+    ds = JSONDataset.__new__(JSONDataset)
+    ds._unprocessed = str(src)
+    ds._json_directory_path = str(dst)
+    ds.logger = redfish_dataset.AbstractLogger.create_logger(__name__)
+    ds._json_files = []
+
+    # Make ONLY the destination look absent to the guard (as every rank sees it),
+    # while it physically exists — the exact window that produced FileExistsError.
+    real_exists = os.path.exists
+    dst_key = str(dst).rstrip("/")
+    monkeypatch.setattr(
+        "os.path.exists",
+        lambda p: False if str(p).rstrip("/") == dst_key else real_exists(p),
+    )
+
+    ds._copy_json_responses()  # must not raise
+
+    assert (dst / "a.json").exists()
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
Two build-path crashes surfaced on the first 4-GPU FSDP2 run on a fresh GB300 node (both before training, both invisible to the local gate because prebuilt caches bypass the build):

1. **UnicodeDecodeError** — `igc_json_pipeline.py` read captured .json as strict UTF-8; real Redfish captures carry latin-1 bytes (0xa3 `£`, 0xb0 `°`) in vendor/sensor strings. Now decoded with `errors='replace'` (json.loads still parses the structure).
2. **FileExistsError copytree race** — `redfish_dataset._copy_json_responses` guards with `if not os.path.exists(dst)`, a check-then-act TOCTOU: all 4 ranks pass the guard, rank 0 creates the dir, ranks 1-3 crash. Now `dirs_exist_ok=True`.

Regression tests drive both directly via class doubles. Offline gate 594 passed, ruff clean. Note: a proper follow-up is to rank-gate the whole build (main_process_first) so a single-process pre-build isn't needed; this PR unblocks the run with pre-build.