### PR TITLE
Add optimization boundary test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  shell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          lfs: true
+      - name: Install shell test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats shellcheck
+      - name: Bash syntax
+        shell: bash
+        run: bash -n scripts/*.sh scripts/*.sbatch tests/bats/*.bats
+      - name: ShellCheck
+        shell: bash
+        run: shellcheck scripts/*.sh scripts/*.sbatch tests/bats/*.bats
+      - name: Bats
+        shell: bash
+        run: bats tests/bats
+
   gate:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
         with:
@@ -20,7 +45,7 @@ jobs:
           lfs: true
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.python-version }}
           cache: pip
       - name: Install dependencies
         run: |
@@ -43,7 +68,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: metrics-${{ github.sha }}
+          name: metrics-py${{ matrix.python-version }}-${{ github.sha }}
           path: |
             coverage.xml
             coverage.json
@@ -51,7 +76,7 @@ jobs:
           retention-days: 90
 
   perf:
-    needs: gate
+    needs: [shell, gate]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -73,7 +98,7 @@ jobs:
           KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 pytest -m perf -q
 
   docker:
-    needs: gate
+    needs: [shell, gate]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     # secrets are NOT available in `if:` conditionals; surface them as env, then gate on env.

--- a/scripts/gpu_dataset_isolation.sh
+++ b/scripts/gpu_dataset_isolation.sh
@@ -26,7 +26,7 @@ CASES=(
   "odd_batch_drop|@|1000|7|1|PASS"
 )
 
-pass=0; fail=0; dead=0
+pass=0; fail=0; dead=0; mismatch=0
 printf "%-26s %-6s %-8s %-9s %s\n" CASE WORLD EXPECT GOT DETAIL
 for world in $WORLDS; do
   for spec in "${CASES[@]}"; do
@@ -40,6 +40,7 @@ for world in $WORLDS; do
     elif [ "$rc" -eq 0 ]; then got="PASS"
     else got="FAIL"; fi
     ok="ok"; [ "$got" != "$expect" ] && ok="MISMATCH"
+    [ "$ok" = "MISMATCH" ] && mismatch=$((mismatch+1))
     [ "$got" = "PASS" ] && pass=$((pass+1))
     [ "$got" = "DEADLOCK" ] && dead=$((dead+1))
     [ "$got" = "FAIL" ] && fail=$((fail+1))
@@ -50,5 +51,8 @@ for world in $WORLDS; do
   done
 done
 echo "----"
-echo "summary: PASS=$pass DEADLOCK(reproduced)=$dead FAIL=$fail"
+echo "summary: PASS=$pass DEADLOCK(reproduced)=$dead FAIL=$fail MISMATCH=$mismatch"
 # Exit nonzero only if an expectation was violated (a PASS-case deadlocked, or a bug-case passed).
+if [ "$mismatch" -ne 0 ]; then
+  exit 1
+fi

--- a/scripts/run_llm_large.sh
+++ b/scripts/run_llm_large.sh
@@ -1,1 +1,4 @@
-python -m torch.distributed.launch --nproc_per_node 2 llm_trainer.py --model_type gpt2-large
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec python -m torch.distributed.launch --nproc_per_node 2 llm_trainer.py --model_type gpt2-large

--- a/scripts/run_profile.sh
+++ b/scripts/run_profile.sh
@@ -27,7 +27,10 @@ METRIC_REPORT="${IGC_METRIC_REPORT:-wandb}"
 # The env file is gitignored (creds never committed); override the path via IGC_WANDB_ENV.
 WANDB_ENV="${IGC_WANDB_ENV:-.internal/wandb.env}"
 if [ -f "$WANDB_ENV" ]; then
-    set -a; . "$WANDB_ENV"; set +a
+    set -a
+    # shellcheck source=/dev/null
+    . "$WANDB_ENV"
+    set +a
     echo "== W&B: streaming to \${WANDB_ENTITY:-?}/\${WANDB_PROJECT:-?} (real-time) =="
 elif [ "$METRIC_REPORT" = "wandb" ]; then
     echo "== W&B: no \$WANDB_API_KEY and no $WANDB_ENV — set IGC_METRIC_REPORT=tensorboard or provide creds ==" >&2
@@ -45,6 +48,7 @@ ARGV=$(python -m igc.modules.train.launch --profile "$PROFILE" "${SET_ARGS[@]}" 
 
 mkdir -p "$OUT_DIR"
 echo "== launching igc_main.py (data=${DATA_DIR}, out=${OUT_DIR}) =="
+# shellcheck disable=SC2086  # ARGV is a shell-form argv emitted by the launcher.
 exec python igc_main.py $ARGV \
   --json_data_dir "$DATA_DIR" \
   --output_dir "$OUT_DIR" \

--- a/scripts/stage_node.sh
+++ b/scripts/stage_node.sh
@@ -28,18 +28,19 @@ IGC_REPO_URL="${IGC_REPO_URL:-$(git -C "${HERE}" remote get-url origin)}"
 BW="--bwlimit=${IGC_BWLIMIT_KBPS:-4000}"
 
 echo "code: ${REMOTE} pulls ${IGC_REPO_URL} (no laptop transfer)"
+# shellcheck disable=SC2029  # Local values intentionally select the remote checkout command.
 ssh "${REMOTE}" "if [ -d '${IGC_DEST}/.git' ]; then git -C '${IGC_DEST}' fetch origin && git -C '${IGC_DEST}' reset --hard origin/main; else git clone '${IGC_REPO_URL}' '${IGC_DEST}'; fi"
 
 if [[ "${IGC_STAGE_DATA:-1}" == "1" ]]; then
     SIZE="$(du -sm "${HOME}/.json_responses" 2>/dev/null | cut -f1 || echo '?')"
     echo "captures: ~${SIZE}MB -> ${REMOTE}:~/.json_responses (bwlimit ${IGC_BWLIMIT_KBPS:-4000}KB/s)"
-    rsync -az ${BW} --exclude '*.tar.gz' --exclude '*.tar' \
+    rsync -az "${BW}" --exclude '*.tar.gz' --exclude '*.tar' \
         "${HOME}/.json_responses/" "${REMOTE}:.json_responses/"
 fi
 
 if [[ "${IGC_STAGE_INTERNAL:-0}" == "1" ]]; then
     echo "run config: .internal/ (tiny; values never printed)"
-    rsync -az ${BW} "${HERE}/.internal/" "${REMOTE}:${IGC_DEST}/.internal/"
+    rsync -az "${BW}" "${HERE}/.internal/" "${REMOTE}:${IGC_DEST}/.internal/"
 fi
 
 echo "dataset caches: NOT transferred — rebuild on the node:"

--- a/scripts/submit_train.sh
+++ b/scripts/submit_train.sh
@@ -56,9 +56,10 @@ if [ "${WANDB_API_KEY:-}" = "" ] && [ ! -f "${HERE}/.internal/wandb.env" ]; then
 fi
 
 set -x
-IGC_GPUS="${IGC_GPUS:-1}"
-IGC_NODES="${IGC_NODES:-1}"
-IGC_STAGE="${STAGE}" IGC_GPUS="${IGC_GPUS}" sbatch \
+export IGC_GPUS="${IGC_GPUS:-1}"
+export IGC_NODES="${IGC_NODES:-1}"
+export IGC_STAGE="${STAGE}"
+sbatch \
     --gres="gpu:${IGC_GPUS}" \
     --nodes="${IGC_NODES}" \
     --ntasks-per-node=1 \

--- a/scripts/train_igc.sbatch
+++ b/scripts/train_igc.sbatch
@@ -89,6 +89,7 @@ IGC_REPORT="${IGC_REPORT:-wandb}"
 RUN_NAME="${WANDB_NAME:-${IGC_STAGE}-${IGC_MODEL//\//_}-${SLURM_JOB_ID:-local}}"
 if [ "${IGC_REPORT}" = "wandb" ]; then
     # convenience: source a node-local gitignored key file if present (.internal/ is never committed)
+    # shellcheck source=/dev/null
     [ -f "${IGC_DIR}/.internal/wandb.env" ] && . "${IGC_DIR}/.internal/wandb.env"
     : "${WANDB_API_KEY:?set WANDB_API_KEY in your env or ${IGC_DIR}/.internal/wandb.env to use wandb}"
     export WANDB_API_KEY
@@ -101,6 +102,7 @@ echo "igc train | stage=${IGC_STAGE} args='${TRAIN_ARGS}' model=${IGC_MODEL} epo
 # Export the few values the inner heredoc needs (avoids brittle nested quoting).
 export IGC_MODEL EPOCHS SEED IGC_REPORT TRAIN_ARGS EPOCH_FLAG EXTRA_ARGS RUN_NAME IGC_RUN RL_EPOCH_ARG IGC_GPUS IGC_SHARDING MASTER_ADDR MASTER_PORT
 
+# shellcheck disable=SC2016  # The single-quoted payload is evaluated inside the container.
 srun --container-image="${NGC_IMAGE}" \
      --container-mounts="${IGC_DIR}:/workspace/igc,${DATA_DIR}:/root/.json_responses" \
      bash -lc '

--- a/scripts/train_m1.sbatch
+++ b/scripts/train_m1.sbatch
@@ -41,6 +41,7 @@ export EXTRA_ARGS=""
 IGC_REPORT="${IGC_REPORT:-wandb}"
 if [ "${IGC_REPORT}" = "wandb" ]; then
     # convenience: source a node-local gitignored key file if present (.internal/ is never committed)
+    # shellcheck source=/dev/null
     [ -f "${IGC_DIR}/.internal/wandb.env" ] && . "${IGC_DIR}/.internal/wandb.env"
     : "${WANDB_API_KEY:?set WANDB_API_KEY in your env or ${IGC_DIR}/.internal/wandb.env to use wandb}"
     export WANDB_API_KEY
@@ -50,6 +51,7 @@ fi
 
 echo "igc M1 SFT | model=${IGC_MODEL} epochs=${EPOCHS} report=${IGC_REPORT} node=$(hostname)"
 
+# shellcheck disable=SC2016  # The single-quoted payload is evaluated inside the container.
 srun --container-image="${NGC_IMAGE}" \
      --container-mounts="${IGC_DIR}:/workspace/igc,${DATA_DIR}:/root/.json_responses" \
      bash -lc '

--- a/tests/bats/gpu_dataset_isolation.bats
+++ b/tests/bats/gpu_dataset_isolation.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+    export REPO_ROOT
+
+    mkdir -p "${BATS_TEST_TMPDIR}/bin"
+    export PATH="${BATS_TEST_TMPDIR}/bin:${PATH}"
+
+    cat >"${BATS_TEST_TMPDIR}/bin/nvidia-smi" <<'EOF'
+#!/usr/bin/env bash
+echo "GPU 0: fake"
+echo "GPU 1: fake"
+EOF
+    chmod +x "${BATS_TEST_TMPDIR}/bin/nvidia-smi"
+
+    cat >"${BATS_TEST_TMPDIR}/bin/timeout" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+_timeout_seconds="$1"
+shift
+
+world=1
+for arg in "$@"; do
+    case "$arg" in
+        --nproc_per_node=*) world="${arg#--nproc_per_node=}" ;;
+    esac
+done
+
+case "${FAKE_TIMEOUT_MODE:-expected}" in
+    all-pass)
+        echo "fake pass world=${world} ds=${DS_SIZE:-?}"
+        exit 0
+        ;;
+    expected)
+        if [[ "${DROP_LAST:-}" == "0" && "${DS_SIZE:-}" == "97" && "${world}" != "1" ]]; then
+            echo "fake deadlock world=${world} ds=${DS_SIZE:-?}"
+            exit 124
+        fi
+        echo "fake pass world=${world} ds=${DS_SIZE:-?}"
+        exit 0
+        ;;
+    *)
+        echo "unknown FAKE_TIMEOUT_MODE=${FAKE_TIMEOUT_MODE}" >&2
+        exit 2
+        ;;
+esac
+EOF
+    chmod +x "${BATS_TEST_TMPDIR}/bin/timeout"
+}
+
+@test "gpu isolation wrapper passes when PASS and DEADLOCK expectations match" {
+    run env \
+        CASE_TIMEOUT=1 \
+        WORLDS="1 2" \
+        FAKE_TIMEOUT_MODE=expected \
+        bash "${REPO_ROOT}/scripts/gpu_dataset_isolation.sh"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"indivisible_NO_drop_last"* ]]
+    [[ "$output" == *"DEADLOCK"* ]]
+    [[ "$output" == *"MISMATCH=0"* ]]
+}
+
+@test "gpu isolation wrapper fails when a known deadlock case unexpectedly passes" {
+    run env \
+        CASE_TIMEOUT=1 \
+        WORLDS="1 2" \
+        FAKE_TIMEOUT_MODE=all-pass \
+        bash "${REPO_ROOT}/scripts/gpu_dataset_isolation.sh"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"MISMATCH"* ]]
+    [[ "$output" == *"MISMATCH=1"* ]]
+}

--- a/tests/bats/preflight_nv72.bats
+++ b/tests/bats/preflight_nv72.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+    export REPO_ROOT
+
+    mkdir -p "${BATS_TEST_TMPDIR}/bin"
+    export PATH="${BATS_TEST_TMPDIR}/bin:${PATH}"
+}
+
+@test "preflight requires the dashboard URL" {
+    run env -u NV72_FLEET_DASHBOARD_URL \
+        bash "${REPO_ROOT}/scripts/preflight_nv72.sh"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"NV72_FLEET_DASHBOARD_URL"* ]]
+}
+
+@test "preflight pipes fleet state JSON to the Python checker" {
+    cat >"${BATS_TEST_TMPDIR}/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+printf '{"status":"ok"}'
+EOF
+    chmod +x "${BATS_TEST_TMPDIR}/bin/curl"
+
+    cat >"${BATS_TEST_TMPDIR}/bin/python3" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+cat >"${PREFLIGHT_STDIN_FILE}"
+printf '%s\n' "$*" >"${PREFLIGHT_ARGS_FILE}"
+printf '%s\n' "${PYTHONPATH:-}" >"${PREFLIGHT_PYTHONPATH_FILE}"
+EOF
+    chmod +x "${BATS_TEST_TMPDIR}/bin/python3"
+
+    run env \
+        NV72_FLEET_DASHBOARD_URL=http://example.invalid \
+        PREFLIGHT_STDIN_FILE="${BATS_TEST_TMPDIR}/stdin.json" \
+        PREFLIGHT_ARGS_FILE="${BATS_TEST_TMPDIR}/args.txt" \
+        PREFLIGHT_PYTHONPATH_FILE="${BATS_TEST_TMPDIR}/pythonpath.txt" \
+        bash "${REPO_ROOT}/scripts/preflight_nv72.sh" --require-endpoint pro
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/stdin.json")" = '{"status":"ok"}' ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/args.txt")" = "-m igc.shared.nv72_preflight --require-endpoint pro" ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/pythonpath.txt")" = "${REPO_ROOT}" ]
+}
+
+@test "preflight reports a blocker when the dashboard request fails" {
+    cat >"${BATS_TEST_TMPDIR}/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 22
+EOF
+    chmod +x "${BATS_TEST_TMPDIR}/bin/curl"
+
+    run env \
+        NV72_FLEET_DASHBOARD_URL=http://example.invalid \
+        bash "${REPO_ROOT}/scripts/preflight_nv72.sh"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"BLOCKER: fleet dashboard unreachable"* ]]
+}

--- a/tests/bats/run_profile.bats
+++ b/tests/bats/run_profile.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+    export REPO_ROOT
+
+    mkdir -p "${BATS_TEST_TMPDIR}/bin" "${BATS_TEST_TMPDIR}/data"
+    export PATH="${BATS_TEST_TMPDIR}/bin:${PATH}"
+}
+
+install_python_stub() {
+    cat >"${BATS_TEST_TMPDIR}/bin/python" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "-m" && "${2:-}" == "igc.modules.train.launch" ]]; then
+    printf '%s\n' "$*" >>"${RUN_PROFILE_CALLS_FILE}"
+    for arg in "$@"; do
+        if [[ "$arg" == "--print-argv" ]]; then
+            echo "--train llm --batch_size 2"
+            exit 0
+        fi
+    done
+    exit 0
+fi
+
+if [[ "${1:-}" == "igc_main.py" ]]; then
+    printf '%s\n' "$*" >"${RUN_PROFILE_FINAL_ARGS_FILE}"
+    exit 0
+fi
+
+echo "unexpected python call: $*" >&2
+exit 2
+EOF
+    chmod +x "${BATS_TEST_TMPDIR}/bin/python"
+}
+
+@test "run_profile requires IGC_PROFILE" {
+    run env -u IGC_PROFILE bash "${REPO_ROOT}/scripts/run_profile.sh"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"set IGC_PROFILE"* ]]
+}
+
+@test "run_profile resolves profile argv and launches igc_main with paths and extras" {
+    install_python_stub
+
+    run env \
+        IGC_PROFILE=m1_gpt2_smoke \
+        IGC_DATA_DIR="${BATS_TEST_TMPDIR}/data" \
+        IGC_OUTPUT_DIR="${BATS_TEST_TMPDIR}/out" \
+        IGC_METRIC_REPORT=tensorboard \
+        IGC_SET="batch_size=2 lr=1e-4" \
+        RUN_PROFILE_CALLS_FILE="${BATS_TEST_TMPDIR}/calls.txt" \
+        RUN_PROFILE_FINAL_ARGS_FILE="${BATS_TEST_TMPDIR}/final-args.txt" \
+        bash "${REPO_ROOT}/scripts/run_profile.sh" -- --recreate_dataset
+
+    [ "$status" -eq 0 ]
+    [ -d "${BATS_TEST_TMPDIR}/out" ]
+
+    calls="$(cat "${BATS_TEST_TMPDIR}/calls.txt")"
+    [[ "$calls" == *"--profile m1_gpt2_smoke"* ]]
+    [[ "$calls" == *"--set batch_size=2"* ]]
+    [[ "$calls" == *"--set lr=1e-4"* ]]
+    [[ "$calls" == *"--print-argv"* ]]
+
+    final_args="$(cat "${BATS_TEST_TMPDIR}/final-args.txt")"
+    [[ "$final_args" == *"igc_main.py --train llm --batch_size 2"* ]]
+    [[ "$final_args" == *"--json_data_dir ${BATS_TEST_TMPDIR}/data"* ]]
+    [[ "$final_args" == *"--output_dir ${BATS_TEST_TMPDIR}/out"* ]]
+    [[ "$final_args" == *"--metric_report tensorboard -- --recreate_dataset"* ]]
+}

--- a/tests/ds/test_dataset_picklable.py
+++ b/tests/ds/test_dataset_picklable.py
@@ -14,7 +14,9 @@ Mus mbayramo@stanford.edu
 
 import pickle
 
+import pytest
 import torch
+from torch.utils.data import DataLoader
 
 from igc.ds.redfish_dataset import JSONDataset
 
@@ -52,6 +54,28 @@ def test_original_instance_unchanged_by_getstate(tmp_path):
     pickle.dumps(ds)
     assert ds.logger is not None
     assert hasattr(ds.logger, "write")  # still the original handle
+
+
+def test_spawn_worker_dataloader_reads_pickled_dataset(tmp_path):
+    """A spawn DataLoader can pickle the dataset and read every tiny item."""
+    ds = _dataset_like(tmp_path)
+    loader = DataLoader(
+        ds,
+        batch_size=1,
+        num_workers=2,
+        multiprocessing_context="spawn",
+    )
+
+    try:
+        rows = [batch.squeeze(0) for batch in loader]
+    except RuntimeError as exc:
+        if "torch_shm_manager" in str(exc):
+            pytest.skip("shared-memory manager unavailable for spawn workers")
+        raise
+
+    assert len(rows) == 2
+    assert torch.equal(rows[0], torch.tensor([1]))
+    assert torch.equal(rows[1], torch.tensor([2]))
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/envs/test_rest_gym_batch_env_boundary.py
+++ b/tests/envs/test_rest_gym_batch_env_boundary.py
@@ -1,0 +1,143 @@
+"""Offline boundary tests for ``VectorizedRestApiEnv`` batch alignment.
+
+The vector env feeds replay and GPU batched encoders, so observation/reward flag
+axes must stay aligned with ``num_envs``. These tests use tmp JSON fixtures and
+a deterministic encoder; no network, GPU, or live Redfish host is involved.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import argparse
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+import torch
+
+from igc.envs.rest_gym_batch_env import VectorizedRestApiEnv
+from igc.envs.rest_gym_env import HttpMethod
+from igc.interfaces.rest_mapping_interface import RestMappingInterface
+
+
+ROOT_URI = "/redfish/v1"
+SYSTEM_URI = "/redfish/v1/Systems/1"
+
+
+class StubEncoder:
+    """Deterministic encoder with a stable vector observation shape."""
+
+    emb_shape = (2, 3)
+
+    def encode(self, observation: str) -> torch.Tensor:
+        seed = sum(str(observation).encode("utf-8")) % 19
+        return torch.arange(6, dtype=torch.float32).reshape(self.emb_shape) + seed
+
+    def initialize(self) -> torch.Tensor:
+        return torch.zeros(self.emb_shape, dtype=torch.float32)
+
+
+class TinyRestMapping(RestMappingInterface):
+    """Small RestMappingInterface double for vector env tests."""
+
+    def __init__(self, mappings: dict[str, Path]) -> None:
+        self._uris = list(mappings)
+        self._mappings = mappings
+
+    def lookup_rest_api_to_respond(self, rest_api: str) -> str:
+        path = self._mappings.get(rest_api)
+        return "" if path is None else str(path)
+
+    def lookup_rest_api_to_method(self, rest_api: str) -> str:
+        return HttpMethod.GET.value if rest_api in self._mappings else ""
+
+    def get_rest_api_mappings(self) -> Iterator[tuple[str, str]]:
+        for rest_api, path in self._mappings.items():
+            yield rest_api, str(path)
+
+    def get_rest_api_methods(self) -> Iterator[tuple[str, str]]:
+        for rest_api in self._uris:
+            yield rest_api, HttpMethod.GET.value
+
+    @property
+    def num_actions(self) -> int:
+        return len(self._uris)
+
+    def entry_rest_api(self) -> tuple[str, torch.Tensor]:
+        return ROOT_URI, self.action_for(ROOT_URI)
+
+    def one_hot_vector_to_action(self, one_hot: torch.Tensor) -> str:
+        return self._uris[int(torch.argmax(one_hot).item())]
+
+    def action_for(self, rest_api: str) -> torch.Tensor:
+        action = torch.zeros(len(self._uris), dtype=torch.float32)
+        action[self._uris.index(rest_api)] = 1.0
+        return action
+
+
+@pytest.fixture
+def vector_env(tmp_path: Path) -> VectorizedRestApiEnv:
+    """Create a two-env vector REST environment backed by tmp JSON files."""
+    root_path = tmp_path / "root.json"
+    root_path.write_text(json.dumps({"@odata.id": ROOT_URI}), encoding="utf-8")
+    system_path = tmp_path / "system.json"
+    system_path.write_text(json.dumps({"@odata.id": SYSTEM_URI}), encoding="utf-8")
+
+    mapping = TinyRestMapping({ROOT_URI: root_path, SYSTEM_URI: system_path})
+    return VectorizedRestApiEnv(
+        args=argparse.Namespace(raw_data_dir=str(tmp_path)),
+        model=None,
+        tokenizer=None,
+        discovered_rest_api=mapping,
+        max_episode=5,
+        num_envs=2,
+        encoder=StubEncoder(),
+    )
+
+
+def _action(env: VectorizedRestApiEnv, rest_api: str) -> torch.Tensor:
+    """Build one vector-env action for ``rest_api`` and GET."""
+    return VectorizedRestApiEnv.concat_rest_api_method(
+        env._discovered_rest_api.action_for(rest_api),
+        VectorizedRestApiEnv.encode_rest_api_method(HttpMethod.GET.value),
+    )
+
+
+def test_vector_reset_and_step_preserve_batch_axes(vector_env: VectorizedRestApiEnv):
+    """A normal two-env step returns one observation/reward/flag row per env."""
+    obs, info = vector_env.reset()
+    actions = torch.stack([_action(vector_env, ROOT_URI), _action(vector_env, SYSTEM_URI)])
+
+    next_obs, rewards, terminated, truncated, infos = vector_env.step(actions)
+
+    assert info == {}
+    assert obs.shape == (2, *StubEncoder.emb_shape)
+    assert next_obs.shape == (2, *StubEncoder.emb_shape)
+    assert rewards.shape == (2,)
+    assert terminated.shape == (2,)
+    assert truncated.shape == (2,)
+    assert len(infos) == 2
+
+
+@pytest.mark.xfail(
+    reason="VectorizedRestApiEnv currently stacks only active responses after a prior done row.",
+    strict=True,
+)
+def test_partial_done_step_preserves_num_envs_axis(vector_env: VectorizedRestApiEnv):
+    """A skipped done sub-env must not shrink the observation batch axis."""
+    obs, _ = vector_env.reset()
+    vector_env.dones[0] = True
+    vector_env.last_observation = obs
+    actions = torch.stack([_action(vector_env, ROOT_URI), _action(vector_env, SYSTEM_URI)])
+
+    next_obs, rewards, terminated, truncated, infos = vector_env.step(actions)
+
+    assert next_obs.shape == (2, *StubEncoder.emb_shape)
+    assert rewards.shape == (2,)
+    assert terminated.shape == (2,)
+    assert truncated.shape == (2,)
+    assert len(infos) == 2
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_dataloader_blocks.py
+++ b/tests/modules/test_dataloader_blocks.py
@@ -1,0 +1,75 @@
+"""Offline boundary tests for trainer DataLoader blocks.
+
+These tests pin the small CPU-safe pieces that feed every later GPU run:
+collation of tokenized rows and sampler selection. They do not instantiate the
+heavy trainers or load models.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import pytest
+import torch
+
+from igc.modules.igc_train_auto_state_encoder import AutoencoderTrainer
+from igc.modules.llm_train_state_encoder import LlmEmbeddingsTrainer
+
+
+def _sample(i: int, *, extra: bool = False) -> dict[str, torch.Tensor]:
+    """Build one tiny tokenized row."""
+    row = {
+        "input_ids": torch.tensor([i, i + 1, i + 2]),
+        "attention_mask": torch.tensor([1, 1, 0]),
+    }
+    if extra:
+        row["labels"] = torch.tensor([99, 99, 99])
+    return row
+
+
+@pytest.mark.parametrize(
+    "collate",
+    [
+        LlmEmbeddingsTrainer.custom_collate_fn,
+        AutoencoderTrainer.custom_collate_fn,
+    ],
+)
+def test_collate_stacks_only_model_inputs(collate):
+    """Collate stacks ids/masks and ignores unrelated dataset columns."""
+    batch = collate([_sample(0, extra=True), _sample(10, extra=True)])
+
+    assert set(batch) == {"input_ids", "attention_mask"}
+    assert batch["input_ids"].shape == (2, 3)
+    assert batch["attention_mask"].shape == (2, 3)
+    assert batch["input_ids"].tolist() == [[0, 1, 2], [10, 11, 12]]
+
+
+@pytest.mark.parametrize(
+    "collate",
+    [
+        LlmEmbeddingsTrainer.custom_collate_fn,
+        AutoencoderTrainer.custom_collate_fn,
+    ],
+)
+def test_collate_rejects_missing_attention_mask(collate):
+    """A malformed row fails before training silently drops the mask."""
+    row = _sample(0)
+    row.pop("attention_mask")
+
+    with pytest.raises(KeyError, match="attention_mask"):
+        collate([row])
+
+
+@pytest.mark.parametrize(
+    "collate",
+    [
+        LlmEmbeddingsTrainer.custom_collate_fn,
+        AutoencoderTrainer.custom_collate_fn,
+    ],
+)
+def test_collate_rejects_empty_micro_batch(collate):
+    """An empty micro-batch is invalid and fails loudly."""
+    with pytest.raises(RuntimeError, match="stack expects a non-empty"):
+        collate([])
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_dist_batch_invariant.py
+++ b/tests/modules/test_dist_batch_invariant.py
@@ -58,4 +58,21 @@ def test_igc_train_dataloaders_use_drop_last():
             f"epoch-boundary save-collective deadlock")
 
 
+def test_autoencoder_train_dataloaders_use_drop_last():
+    """Autoencoder train/sample loaders also keep equal batch counts per rank."""
+    from igc.modules import igc_train_auto_state_encoder as auto_mod
+
+    src = inspect.getsource(auto_mod)
+    blocks = re.findall(
+        r"train_dataloader = DataLoader\((.*?)collate_fn=AutoencoderTrainer\.custom_collate_fn\)",
+        src,
+        re.S,
+    )
+    assert len(blocks) == 2, "expected sample_all() and train() train_dataloader blocks"
+    for i, block in enumerate(blocks):
+        assert "drop_last=True" in block, (
+            f"autoencoder train_dataloader #{i} is missing drop_last=True — this can "
+            f"create uneven epoch-boundary batch counts under distributed execution")
+
+
 # Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_pointer_policy.py
+++ b/tests/modules/test_pointer_policy.py
@@ -9,6 +9,7 @@ Author:
 Mus mbayramo@stanford.edu
 """
 import torch
+import pytest
 
 from igc.modules.policy.pointer_policy import (
     ActionProjector,
@@ -37,6 +38,18 @@ def test_mask_excludes_padding_even_if_highest():
     scores = score_candidates(query, keys, mask)
     assert scores[0, 2] == float("-inf")
     assert int(greedy_select(scores)[0]) == 0
+
+
+@pytest.mark.xfail(
+    reason="greedy_select currently argmaxes an all-masked row to candidate 0.",
+    strict=True,
+)
+def test_greedy_select_rejects_all_masked_rows():
+    """A row with no legal candidates must not emit a concrete candidate index."""
+    scores = torch.tensor([[float("-inf"), float("-inf")]])
+
+    with pytest.raises(ValueError, match="no legal candidates"):
+        greedy_select(scores)
 
 
 def test_output_width_tracks_num_candidates_not_global():

--- a/tests/modules/test_q_targets.py
+++ b/tests/modules/test_q_targets.py
@@ -54,6 +54,21 @@ def test_all_masked_next_state_is_terminal_and_target_stays_finite():
     assert torch.isclose(target[1], torch.tensor(3.6))
 
 
+@pytest.mark.xfail(
+    reason="q_learning_target does not yet handle next_q with zero legal-action width.",
+    strict=True,
+)
+def test_zero_width_next_q_is_terminal_and_target_stays_finite():
+    """A true zero-candidate next state should behave like a terminal dead end."""
+    reward = torch.tensor([0.25, -0.5])
+    done = torch.tensor([0.0, 0.0])
+    next_q = torch.empty(2, 0)
+
+    target = q_learning_target(reward, done, next_q, gamma=0.99)
+
+    torch.testing.assert_close(target, reward)
+
+
 @pytest.mark.parametrize(
     ("gamma", "expected"),
     [

--- a/tests/scripts/test_gpu_dataset_isolation.py
+++ b/tests/scripts/test_gpu_dataset_isolation.py
@@ -1,0 +1,74 @@
+"""Offline boundary tests for ``scripts/gpu_dataset_isolation.py``.
+
+The multi-rank NCCL deadlock case is intentionally opt-in on GB300. These tests
+exercise the same harness in single-rank CPU mode so edge cases around zero
+batches, exact divisibility, and indivisible tails stay covered in the default
+gate.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HARNESS = REPO_ROOT / "scripts" / "gpu_dataset_isolation.py"
+
+
+def _load_harness():
+    """Import the script as a module without requiring it to be on PYTHONPATH."""
+    spec = importlib.util.spec_from_file_location("gpu_dataset_isolation", HARNESS)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    "ds_size,batch,drop_last,expected_batches",
+    [
+        (3, 4, 1, "batches=0"),
+        (8, 4, 1, "batches=2"),
+        (9, 4, 1, "batches=2"),
+        (9, 4, 0, "batches=3"),
+    ],
+)
+def test_single_rank_boundary_cases_exit_cleanly(
+    monkeypatch,
+    capsys,
+    ds_size,
+    batch,
+    drop_last,
+    expected_batches,
+):
+    """Single-rank harness handles zero/exact/tail batches without a GPU."""
+    harness = _load_harness()
+    monkeypatch.delenv("RANK", raising=False)
+    monkeypatch.delenv("WORLD_SIZE", raising=False)
+    monkeypatch.delenv("LOCAL_RANK", raising=False)
+    monkeypatch.setenv("DS_SIZE", str(ds_size))
+    monkeypatch.setenv("BATCH", str(batch))
+    monkeypatch.setenv("DROP_LAST", str(drop_last))
+    monkeypatch.setenv("EPOCHS", "1")
+
+    with pytest.raises(SystemExit) as exc:
+        harness.main()
+
+    assert exc.value.code == 0
+    out = capsys.readouterr().out
+    assert expected_batches in out
+    assert "PASS" in out
+
+
+def test_env_int_defaults_when_unset(monkeypatch):
+    """Missing integer env knobs use the caller-provided default."""
+    harness = _load_harness()
+    monkeypatch.delenv("IGC_MISSING_INT", raising=False)
+
+    assert harness._env_int("IGC_MISSING_INT", 17) == 17
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/scripts/test_gpu_dataset_isolation_sh.py
+++ b/tests/scripts/test_gpu_dataset_isolation_sh.py
@@ -1,0 +1,91 @@
+"""Offline contract tests for the GPU dataset-isolation sweep wrapper.
+
+The real sweep runs on GB300 with ``torchrun`` and per-case timeouts. These
+tests keep that behavior mocked: fake ``nvidia-smi`` controls the detected
+world sizes and fake ``timeout`` returns PASS/DEADLOCK outcomes from the
+environment variables the wrapper sets for each case.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "gpu_dataset_isolation.sh"
+
+
+def _write_executable(path: Path, text: str) -> None:
+    """Write a small fake command into ``path`` and make it executable."""
+    path.write_text(text)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _run_sweep(tmp_path: Path, timeout_body: str) -> subprocess.CompletedProcess[str]:
+    """Run the wrapper with fake GPU/timeout commands and a stable environment."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "nvidia-smi",
+        "#!/usr/bin/env bash\n"
+        "if [ \"${1:-}\" = \"-L\" ]; then\n"
+        "  printf 'GPU 0\\nGPU 1\\n'\n"
+        "fi\n",
+    )
+    _write_executable(
+        bin_dir / "timeout",
+        "#!/usr/bin/env bash\n"
+        "shift\n"
+        f"{timeout_body}\n",
+    )
+
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "WORLDS": "2",
+        "CASE_TIMEOUT": "1",
+    }
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
+def test_gpu_dataset_isolation_wrapper_exits_nonzero_on_mismatch(tmp_path):
+    """Any expected-vs-got mismatch must make the sweep fail."""
+    result = _run_sweep(
+        tmp_path,
+        # Force a PASS case to time out. The wrapper should report MISMATCH and
+        # exit nonzero so CI/automation cannot mistake it for a usable sweep.
+        'if [ "$DS_SIZE" = "128" ]; then exit 124; fi\n'
+        "exit 0",
+    )
+
+    assert result.returncode != 0
+    assert "MISMATCH" in result.stdout
+
+
+def test_gpu_dataset_isolation_wrapper_passes_when_expectations_match(tmp_path):
+    """The deterministic matrix exits cleanly when PASS and DEADLOCK cases match."""
+    result = _run_sweep(
+        tmp_path,
+        'if [ "$DROP_LAST" = "0" ]; then exit 124; fi\n'
+        "exit 0",
+    )
+
+    assert result.returncode == 0
+    rows = [line for line in result.stdout.splitlines() if not line.startswith("summary:")]
+    assert not any(line.rstrip().endswith("MISMATCH") for line in rows)
+    assert "summary:" in result.stdout
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
## Summary
- add CPU-safe boundary tests for GPU dataset-isolation harness behavior and wrapper mismatch exits
- add dataloader/collate/drop_last concurrency guards for state-encoder and autoencoder paths
- add vector-env, q-target, and pointer-policy boundary probes with strict xfails for known engine gaps

## Verification
- pytest -q: 629 passed, 1 skipped, 21 deselected, 3 xfailed
- ruff check changed Python files: All checks passed
- shellcheck scripts/gpu_dataset_isolation.sh: clean
- git diff --check -- tests scripts: clean

## Notes
- GPU/NCCL execution remains opt-in on GB300; this PR only adds offline contracts and script-exit correctness.
- Strict xfails track known boundaries: vector partial-done batch shrink, zero-width next-Q target, and all-masked greedy selection.