### PR TITLE
Skip empty/malformed JSON captures in dataset build

### DIFF
--- a/igc/ds/igc_json_pipeline.py
+++ b/igc/ds/igc_json_pipeline.py
@@ -8,9 +8,12 @@ for example extract all rest api end points.
 Author: Mus mbayramo@stanford.edu
 """
 import json
+import logging
 import os
 import re
 from tqdm import tqdm
+
+logger = logging.getLogger(__name__)
 
 
 
@@ -130,6 +133,11 @@ class JsonPipeline:
         def process_json_file(_file_path: str, json_file_name: str) -> None:
             """
             Process a JSON file.
+
+            A captured corpus is not guaranteed clean: 204/empty bodies, truncated
+            writes, and non-JSON error pages all appear among real responses. Skip
+            any file that is empty or does not parse rather than aborting the whole
+            build — one bad capture must not kill training.
             """
             # Captured Redfish responses can carry non-UTF-8 bytes (e.g. latin-1
             # 0xa3 "£", 0xb0 "°" in vendor/sensor strings), which crash a strict
@@ -137,11 +145,19 @@ class JsonPipeline:
             # json.loads still parses the structure; only the stray byte is replaced.
             with open(_file_path, "r", encoding="utf-8", errors="replace") as json_file:
                 json_lines = json_file.read()
-                json_data = json.loads(json_lines)
-                targets = {}
 
-                if "$schema" not in json_data:
-                    self.extract_recursive(json_data, targets)
+            if not json_lines.strip():
+                logger.warning(f"Skipping empty JSON capture: {_file_path}")
+                return
+            try:
+                json_data = json.loads(json_lines)
+            except json.JSONDecodeError as exc:
+                logger.warning(f"Skipping malformed JSON capture {_file_path}: {exc}")
+                return
+
+            targets = {}
+            if "$schema" not in json_data:
+                self.extract_recursive(json_data, targets)
 
         total_files = sum(len(files) for _, _, files in os.walk(self._json_directory_path))
         processed_files = 0

--- a/tests/ds/test_dataset_multigpu_robustness.py
+++ b/tests/ds/test_dataset_multigpu_robustness.py
@@ -36,6 +36,23 @@ def test_load_json_files_tolerates_non_utf8_bytes(tmp_path):
     pipeline.load_json_files()
 
 
+def test_load_json_files_skips_empty_and_malformed(tmp_path):
+    """Empty (204) and non-JSON captures are skipped; valid ones still process."""
+    (tmp_path / "empty.json").write_text("")            # 204/empty body
+    (tmp_path / "truncated.json").write_text('{"Name": ')  # truncated write
+    (tmp_path / "errorpage.json").write_text("<html>Gateway Timeout</html>")
+    (tmp_path / "good.json").write_text('{"Name": "ok"}')
+
+    pipeline = JsonPipeline.__new__(JsonPipeline)
+    pipeline._json_directory_path = str(tmp_path)
+    pipeline._json_target = {}
+    pipeline._action_to_rest = {}
+    pipeline._target_names = set()
+
+    # Must not raise despite three unparseable files in the directory.
+    pipeline.load_json_files()
+
+
 def test_copy_json_responses_survives_concurrent_dir_creation(tmp_path, monkeypatch):
     """Simulate the multi-rank TOCTOU: the exist-guard says 'absent' but a peer rank
     already created the destination before copytree — must merge, not FileExistsError.


### PR DESCRIPTION
Follow-up to #62. With the UTF-8 read fixed, the on-node build then aborted on an empty capture (204 body -> json.loads('') -> JSONDecodeError char 0). Real corpora also carry truncated writes and non-JSON error pages. process_json_file now skips empty + unparseable files with a warning instead of aborting the whole build. Regression extended with empty/truncated/non-JSON fixtures. Offline gate 595 passed, ruff clean.