### PR TITLE
dataset_sanity: fix 'import igc' (repo root on sys.path)

### DIFF
--- a/scripts/dataset_sanity.py
+++ b/scripts/dataset_sanity.py
@@ -21,7 +21,12 @@ Mus mbayramo@stanford.edu
 """
 
 import os
+import sys
 import time
+
+# torchrun runs this from scripts/, so scripts/ (not the repo root) is on sys.path;
+# add the repo root so `import igc` resolves inside the container.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import torch
 import torch.distributed as dist


### PR DESCRIPTION
torchrun puts scripts/ on sys.path, not the repo root, so dataset_sanity.py failed with ModuleNotFoundError: igc. Insert the repo root before the import. py_compile + ruff clean.