### PR TITLE
Dockerfile.train: add wget/curl/bash/unzip/zip/gzip tools

### DIFF
--- a/docker/Dockerfile.train
+++ b/docker/Dockerfile.train
@@ -30,7 +30,7 @@ WORKDIR /workspace/igc
 #   nvtop    — live per-GPU utilisation/memory view while a run trains.
 #   htop     — live CPU/RAM view (dataset build is CPU-heavy).
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        git-lfs nvtop htop \
+        wget git-lfs nvtop htop curl bash unzip zip gzip \
     && git lfs install --system \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Operator's tool additions to the training image so a bug fix can be pulled/committed/PR'd from inside the running container (no docker teardown). Keyless-image change; safe to distribute.