### PR TITLE
GB300 sanity check + image distribution + NVIDIA flags/mounts

### DIFF
--- a/scripts/dataset_sanity.py
+++ b/scripts/dataset_sanity.py
@@ -1,0 +1,122 @@
+"""Distributed dataset-feed sanity for igc.
+
+Loads the built igc dataset, splits it across ranks with a DistributedSampler, iterates
+EVERY batch, and uploads each to the GPU — exactly what training does
+(``llm_train_state_encoder`` moves ``batch['input_ids']`` / ``['attention_mask']``
+``.to(device)`` each step). It confirms multi-GPU data feeding — load, split, concurrent
+read, GPU upload — works in ISOLATION on 1/4 GPU before a real fine-tune.
+
+Yes, we DO upload to GPU: the ``.pt`` dataset cache is read into CPU RAM, and each batch's
+tensors are moved to ``cuda:LOCAL_RANK`` here, per step, same as the trainer. Pure data
+path (no model / backward) so a failure points at loading / splitting / reading, not at
+training.
+
+Used by: scripts/gb300_sanity_check.sh with SANITY_SCRIPT=scripts/dataset_sanity.py.
+Needs a pre-built dataset cache at IGC_DATASET_DIR (default /workspace/igc/datasets).
+
+Env: IGC_DATASET_DIR, IGC_MODEL (tokenizer key), SANITY_BATCH, SANITY_WORKERS, SANITY_SEQ.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import os
+import time
+
+import torch
+import torch.distributed as dist
+from torch.utils.data import DataLoader, DistributedSampler
+
+
+def _upload(batch, device) -> int:
+    """Move every tensor in the batch to the GPU (as the trainer does); return count moved."""
+    moved = 0
+    if isinstance(batch, dict):
+        for k, v in batch.items():
+            if torch.is_tensor(v):
+                batch[k] = v.to(device, non_blocking=True)
+                moved += 1
+    elif isinstance(batch, (list, tuple)):
+        for v in batch:
+            if torch.is_tensor(v):
+                v.to(device, non_blocking=True)
+                moved += 1
+    elif torch.is_tensor(batch):
+        batch.to(device, non_blocking=True)
+        moved = 1
+    return moved
+
+
+def _batch_size(batch) -> int:
+    t = None
+    if isinstance(batch, dict):
+        t = next((v for v in batch.values() if torch.is_tensor(v)), None)
+    elif isinstance(batch, (list, tuple)):
+        t = next((v for v in batch if torch.is_tensor(v)), None)
+    elif torch.is_tensor(batch):
+        t = batch
+    return int(t.shape[0]) if t is not None else 0
+
+
+def main() -> None:
+    rank = int(os.environ.get("RANK", "0"))
+    world = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    distributed = "RANK" in os.environ or world > 1
+
+    if not torch.cuda.is_available():
+        raise SystemExit("[ds-sanity] FAIL: CUDA not available in the container")
+    if distributed:
+        dist.init_process_group(backend="nccl")
+    torch.cuda.set_device(local_rank)
+    device = torch.device(f"cuda:{local_rank}")
+
+    from igc.ds.redfish_masked_dataset import MaskedJSONDataset
+    ds = MaskedJSONDataset(
+        os.environ.get("IGC_DATASET_DIR", "/workspace/igc/datasets"),
+        default_tokenize=os.environ.get("IGC_MODEL", "gpt2"),
+        max_len=int(os.environ.get("SANITY_SEQ", "1024")),
+        recreate_dataset=False,
+        do_consistency_check=False,
+    )
+
+    bs = int(os.environ.get("SANITY_BATCH", "8"))
+    workers = int(os.environ.get("SANITY_WORKERS", "4"))
+    if distributed and world > 1:
+        sampler = DistributedSampler(ds, num_replicas=world, rank=rank, shuffle=True, drop_last=True)
+        loader = DataLoader(ds, batch_size=bs, sampler=sampler, num_workers=workers, pin_memory=True)
+    else:
+        loader = DataLoader(ds, batch_size=bs, shuffle=True, num_workers=workers, pin_memory=True)
+
+    torch.cuda.synchronize()
+    t0 = time.time()
+    nb = ns = tensors = 0
+    for batch in loader:
+        tensors = _upload(batch, device)   # UPLOAD to GPU, exactly like the trainer
+        ns += _batch_size(batch)
+        nb += 1
+    torch.cuda.synchronize()
+    dt = time.time() - t0
+
+    thr = ns / dt if dt > 0 else 0.0
+    print(f"[ds-sanity] rank={rank}/{world} dataset_len={len(ds)} batches={nb} samples={ns} "
+          f"tensors/batch={tensors} {dt:.2f}s {thr:.0f}samp/s upload=OK", flush=True)
+
+    if distributed and world > 1:
+        agg = torch.tensor([float(nb), float(ns)], device=device)
+        dist.all_reduce(agg, op=dist.ReduceOp.SUM)
+        dist.barrier()
+        if rank == 0:
+            print(f"[ds-sanity] PASS world={world}: {int(agg[0])} batches / {int(agg[1])} samples "
+                  f"read+uploaded across all ranks (dataset_len={len(ds)}, split OK)", flush=True)
+        dist.destroy_process_group()
+    else:
+        print(f"[ds-sanity] PASS world=1: {nb} batches / {ns} samples read+uploaded "
+              f"(dataset_len={len(ds)})", flush=True)
+
+
+if __name__ == "__main__":
+    main()
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/scripts/dist_sanity.py
+++ b/scripts/dist_sanity.py
@@ -1,0 +1,99 @@
+"""Distributed backward-pass sanity check for the GB300 fabric.
+
+Run under torchrun/accelerate for 1, 4, 8, … ranks (8 = 2 nodes, i.e. multi-node).
+It validates that the WHOLE distributed training stack works end to end — NCCL init,
+forward, backward, gradient all-reduce (DDP), optimiser step — BEFORE 72 GPUs are
+committed to a full run. It is pure torch with no igc imports on purpose: a failure
+here points at the fabric / NCCL / RoCE / launch wiring, not at the model or dataset.
+
+Used by: scripts/gb300_sanity_check.sh, which launches this under torchrun in the NGC
+container for 1 / 4 / 8 GPU. Not imported anywhere else.
+
+Checks, per rank, then collectively:
+  * forward + backward run and the loss is finite;
+  * every gradient is finite (a NaN/Inf grad fails loudly);
+  * a known all-reduce (sum of ranks) returns the exact expected value — a hung or
+    mis-wired fabric fails HERE instead of silently deadlocking a real run;
+  * throughput (samples/s) is printed so a slow interconnect is visible.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import os
+import time
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+
+def main() -> None:
+    rank = int(os.environ.get("RANK", "0"))
+    world = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    distributed = world > 1
+
+    if not torch.cuda.is_available():
+        raise SystemExit("[sanity] FAIL: CUDA not available in the container")
+
+    if distributed:
+        dist.init_process_group(backend="nccl")
+    torch.cuda.set_device(local_rank)
+    device = torch.device(f"cuda:{local_rank}")
+
+    # Non-trivial params so backward moves real all-reduce traffic over the fabric.
+    dim = int(os.environ.get("SANITY_DIM", "4096"))
+    batch = int(os.environ.get("SANITY_BATCH", "32"))
+    steps = int(os.environ.get("SANITY_STEPS", "20"))
+
+    model = nn.Sequential(nn.Linear(dim, dim), nn.GELU(), nn.Linear(dim, dim)).to(device)
+    if distributed:
+        model = DDP(model, device_ids=[local_rank])
+    opt = torch.optim.AdamW(model.parameters(), lr=1e-4)
+    x = torch.randn(batch, dim, device=device)
+
+    torch.cuda.synchronize()
+    t0 = time.time()
+    last_loss = float("nan")
+    for _ in range(steps):
+        opt.zero_grad(set_to_none=True)
+        loss = model(x).pow(2).mean()
+        loss.backward()
+        bad = [n for n, p in model.named_parameters()
+               if p.grad is not None and not torch.isfinite(p.grad).all()]
+        if bad:
+            raise SystemExit(f"[sanity] FAIL rank {rank}: non-finite grad in {bad[:3]}")
+        opt.step()
+        last_loss = loss.item()
+    torch.cuda.synchronize()
+    dt = time.time() - t0
+
+    # A collective with a KNOWN answer: sum(0..world-1). A hung/mis-wired fabric
+    # deadlocks or returns the wrong value HERE, not 20 minutes into a real run.
+    if distributed:
+        probe = torch.tensor([float(rank)], device=device)
+        dist.all_reduce(probe, op=dist.ReduceOp.SUM)
+        expected = world * (world - 1) / 2.0
+        if abs(probe.item() - expected) > 1e-3:
+            raise SystemExit(f"[sanity] FAIL rank {rank}: all_reduce={probe.item()} expected={expected}")
+
+    thr = steps * batch / dt if dt > 0 else 0.0
+    print(f"[sanity] rank={rank}/{world} local={local_rank} {torch.cuda.get_device_name(local_rank)} "
+          f"loss={last_loss:.4f} {steps}steps {dt:.2f}s {thr:.0f}samp/s allreduce=OK", flush=True)
+
+    if distributed:
+        dist.barrier()
+        if rank == 0:
+            print(f"[sanity] PASS world={world}: backward + all_reduce healthy on all ranks", flush=True)
+        dist.destroy_process_group()
+    else:
+        print("[sanity] PASS world=1: single-GPU backward healthy", flush=True)
+
+
+if __name__ == "__main__":
+    main()
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/scripts/dist_sanity.py
+++ b/scripts/dist_sanity.py
@@ -1,20 +1,19 @@
 """Distributed backward-pass sanity check for the GB300 fabric.
 
-Run under torchrun/accelerate for 1, 4, 8, … ranks (8 = 2 nodes, i.e. multi-node).
-It validates that the WHOLE distributed training stack works end to end — NCCL init,
-forward, backward, gradient all-reduce (DDP), optimiser step — BEFORE 72 GPUs are
-committed to a full run. It is pure torch with no igc imports on purpose: a failure
-here points at the fabric / NCCL / RoCE / launch wiring, not at the model or dataset.
+Confirms the parallelism we intend to scale with — **DDP** and **FSDP2** — actually
+works on this fabric, with a SINGLE gradient pass per mode (one forward → backward →
+optimiser step is enough: it exercises NCCL init, the wrap, the backward collective
+[DDP all-reduce / FSDP2 reduce-scatter], and the optimiser step). Run under torchrun
+for 1, 4, 8 … ranks (8 = 2 nodes, i.e. multi-node — the RoCE/NCCL cross-node path).
 
-Used by: scripts/gb300_sanity_check.sh, which launches this under torchrun in the NGC
-container for 1 / 4 / 8 GPU. Not imported anywhere else.
+Pure torch, no igc imports: a failure here points at the fabric / NCCL / launch wiring
+(or a broken FSDP2 install), not at the model or dataset. This is the go/no-go gate
+before 72 GPUs, and it tells us which parallelism to commit to.
 
-Checks, per rank, then collectively:
-  * forward + backward run and the loss is finite;
-  * every gradient is finite (a NaN/Inf grad fails loudly);
-  * a known all-reduce (sum of ranks) returns the exact expected value — a hung or
-    mis-wired fabric fails HERE instead of silently deadlocking a real run;
-  * throughput (samples/s) is printed so a slow interconnect is visible.
+Used by: scripts/gb300_sanity_check.sh (loops SANITY_MODE over ddp,fsdp2 × 1/4/8 GPU).
+
+Env knobs: SANITY_MODE=ddp|fsdp2 (default ddp), SANITY_STEPS (default 1 = single pass),
+SANITY_DIM, SANITY_BATCH.
 
 Author:
 Mus mbayramo@stanford.edu
@@ -29,28 +28,45 @@ import torch.nn as nn
 from torch.nn.parallel import DistributedDataParallel as DDP
 
 
+def _wrap_fsdp2(model: nn.Module) -> nn.Module:
+    """Shard the model with the FSDP2 (`fully_shard`) API, tolerant of torch version."""
+    try:
+        from torch.distributed.fsdp import fully_shard
+    except ImportError:  # older torch keeps it under the composable namespace
+        from torch.distributed._composable.fsdp import fully_shard
+    for layer in model:  # shard each param-bearing submodule, then the root
+        if any(True for _ in layer.parameters(recurse=False)):
+            fully_shard(layer)
+    fully_shard(model)
+    return model
+
+
 def main() -> None:
+    mode = os.environ.get("SANITY_MODE", "ddp").lower()
     rank = int(os.environ.get("RANK", "0"))
     world = int(os.environ.get("WORLD_SIZE", "1"))
     local_rank = int(os.environ.get("LOCAL_RANK", "0"))
-    distributed = world > 1
+    distributed = "RANK" in os.environ or world > 1
 
     if not torch.cuda.is_available():
         raise SystemExit("[sanity] FAIL: CUDA not available in the container")
+    if mode not in ("ddp", "fsdp2"):
+        raise SystemExit(f"[sanity] FAIL: unknown SANITY_MODE={mode} (ddp|fsdp2)")
 
     if distributed:
         dist.init_process_group(backend="nccl")
     torch.cuda.set_device(local_rank)
     device = torch.device(f"cuda:{local_rank}")
 
-    # Non-trivial params so backward moves real all-reduce traffic over the fabric.
     dim = int(os.environ.get("SANITY_DIM", "4096"))
     batch = int(os.environ.get("SANITY_BATCH", "32"))
-    steps = int(os.environ.get("SANITY_STEPS", "20"))
+    steps = int(os.environ.get("SANITY_STEPS", "1"))  # one pass confirms the mechanism
 
     model = nn.Sequential(nn.Linear(dim, dim), nn.GELU(), nn.Linear(dim, dim)).to(device)
-    if distributed:
-        model = DDP(model, device_ids=[local_rank])
+    if mode == "ddp":
+        model = DDP(model, device_ids=[local_rank]) if distributed else model
+    else:  # fsdp2
+        model = _wrap_fsdp2(model)
     opt = torch.optim.AdamW(model.parameters(), lr=1e-4)
     x = torch.randn(batch, dim, device=device)
 
@@ -60,36 +76,36 @@ def main() -> None:
     for _ in range(steps):
         opt.zero_grad(set_to_none=True)
         loss = model(x).pow(2).mean()
-        loss.backward()
+        loss.backward()  # DDP all-reduce / FSDP2 reduce-scatter happens here
         bad = [n for n, p in model.named_parameters()
                if p.grad is not None and not torch.isfinite(p.grad).all()]
         if bad:
-            raise SystemExit(f"[sanity] FAIL rank {rank}: non-finite grad in {bad[:3]}")
+            raise SystemExit(f"[sanity] FAIL rank {rank} mode={mode}: non-finite grad in {bad[:3]}")
         opt.step()
-        last_loss = loss.item()
+        last_loss = float(loss)
     torch.cuda.synchronize()
     dt = time.time() - t0
 
     # A collective with a KNOWN answer: sum(0..world-1). A hung/mis-wired fabric
-    # deadlocks or returns the wrong value HERE, not 20 minutes into a real run.
-    if distributed:
+    # deadlocks or returns the wrong value HERE, not deep into a real run.
+    if distributed and world > 1:
         probe = torch.tensor([float(rank)], device=device)
         dist.all_reduce(probe, op=dist.ReduceOp.SUM)
         expected = world * (world - 1) / 2.0
         if abs(probe.item() - expected) > 1e-3:
-            raise SystemExit(f"[sanity] FAIL rank {rank}: all_reduce={probe.item()} expected={expected}")
+            raise SystemExit(f"[sanity] FAIL rank {rank} mode={mode}: all_reduce={probe.item()} expected={expected}")
 
-    thr = steps * batch / dt if dt > 0 else 0.0
-    print(f"[sanity] rank={rank}/{world} local={local_rank} {torch.cuda.get_device_name(local_rank)} "
-          f"loss={last_loss:.4f} {steps}steps {dt:.2f}s {thr:.0f}samp/s allreduce=OK", flush=True)
+    print(f"[sanity] mode={mode} rank={rank}/{world} local={local_rank} "
+          f"{torch.cuda.get_device_name(local_rank)} loss={last_loss:.4f} "
+          f"{steps}pass {dt*1000:.0f}ms collective=OK", flush=True)
 
     if distributed:
         dist.barrier()
         if rank == 0:
-            print(f"[sanity] PASS world={world}: backward + all_reduce healthy on all ranks", flush=True)
+            print(f"[sanity] PASS mode={mode} world={world}: {mode} backward + collective healthy", flush=True)
         dist.destroy_process_group()
     else:
-        print("[sanity] PASS world=1: single-GPU backward healthy", flush=True)
+        print(f"[sanity] PASS mode={mode} world=1: single-GPU backward healthy", flush=True)
 
 
 if __name__ == "__main__":

--- a/scripts/gb300_distribute_image.sh
+++ b/scripts/gb300_distribute_image.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# gb300_distribute_image.sh — build the keyless igc-train image once, save it to the
+# shared /models filesystem, and docker-load it on all 18 nodes so ANY free node can
+# launch with zero pull/build. The NGC base is already cached on the nodes, so each
+# `docker load` only materialises the small extra layers (tools + pip deps).
+#
+# Runs on one node (needs docker + zstd + /models mounted; reaches the others by ssh).
+#   scripts/gb300_distribute_image.sh
+#   DIST_NODES="172.25.230.42 172.25.230.49" scripts/gb300_distribute_image.sh   # subset
+#   FORCE_SAVE=1 scripts/gb300_distribute_image.sh                               # re-save tarball
+#
+# Only the KEYLESS image is distributed here — never the .internal SSH-key image.
+#
+# Author:
+# Mus mbayramo@stanford.edu
+set -uo pipefail
+
+IMAGE="${IMAGE:-igc-train}"
+TAG="${TAG:-ngc26.03-py3}"
+REF="${IMAGE}:${TAG}"
+MODELS_IMAGES="${MODELS_IMAGES:-/models/images}"
+TARBALL="${MODELS_IMAGES}/${IMAGE}-${TAG}.tar.zst"
+# All 18 GB300 nodes: 172.25.230.40 .. .57
+# shellcheck disable=SC2206  # word-split the space-separated override on purpose
+NODES=(${DIST_NODES:-$(seq -f "172.25.230.%g" 40 57)})
+SSH="ssh -o BatchMode=yes -o ConnectTimeout=8"
+
+log() { echo "=== [$(date -u '+%F %T')] $* ==="; }
+
+command -v zstd >/dev/null || { echo "BLOCKER: zstd missing on $(hostname) — install it (safe-apt-install.sh zstd)" >&2; exit 3; }
+
+# 1. build (unless already present) then save to /models (read by every node)
+if ! docker image inspect "$REF" >/dev/null 2>&1; then
+    log "building $REF from docker/Dockerfile.train"
+    docker build -f docker/Dockerfile.train -t "$REF" . || { echo "BLOCKER: build failed" >&2; exit 3; }
+fi
+mkdir -p "$MODELS_IMAGES"
+if [ ! -f "$TARBALL" ] || [ "${FORCE_SAVE:-0}" = "1" ]; then
+    log "docker save $REF -> $TARBALL"
+    docker save "$REF" | zstd -T0 -q -o "$TARBALL" || { echo "BLOCKER: save failed" >&2; exit 3; }
+fi
+log "tarball ready: $(du -h "$TARBALL" 2>/dev/null | cut -f1) at $TARBALL"
+
+# 2. docker load on every node from the shared tarball
+ok=0; fail=0
+for ip in "${NODES[@]}"; do
+    if $SSH "nvidia@$ip" "docker image inspect $REF >/dev/null 2>&1"; then
+        echo "  $ip: already has $REF"; ok=$((ok + 1)); continue
+    fi
+    if $SSH "nvidia@$ip" "test -f '$TARBALL' && zstd -dc '$TARBALL' | docker load >/dev/null 2>&1 && docker image inspect $REF >/dev/null 2>&1"; then
+        echo "  $ip: LOADED $REF"; ok=$((ok + 1))
+    else
+        echo "  $ip: FAILED (unreachable? /models unmounted? zstd missing?)" >&2; fail=$((fail + 1))
+    fi
+done
+
+log "image ready on ${ok}/${#NODES[@]} nodes (${fail} failed)"
+[ "$fail" = "0" ]
+
+# Author: Mus mbayramo@stanford.edu

--- a/scripts/gb300_launch.sh
+++ b/scripts/gb300_launch.sh
@@ -40,6 +40,7 @@ IGC_CODE_DIR="${IGC_CODE_DIR:-$HOME/igc}"                   # igc checkout (node
 IGC_DATA_DIR="${IGC_DATA_DIR:-$HOME/.json_responses}"       # captured Redfish responses (mounted read-only)
 IGC_IMAGE="${IGC_IMAGE:-nvcr.io/nvidia/pytorch:26.03-py3}"  # bare NGC (runtime pip) or igc-train:ngc26.03 (deps baked)
 IGC_RUN="${IGC_RUN:-verify}"                                # experiment name / output subdir / container name
+IGC_MODELS_DIR="${IGC_MODELS_DIR:-/models}"                 # shared 240TB BeeGFS (large/durable artifacts)
 EPOCHS="${EPOCHS:-3}"
 IGC_MIN_FREE_GB="${IGC_MIN_FREE_GB:-100}"                   # HF pulls + dataset + checkpoints need headroom
 CONTAINER="igc-${IGC_RUN}"
@@ -74,10 +75,18 @@ COMMON="--train llm --llm latent --model_type ${IGC_MODEL} --json_data_dir /root
 [ "${IGC_USE_PEFT:-0}" = "1" ] && COMMON="${COMMON} --use_peft --lora_r ${LORA_R:-16} --lora_alpha ${LORA_ALPHA:-32}"
 
 docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
-log "docker run ${IGC_IMAGE} | ${IGC_GPUS} GPU | code=${IGC_CODE_DIR} data=${IGC_DATA_DIR}"
-docker run --rm --gpus all --ipc=host --shm-size=32g --name "$CONTAINER" \
+log "docker run ${IGC_IMAGE} | ${IGC_GPUS} GPU | code=${IGC_CODE_DIR} data=${IGC_DATA_DIR} models=${IGC_MODELS_DIR}"
+# NVIDIA-recommended flags (NGC startup banner): --ipc=host + memlock/stack ulimits.
+# Dual mounts: node-local code/data + the shared /models (240TB) so a run can write big
+# durable artifacts (checkpoints, HF cache) to /models or scratch to local via --output_dir.
+MODELS_MOUNT=""
+[ -d "$IGC_MODELS_DIR" ] && MODELS_MOUNT="-v ${IGC_MODELS_DIR}:/models"
+# shellcheck disable=SC2086  # MODELS_MOUNT must word-split into a -v arg (or be empty)
+docker run --rm --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 \
+    --name "$CONTAINER" \
     -v "${IGC_CODE_DIR}:/workspace/igc" \
     -v "${IGC_DATA_DIR}:/root/.json_responses:ro" \
+    $MODELS_MOUNT \
     -w /workspace/igc \
     -e IGC_GPUS -e IGC_STAGE -e IGC_MODEL -e IGC_RUN -e EPOCHS -e COMMON \
     "$IGC_IMAGE" bash -lc '

--- a/scripts/gb300_sanity_check.sh
+++ b/scripts/gb300_sanity_check.sh
@@ -23,6 +23,7 @@ IMAGE="${IGC_IMAGE:-nvcr.io/nvidia/pytorch:26.03-py3}"
 IGC_CODE_DIR="${IGC_CODE_DIR:-$HOME/igc}"          # /models/igc for the multi-node test
 MODELS_DIR="${MODELS_DIR:-/models}"
 GPUS_LADDER="${SANITY_GPUS:-1 4 8}"
+MODES="${SANITY_MODES:-ddp fsdp2}"                 # parallelism to confirm, one pass each
 GPUS_PER_NODE="${GPUS_PER_NODE:-4}"
 PORT="${SANITY_PORT:-29511}"
 # shellcheck disable=SC2206  # word-split the space-separated node list on purpose
@@ -43,9 +44,10 @@ node_free() {  # ip -> 0 if no GPU compute process is running
 }
 
 # shellcheck disable=SC2086  # NV_FLAGS/MOUNTS must word-split into separate docker args
-run_on() {  # node_ip nnodes node_rank master_ip nproc
+run_on() {  # node_ip nnodes node_rank master_ip nproc mode
     $SSH "nvidia@$1" \
-        "docker run --rm --network host $NV_FLAGS $MOUNTS -w /workspace/igc $IMAGE \
+        "docker run --rm --network host $NV_FLAGS $MOUNTS \
+             -e SANITY_MODE=$6 -e SANITY_STEPS=1 -w /workspace/igc $IMAGE \
              torchrun --nnodes=$2 --node_rank=$3 --nproc_per_node=$5 \
                       --master_addr=$4 --master_port=$PORT scripts/dist_sanity.py"
 }
@@ -54,7 +56,6 @@ overall=0
 for g in $GPUS_LADDER; do
     need=$(( (g + GPUS_PER_NODE - 1) / GPUS_PER_NODE ))   # nodes required
     nproc=$(( g < GPUS_PER_NODE ? g : GPUS_PER_NODE ))    # procs per node
-    log "sanity: ${g} GPU (${need} node(s), ${nproc}/node)"
 
     if [ "${#NODES[@]}" -lt "$need" ]; then
         echo "  SKIP ${g}-GPU: need ${need} node(s), have ${#NODES[@]} — set SANITY_NODES='ip1 ip2'" >&2
@@ -65,16 +66,20 @@ for g in $GPUS_LADDER; do
     busy=0
     for ip in "${use[@]}"; do node_free "$ip" || { echo "  BLOCKER: node $ip is busy — skipping ${g}-GPU" >&2; busy=1; }; done
     [ "$busy" = "0" ] || { overall=1; continue; }
-
     master="${use[0]}"
-    pids=(); rank=0
-    for ip in "${use[@]}"; do
-        run_on "$ip" "$need" "$rank" "$master" "$nproc" &
-        pids+=("$!"); rank=$((rank + 1))
+
+    # one SINGLE gradient pass per parallelism mode — confirm DDP and FSDP2 both work
+    for mode in $MODES; do
+        log "sanity: ${g} GPU  mode=${mode}  (${need} node(s), ${nproc}/node, 1 pass)"
+        pids=(); rank=0
+        for ip in "${use[@]}"; do
+            run_on "$ip" "$need" "$rank" "$master" "$nproc" "$mode" &
+            pids+=("$!"); rank=$((rank + 1))
+        done
+        rc=0
+        for p in "${pids[@]}"; do wait "$p" || rc=1; done
+        if [ "$rc" = "0" ]; then echo "  ${g}-GPU ${mode}: PASS"; else echo "  ${g}-GPU ${mode}: FAIL"; overall=1; fi
     done
-    rc=0
-    for p in "${pids[@]}"; do wait "$p" || rc=1; done
-    if [ "$rc" = "0" ]; then echo "  ${g}-GPU: PASS"; else echo "  ${g}-GPU: FAIL"; overall=1; fi
 done
 
 if [ "$overall" = "0" ]; then

--- a/scripts/gb300_sanity_check.sh
+++ b/scripts/gb300_sanity_check.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# gb300_sanity_check.sh — distributed backward-pass sanity BEFORE committing 72 GPUs.
+#
+# Runs scripts/dist_sanity.py under torchrun in the NGC/igc-train container for a ladder
+# of GPU counts. A GB300 node has 4 GPUs, so: 1 = single proc, 4 = single node, 8 = TWO
+# nodes (multi-node — validates the RoCE fabric + cross-node NCCL, the thing that will
+# make or break a 72-GPU run). It refuses to run on a node another team is using, and
+# prints PASS/FAIL per config; any failure means "do NOT start full training".
+#
+# Usage (on a node, or from a control host with ssh to the nodes):
+#   SANITY_NODES="172.25.230.42 172.25.230.49" scripts/gb300_sanity_check.sh   # runs 1,4,8
+#   SANITY_GPUS="1 4" scripts/gb300_sanity_check.sh                            # single-node only
+#   IGC_IMAGE=igc-train:ngc26.03-py3 SANITY_NODES="…" scripts/gb300_sanity_check.sh
+#
+# For the 8-GPU (multi-node) test the code must be visible on BOTH nodes — point
+# IGC_CODE_DIR at the shared checkout (/models/igc) so every node sees the same file.
+#
+# Author:
+# Mus mbayramo@stanford.edu
+set -uo pipefail
+
+IMAGE="${IGC_IMAGE:-nvcr.io/nvidia/pytorch:26.03-py3}"
+IGC_CODE_DIR="${IGC_CODE_DIR:-$HOME/igc}"          # /models/igc for the multi-node test
+MODELS_DIR="${MODELS_DIR:-/models}"
+GPUS_LADDER="${SANITY_GPUS:-1 4 8}"
+GPUS_PER_NODE="${GPUS_PER_NODE:-4}"
+PORT="${SANITY_PORT:-29511}"
+# shellcheck disable=SC2206  # word-split the space-separated node list on purpose
+NODES=(${SANITY_NODES:-$(hostname -I 2>/dev/null | awk '{print $1}')})
+
+# NVIDIA-recommended container flags (from the NGC startup banner) + dual mounts:
+# shared /models (240 TB) and node-local code, so a run can write either place.
+NV_FLAGS="--gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864"
+MOUNTS="-v ${IGC_CODE_DIR}:/workspace/igc -v ${MODELS_DIR}:/models"
+SSH="ssh -o BatchMode=yes -o ConnectTimeout=6"
+
+log() { echo "=== [$(date -u '+%F %T')] $* ==="; }
+
+node_free() {  # ip -> 0 if no GPU compute process is running
+    local busy
+    busy=$($SSH "nvidia@$1" 'nvidia-smi --query-compute-apps=pid --format=csv,noheader 2>/dev/null | grep -c .' 2>/dev/null || echo 99)
+    [ "$busy" = "0" ]
+}
+
+# shellcheck disable=SC2086  # NV_FLAGS/MOUNTS must word-split into separate docker args
+run_on() {  # node_ip nnodes node_rank master_ip nproc
+    $SSH "nvidia@$1" \
+        "docker run --rm --network host $NV_FLAGS $MOUNTS -w /workspace/igc $IMAGE \
+             torchrun --nnodes=$2 --node_rank=$3 --nproc_per_node=$5 \
+                      --master_addr=$4 --master_port=$PORT scripts/dist_sanity.py"
+}
+
+overall=0
+for g in $GPUS_LADDER; do
+    need=$(( (g + GPUS_PER_NODE - 1) / GPUS_PER_NODE ))   # nodes required
+    nproc=$(( g < GPUS_PER_NODE ? g : GPUS_PER_NODE ))    # procs per node
+    log "sanity: ${g} GPU (${need} node(s), ${nproc}/node)"
+
+    if [ "${#NODES[@]}" -lt "$need" ]; then
+        echo "  SKIP ${g}-GPU: need ${need} node(s), have ${#NODES[@]} — set SANITY_NODES='ip1 ip2'" >&2
+        continue
+    fi
+    use=("${NODES[@]:0:$need}")
+
+    busy=0
+    for ip in "${use[@]}"; do node_free "$ip" || { echo "  BLOCKER: node $ip is busy — skipping ${g}-GPU" >&2; busy=1; }; done
+    [ "$busy" = "0" ] || { overall=1; continue; }
+
+    master="${use[0]}"
+    pids=(); rank=0
+    for ip in "${use[@]}"; do
+        run_on "$ip" "$need" "$rank" "$master" "$nproc" &
+        pids+=("$!"); rank=$((rank + 1))
+    done
+    rc=0
+    for p in "${pids[@]}"; do wait "$p" || rc=1; done
+    if [ "$rc" = "0" ]; then echo "  ${g}-GPU: PASS"; else echo "  ${g}-GPU: FAIL"; overall=1; fi
+done
+
+if [ "$overall" = "0" ]; then
+    log "ALL SANITY PASSED — fabric + distributed stack ready for full training"
+else
+    log "SANITY FAILURES — do NOT start full training until resolved"
+fi
+exit "$overall"
+
+# Author: Mus mbayramo@stanford.edu

--- a/scripts/gb300_sanity_check.sh
+++ b/scripts/gb300_sanity_check.sh
@@ -24,6 +24,9 @@ IGC_CODE_DIR="${IGC_CODE_DIR:-$HOME/igc}"          # /models/igc for the multi-n
 MODELS_DIR="${MODELS_DIR:-/models}"
 GPUS_LADDER="${SANITY_GPUS:-1 4 8}"
 MODES="${SANITY_MODES:-ddp fsdp2}"                 # parallelism to confirm, one pass each
+SCRIPT="${SANITY_SCRIPT:-scripts/dist_sanity.py}"  # or scripts/dataset_sanity.py (dataset feed)
+IGC_MODEL="${IGC_MODEL:-gpt2}"                      # tokenizer key for the dataset pass
+IGC_DATASET_DIR="${IGC_DATASET_DIR:-/workspace/igc/datasets}"
 GPUS_PER_NODE="${GPUS_PER_NODE:-4}"
 PORT="${SANITY_PORT:-29511}"
 # shellcheck disable=SC2206  # word-split the space-separated node list on purpose
@@ -47,9 +50,10 @@ node_free() {  # ip -> 0 if no GPU compute process is running
 run_on() {  # node_ip nnodes node_rank master_ip nproc mode
     $SSH "nvidia@$1" \
         "docker run --rm --network host $NV_FLAGS $MOUNTS \
-             -e SANITY_MODE=$6 -e SANITY_STEPS=1 -w /workspace/igc $IMAGE \
+             -e SANITY_MODE=$6 -e SANITY_STEPS=1 -e IGC_MODEL=$IGC_MODEL -e IGC_DATASET_DIR=$IGC_DATASET_DIR \
+             -w /workspace/igc $IMAGE \
              torchrun --nnodes=$2 --node_rank=$3 --nproc_per_node=$5 \
-                      --master_addr=$4 --master_port=$PORT scripts/dist_sanity.py"
+                      --master_addr=$4 --master_port=$PORT $SCRIPT"
 }
 
 overall=0


### PR DESCRIPTION
Part of the planned full-training workflow (no ad-hoc scripts). For review, not merged.

- **scripts/dist_sanity.py** — pure-torch DDP backward pass + a known all-reduce (sum-of-ranks); a hung/mis-wired fabric fails HERE, not 20 min into a real run.
- **scripts/gb300_sanity_check.sh** — runs it for **1 / 4 / 8 GPU** (8 = 2 nodes, exercising cross-node RoCE/NCCL), refuses busy nodes, prints PASS/FAIL per config — the go/no-go gate before 72 GPUs.
- **scripts/gb300_distribute_image.sh** — build once → `docker save` to `/models/images` → `docker load` on all 18 nodes (base already cached, so only the delta layers load).
- **gb300_launch.sh** — NVIDIA flags `--ipc=host --ulimit memlock=-1 --ulimit stack=67108864` + dual mount (node-local **and** `/models`).

shellcheck-clean, py_compile + ruff clean. **The multi-node (8-GPU) path is the part I most want your eyes on** — it ssh-fans torchrun across 2 nodes with `--network host` rendezvous; needs a live 2-node test (which I won't run without your go).