### PR TITLE
Fix M2 state autoencoder crash on non-GPT-2 backbones

### DIFF
--- a/igc/modules/igc_train_auto_state_encoder.py
+++ b/igc/modules/igc_train_auto_state_encoder.py
@@ -76,7 +76,17 @@ class AutoencoderTrainer(IgcModule):
         input_shape = emb_shape(self.model)
         self.emb_shape = (input_shape[0] - 1, input_shape[1])
 
-        self.model_autoencoder = AutoStateEncoder(input_shape=input_shape)
+        # AutoStateEncoder reconstructs backbone hidden states shaped
+        # (batch, seq_len, hidden_dim): hidden_dim is the backbone hidden size
+        # (input_shape[1]) and seq_len is the dataset chunk length every sample is
+        # padded to. Passing them keeps the encoder off the GPT-2 768/1024 defaults,
+        # which mismatch any modern backbone (e.g. Qwen2.5-3B, hidden 2048).
+        seq_len = self._resolve_seq_len(spec, input_shape)
+        self.model_autoencoder = AutoStateEncoder(
+            input_shape=input_shape,
+            seq_len=seq_len,
+            hidden_dim=input_shape[1],
+        )
 
         self.logger.info(f"Creating optimizer {spec.auto_encoder_optimizer} "
                          f"lr: {spec.auto_encoder_lr} "
@@ -90,6 +100,28 @@ class AutoencoderTrainer(IgcModule):
             spec.auto_encoder_weight_decay,
             **vars(spec)
         )
+
+    def _resolve_seq_len(self, spec, input_shape):
+        """Resolve the hidden-state sequence length the autoencoder reconstructs.
+
+        Every dataset chunk is padded to ``max_len`` (built from ``--seq_len``), so
+        the backbone emits hidden states of that length. Prefer the dataset's real
+        ``max_len`` (the ground truth for the tensors fed to the autoencoder), fall
+        back to the CLI ``seq_len``, then to the positional dimension for the legacy
+        GPT-2 path.
+
+        :param spec: training spec namespace (carries ``seq_len``).
+        :param input_shape: ``(positions, hidden)`` backbone shape from ``emb_shape``.
+        :return: the sequence length to build ``AutoStateEncoder`` with.
+        """
+        ds = getattr(self, "dataset", None)
+        ds_max_len = getattr(ds, "_max_len", None)
+        if isinstance(ds_max_len, int) and ds_max_len > 0:
+            return ds_max_len
+        spec_seq_len = getattr(spec, "seq_len", None)
+        if isinstance(spec_seq_len, int) and spec_seq_len > 0:
+            return spec_seq_len
+        return int(input_shape[0])
 
     def _get_reconstruction_loss(self, batch):
         """

--- a/igc/modules/llm/igc_autoencoder.py
+++ b/igc/modules/llm/igc_autoencoder.py
@@ -1,23 +1,42 @@
+import torch
 import torch.nn as nn
 
 from igc.modules.encoders.base_encoder import Conv1DLatent
 
 
 class AutoStateEncoder(nn.Module):
+    """Reconstruct backbone hidden states through a compact latent bottleneck.
+
+    ``Conv1DLatent`` pools ``(batch, seq_len, hidden_dim)`` hidden states into a
+    per-sequence feature vector, the encoder squeezes it to ``latent_dim``, and
+    the decoder expands the latent back to the flattened ``seq_len * hidden_dim``
+    hidden state. ``hidden_dim`` and ``seq_len`` must match the backbone that
+    produced the states — the backbone hidden size and the dataset chunk length.
+    They used to be hardcoded to GPT-2's 768 / 1024, so any other backbone (e.g.
+    Qwen2.5-3B, hidden 2048) crashed with a reconstruction-shape mismatch.
     """
-    """
+
     def __init__(self, input_shape=None, seq_len=1024, hidden_dim=768, latent_dim=64):
         """
-        :param seq_len:
-        :param hidden_dim:
-        :param latent_dim:
+        :param input_shape: ``(positions, hidden)`` backbone shape driving Conv1DLatent.
+        :param seq_len: sequence length of the hidden states to reconstruct — the
+            dataset chunk length (``max_len``), not the GPT-2 default.
+        :param hidden_dim: backbone hidden size ``H`` of the states to reconstruct.
+        :param latent_dim: bottleneck width.
         """
         super(AutoStateEncoder, self).__init__()
 
         self.conv1d = Conv1DLatent(input_shape)
 
+        # Conv1DLatent maps (batch, seq_len, H) -> (batch, conv_out). Measure that
+        # width from a dummy forward instead of hardcoding GPT-2's 1026 (= 1024 + 2),
+        # so a different seq_len or conv geometry stays consistent.
+        with torch.no_grad():
+            probe = torch.zeros(1, seq_len, input_shape[1])
+            conv_out_dim = self.conv1d(probe).shape[-1]
+
         self.encoder = nn.Sequential(
-            nn.Linear(1026, hidden_dim),
+            nn.Linear(conv_out_dim, hidden_dim),
             nn.ReLU(),
             nn.Linear(hidden_dim, 256),
             nn.ReLU(),
@@ -34,12 +53,10 @@ class AutoStateEncoder(nn.Module):
 
     def forward(self, x):
         """
-        :param x:
-        :return:
+        :param x: hidden states ``(batch, seq_len, hidden_dim)``.
+        :return: flattened reconstruction ``(batch, seq_len * hidden_dim)``.
         """
         x = self.conv1d(x)
         latent = self.encoder(x)
         reconstructed = self.decoder(latent)
         return reconstructed
-
-

--- a/tests/modules/test_autoencoder_seq_len.py
+++ b/tests/modules/test_autoencoder_seq_len.py
@@ -1,0 +1,54 @@
+"""Offline regression: the trainer resolves the real hidden-state seq_len.
+
+``AutoencoderTrainer`` used to build ``AutoStateEncoder`` without a seq_len /
+hidden_dim, defaulting to GPT-2's 1024 / 768 and crashing on any other backbone.
+``_resolve_seq_len`` now derives the sequence length from the dataset chunk
+length (``max_len``), falling back to the CLI ``seq_len`` and then the positional
+dimension. CPU-only; uses ``__new__`` to skip the heavy backbone constructor.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import argparse
+from types import SimpleNamespace
+
+from igc.modules.igc_train_auto_state_encoder import AutoencoderTrainer
+
+
+def _trainer():
+    return AutoencoderTrainer.__new__(AutoencoderTrainer)
+
+
+def test_prefers_dataset_max_len():
+    """The dataset's real max_len wins over the CLI seq_len and positions."""
+    t = _trainer()
+    t.dataset = SimpleNamespace(_max_len=777)
+    spec = argparse.Namespace(seq_len=1024)
+    assert t._resolve_seq_len(spec, (2048, 4096)) == 777
+
+
+def test_falls_back_to_spec_seq_len_without_dataset():
+    """No usable dataset max_len -> use the CLI seq_len."""
+    t = _trainer()  # no self.dataset attribute at all (inference path)
+    spec = argparse.Namespace(seq_len=512)
+    assert t._resolve_seq_len(spec, (2048, 4096)) == 512
+
+
+def test_falls_back_to_positions_last():
+    """No dataset and no seq_len -> the positional dimension of input_shape."""
+    t = _trainer()
+    t.dataset = None
+    spec = argparse.Namespace()  # no seq_len
+    assert t._resolve_seq_len(spec, (2048, 4096)) == 2048
+
+
+def test_ignores_non_positive_max_len():
+    """A zero/None max_len is skipped, not returned as a bogus seq_len."""
+    t = _trainer()
+    t.dataset = SimpleNamespace(_max_len=0)
+    spec = argparse.Namespace(seq_len=333)
+    assert t._resolve_seq_len(spec, (2048, 4096)) == 333
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_autoencoder_shape.py
+++ b/tests/modules/test_autoencoder_shape.py
@@ -1,0 +1,64 @@
+"""Offline regression: AutoStateEncoder adapts to non-GPT-2 backbones.
+
+The decoder's final Linear and the encoder's first Linear were hardcoded to
+GPT-2's hidden 768 / seq_len 1024 (the ``1026 = 1024 + 2`` conv-output magic), so
+a modern backbone like Qwen2.5-3B (hidden 2048) crashed with a
+'2097152 must match 786432' reconstruction-shape mismatch. AutoStateEncoder now
+takes ``hidden_dim`` / ``seq_len`` and derives the encoder input from
+Conv1DLatent's real output width. CPU-only.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import torch
+
+from igc.modules.llm.igc_autoencoder import AutoStateEncoder
+
+
+def _make(input_shape, seq_len, hidden_dim):
+    """Build an AutoStateEncoder and a zero hidden-state batch for it."""
+    ae = AutoStateEncoder(input_shape=input_shape, seq_len=seq_len, hidden_dim=hidden_dim)
+    x = torch.zeros(2, seq_len, hidden_dim)  # (batch, seq_len, hidden_dim)
+    return ae, x
+
+
+def test_reconstruct_matches_flattened_input_hidden_2048():
+    """A 2048-hidden backbone reconstructs to the flattened input shape (the crash case)."""
+    seq_len, hidden_dim = 1024, 2048
+    ae, x = _make((seq_len, hidden_dim), seq_len, hidden_dim)
+    recon = ae(x)
+    # decoder reconstructs the flattened hidden state (batch, seq_len * hidden_dim)
+    assert recon.shape == (x.shape[0], seq_len * hidden_dim)
+    # the trainer's mse target lines up element-for-element (no broadcast mismatch)
+    flat = x.view(x.shape[0], -1)
+    assert flat.shape == recon.shape
+    torch.nn.functional.mse_loss(flat, recon)  # would raise on a shape mismatch
+
+
+def test_reconstruct_gpt2_dims_unchanged():
+    """The legacy GPT-2 geometry (768 / 1024) still round-trips (no regression)."""
+    seq_len, hidden_dim = 1024, 768
+    ae, x = _make((seq_len, hidden_dim), seq_len, hidden_dim)
+    recon = ae(x)
+    assert recon.shape == (x.shape[0], seq_len * hidden_dim)
+
+
+def test_encoder_input_tracks_seq_len_not_hardcoded_1026():
+    """Encoder first Linear derives from Conv1DLatent output, not the 1026 magic."""
+    # conv output width is seq_len + 2, so a non-1024 seq_len must NOT stay 1026.
+    seq_len, hidden_dim = 512, 2048
+    ae, x = _make((seq_len, hidden_dim), seq_len, hidden_dim)
+    assert ae.encoder[0].in_features == seq_len + 2  # 514, proving 1026 is gone
+    recon = ae(x)
+    assert recon.shape == (x.shape[0], seq_len * hidden_dim)
+
+
+def test_default_dims_are_gpt2():
+    """Unspecified hidden_dim/seq_len keep the GPT-2 defaults (backward compatible)."""
+    ae = AutoStateEncoder(input_shape=(1024, 768))
+    assert ae.decoder[-1].out_features == 1024 * 768
+    assert ae.encoder[0].in_features == 1024 + 2
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
## Problem

The M2 state autoencoder (`AutoStateEncoder` + `Conv1DLatent`, trained via `--llm encoder`) hardcoded GPT-2's dimensions and crashed on any modern backbone. Verified on the GB300 with Qwen2.5-3B (hidden 2048):

```
RuntimeError: The size of tensor a (2097152) must match the size of tensor b (786432)
```

The decoder's final `nn.Linear(hidden_dim, seq_len * hidden_dim)` used the **default** `hidden_dim=768` / `seq_len=1024` (→ `786432`) instead of the real backbone shape (`1024*2048 = 2097152`). Root cause: `AutoencoderTrainer` built `AutoStateEncoder(input_shape=...)` and passed neither `hidden_dim` nor `seq_len`. The encoder's `nn.Linear(1026, …)` was likewise a GPT-2 magic number (`seq_len + 2`).

## Fix

- **`igc_train_auto_state_encoder.py`**: pass `hidden_dim=input_shape[1]` (backbone hidden size) and a resolved `seq_len` into `AutoStateEncoder`. New `_resolve_seq_len` takes the ground-truth dataset chunk length (`_max_len`), falling back to CLI `--seq_len`, then the positional dim (covers the inference path with no dataset).
- **`igc_autoencoder.py`**: derive the encoder's first-Linear input from `Conv1DLatent`'s real output width via a dummy forward, instead of the hardcoded `1026`. Honor the passed `hidden_dim`/`seq_len` in the decoder.

## Tests (offline, CPU-only)

- `test_autoencoder_shape.py` — hidden-2048 forward/reconstruct round-trip (the crash case) + `mse_loss` shape check; non-1024 seq_len proving the encoder input tracks `seq_len+2` (not 1026); GPT-2 no-regression + defaults cases.
- `test_autoencoder_seq_len.py` — `_resolve_seq_len` dataset-first priority, both fallbacks, and the non-positive `_max_len` edge case.

## Gate

- `set -o pipefail; KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 python -m pytest -q` → **590 passed, 21 deselected, 0 failures**.
- `ruff check` on all changed files → clean.

Scope limited to the M2 `--llm encoder` path; the M1 `--llm latent` path is separately validated.