### PR TITLE
Unwrap accelerate optimizer/scheduler without unwrap_model

### DIFF
--- a/igc/modules/llm_train_state_encoder.py
+++ b/igc/modules/llm_train_state_encoder.py
@@ -119,6 +119,22 @@ def reached_max_steps(global_step: int, max_steps: Optional[int]) -> bool:
     return max_steps is not None and max_steps > 0 and global_step >= max_steps
 
 
+def unwrap_accelerate(wrapped, inner_attr: str):
+    """Return the base optimizer/scheduler that accelerate wrapped, or ``wrapped``.
+
+    ``Accelerator.unwrap_model`` is for ``nn.Module``s only — in accelerate>=1.14 it
+    probes ``model._modules``, which an ``AcceleratedOptimizer`` / ``AcceleratedScheduler``
+    does not have, raising ``AttributeError('_modules')`` and killing the checkpoint
+    save on the multi-GPU (FSDP) path. accelerate exposes the inner object as
+    ``AcceleratedOptimizer.optimizer`` / ``AcceleratedScheduler.scheduler``, so read that.
+
+    :param wrapped: the (possibly accelerate-wrapped) optimizer or scheduler.
+    :param inner_attr: ``"optimizer"`` or ``"scheduler"`` — the wrapper's inner attribute.
+    :return: the unwrapped inner object, or ``wrapped`` if it is not wrapped.
+    """
+    return getattr(wrapped, inner_attr, wrapped)
+
+
 class LlmEmbeddingsTrainer(LlmModule):
     """
     Train a language model on masked Redfish JSON sequences.
@@ -732,8 +748,10 @@ class LlmEmbeddingsTrainer(LlmModule):
                     if self._module_checkpoint_dir is not None:
                         if self.is_accelerator:
                             model = self.accelerator.unwrap_model(self.model)
-                            opt = self.accelerator.unwrap_model(self.optimizer)
-                            shed = self.accelerator.unwrap_model(self.scheduler)
+                            # unwrap_model is for nn.Modules only; the optimizer/scheduler
+                            # are accelerate wrappers (see unwrap_accelerate).
+                            opt = unwrap_accelerate(self.optimizer, "optimizer")
+                            shed = unwrap_accelerate(self.scheduler, "scheduler")
                             self.save_checkpoint(
                                 self._module_checkpoint_dir,
                                 epoch + 1,

--- a/tests/modules/test_accelerate_unwrap.py
+++ b/tests/modules/test_accelerate_unwrap.py
@@ -1,0 +1,40 @@
+"""Offline regression for unwrapping accelerate-wrapped optimizer/scheduler.
+
+The multi-GPU (FSDP) checkpoint save called ``Accelerator.unwrap_model`` on the
+optimizer and scheduler. That helper is for ``nn.Module``s; in accelerate>=1.14 it
+probes ``._modules`` and raises ``AttributeError('_modules')`` on an
+``AcceleratedOptimizer`` / ``AcceleratedScheduler``, killing every 4-GPU run at the
+first best-checkpoint save. ``unwrap_accelerate`` reads the wrapper's own inner
+attribute instead. This drives it without a distributed launch.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+from igc.modules.llm_train_state_encoder import unwrap_accelerate
+
+
+def test_unwrap_accelerate_returns_inner_for_wrapped():
+    """A wrapper exposing ``.optimizer`` / ``.scheduler`` yields its inner object."""
+    class AcceleratedOptimizer:
+        def __init__(self, inner):
+            self.optimizer = inner
+
+    class AcceleratedScheduler:
+        def __init__(self, inner):
+            self.scheduler = inner
+
+    base_opt = object()
+    base_sched = object()
+    assert unwrap_accelerate(AcceleratedOptimizer(base_opt), "optimizer") is base_opt
+    assert unwrap_accelerate(AcceleratedScheduler(base_sched), "scheduler") is base_sched
+
+
+def test_unwrap_accelerate_passes_through_unwrapped():
+    """A plain optimizer/scheduler (single-GPU path) is returned unchanged."""
+    plain = object()
+    assert unwrap_accelerate(plain, "optimizer") is plain
+    assert unwrap_accelerate(plain, "scheduler") is plain
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
4-GPU FSDP run crashed at the first best-checkpoint save: `llm_train_state_encoder` called `accelerator.unwrap_model(self.optimizer)` and `(self.scheduler)`. `unwrap_model` is for nn.Modules; accelerate>=1.14 probes `._modules` -> `AttributeError('_modules')` on `AcceleratedOptimizer`/`AcceleratedScheduler`. New `unwrap_accelerate` helper reads the wrapper's inner `.optimizer`/`.scheduler` attribute (pass-through when unwrapped). Found on a live 4-GPU run that now builds the dataset and reaches training + wandb. Offline gate 599 passed, ruff clean.