### PR TITLE
Fix F523: interpolate values in _download_module log/warning messages

### DIFF
--- a/igc/modules/base/igc_base_module.py
+++ b/igc/modules/base/igc_base_module.py
@@ -1025,7 +1025,7 @@ class IgcModule(IgcBaseState):
 
         root_dir = Path(path).expanduser()
         if Path(root_dir).is_dir():
-            logger.debug("Creating directory structure.".format(str(root_dir)))
+            logger.debug("Creating directory structure %s", str(root_dir))
             os.makedirs(root_dir, exist_ok=True)
 
         if not filename:
@@ -1061,7 +1061,7 @@ class IgcModule(IgcBaseState):
             igc_util.fetch_content(final_url, str(full_path))
 
         except (urllib.error.URLError, OSError) as e:
-            warnings.warn("Failed to fetch".format(final_url))
+            warnings.warn(f"Failed to fetch {final_url}")
             if is_strict:
                 raise e
 


### PR DESCRIPTION
## What

Fixes two pre-existing `ruff` F523 errors in `IgcModule._download_module` (in `igc/modules/base/igc_base_module.py`). Both were `.format()` calls on a string with no `{}` placeholder, so the argument was silently discarded:

- The directory-structure debug log dropped `str(root_dir)` — now `logger.debug("Creating directory structure %s", str(root_dir))`.
- The fetch-failure warning dropped `final_url`, so it never named the URL that failed — now `warnings.warn(f"Failed to fetch {final_url}")`.

Both are present on HEAD and unrelated to any feature work.

## Verification

- `ruff check igc/modules/base/igc_base_module.py` → **All checks passed!**
- Offline gate (`KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 python -m pytest -q`) → **597 passed, 21 deselected** (the touched download path is covered by `test_download` / `test_we_don_download`).