### PR TITLE
gb300_launch.sh: export env vars for docker -e forwarding

### DIFF
--- a/scripts/gb300_launch.sh
+++ b/scripts/gb300_launch.sh
@@ -74,6 +74,11 @@ docker image inspect "$IGC_IMAGE" >/dev/null 2>&1 || blocker "image $IGC_IMAGE n
 COMMON="--train llm --llm latent --model_type ${IGC_MODEL} --json_data_dir /root/.json_responses --tf32 --seed 42 --log_level info --llm_log_level info"
 [ "${IGC_USE_PEFT:-0}" = "1" ] && COMMON="${COMMON} --use_peft --lora_r ${LORA_R:-16} --lora_alpha ${LORA_ALPHA:-32}"
 
+# Export so the bare `-e VAR` on `docker run` actually forwards them; otherwise a
+# non-exported shell var arrives empty and the container's `set -u` aborts (rc=127,
+# "COMMON: unbound variable").
+export IGC_GPUS IGC_STAGE IGC_MODEL IGC_RUN EPOCHS COMMON
+
 docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
 log "docker run ${IGC_IMAGE} | ${IGC_GPUS} GPU | code=${IGC_CODE_DIR} data=${IGC_DATA_DIR} models=${IGC_MODELS_DIR}"
 # NVIDIA-recommended flags (NGC startup banner): --ipc=host + memlock/stack ulimits.


### PR DESCRIPTION
First real multi-GPU launch hit rc=127 'COMMON: unbound variable' — bare `-e COMMON`/`-e EPOCHS`/`-e IGC_STAGE` only forward vars in the environment, but they're plain (non-exported) shell vars → arrived empty → container `set -u` aborted before Phase A. Export them. shellcheck clean.