### PR TITLE
Fix epoch-boundary deadlock: barrier after save + guard empty eval

### DIFF
--- a/igc/modules/llm_train_state_encoder.py
+++ b/igc/modules/llm_train_state_encoder.py
@@ -348,7 +348,9 @@ class LlmEmbeddingsTrainer(LlmModule):
                 correct_predictions += compute_accuracy * batch_size
                 total_predictions += batch_size
 
-        accuracy = correct_predictions / total_predictions * 100.0
+        # Guard: with drop_last + a small eval shard a rank can get 0 eval batches; a
+        # bare division would crash (and take the fleet down mid-epoch) — return 0.0.
+        accuracy = (correct_predictions / total_predictions * 100.0) if total_predictions else 0.0
         return accuracy
 
     def is_distributed(self):
@@ -771,6 +773,14 @@ class LlmEmbeddingsTrainer(LlmModule):
                                 initial_lr=self._lr,
                                 is_best_accuracy=is_best_accuracy,
                             )
+
+            # Epoch-boundary barrier: all ranks meet here AFTER the rank-0 checkpoint
+            # write, so no rank races into the next epoch's first FSDP collective (an
+            # all-gather) while rank 0 is still saving. Without it, rank 0 sits in the
+            # save while the others wait in the next collective -> the epoch-2 deadlock
+            # (ranks spinning, one idle). Collective — every rank must reach it.
+            if self.is_accelerator:
+                self.accelerator.wait_for_everyone()
 
         if self._is_quantize:
             self.model = convert(self.model)

--- a/tests/modules/test_validate_empty_eval.py
+++ b/tests/modules/test_validate_empty_eval.py
@@ -1,0 +1,27 @@
+"""Offline regression: validate() tolerates an empty eval shard.
+
+Under FSDP with drop_last + a small eval set, a rank can be handed 0 eval batches.
+The accuracy computation divided correct/total unconditionally, so that rank crashed
+with ZeroDivisionError mid-epoch — which, on a multi-GPU run, takes the whole fleet
+down at a collective. validate() now returns 0.0 for an empty shard. (The companion
+epoch-boundary barrier fix is distributed-only and is exercised on the 4-GPU run.)
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import types
+
+from igc.modules.llm_train_state_encoder import LlmEmbeddingsTrainer
+
+
+def test_validate_empty_eval_returns_zero_not_crash():
+    """0 eval batches -> 0.0 accuracy, no ZeroDivisionError."""
+    trainer = LlmEmbeddingsTrainer.__new__(LlmEmbeddingsTrainer)
+    trainer.model = types.SimpleNamespace(eval=lambda: None)
+
+    # empty dataloader -> the batch loop never runs -> total_predictions == 0
+    assert trainer.validate([]) == 0.0
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
Root cause (from a live 4-GPU run + Pro max-reasoning review): epoch 1 trained, rank 0 saved, then epoch 2 hung — ranks spinning, one idle. `get_state_dict` is collective-safe, but there was **no barrier after the rank-0 save**, so ranks 1..N raced into epoch 2's first FSDP all-gather while rank 0 was still writing the checkpoint -> cyclic wait. Adds `accelerator.wait_for_everyone()` after the save (every rank meets at the epoch boundary). Also guards `validate()` against a 0-batch eval shard (ZeroDivisionError would crash the fleet). Offline gate 608 passed; the barrier is distributed-only and gets verified on the next 4-GPU run.