### PR TITLE
Harden RL env sanity harness

### DIFF
--- a/scripts/rl_env_sanity.py
+++ b/scripts/rl_env_sanity.py
@@ -27,6 +27,7 @@ import tempfile
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import torch
 
@@ -156,6 +157,49 @@ def rollout_actions(env: VectorizedRestApiEnv, step: int) -> torch.Tensor:
     return torch.stack(actions, dim=0)
 
 
+def validate_transition_tensors(
+    *,
+    next_obs: torch.Tensor,
+    actions: torch.Tensor,
+    rewards: torch.Tensor,
+    terminated: torch.Tensor,
+    time_limited: torch.Tensor,
+    infos: list[dict[str, object]],
+    num_envs: int,
+    rank: int,
+) -> None:
+    """Validate rollout tensor shapes, dtypes, and finite numeric values."""
+    if next_obs.shape[0] != num_envs:
+        raise RuntimeError(
+            f"rank {rank}: observation batch shrank from {num_envs} to {next_obs.shape[0]}"
+        )
+    if actions.shape[0] != num_envs:
+        raise RuntimeError(f"rank {rank}: action batch mismatch {tuple(actions.shape)}")
+    if rewards.shape != (num_envs,):
+        raise RuntimeError(f"rank {rank}: reward shape mismatch {tuple(rewards.shape)}")
+    if terminated.shape != (num_envs,) or time_limited.shape != (num_envs,):
+        raise RuntimeError(
+            f"rank {rank}: flag shape mismatch terminated={tuple(terminated.shape)} "
+            f"truncated={tuple(time_limited.shape)}"
+        )
+    if len(infos) != num_envs:
+        raise RuntimeError(f"rank {rank}: info rows mismatch {len(infos)}")
+    if not torch.is_floating_point(next_obs):
+        raise RuntimeError(f"rank {rank}: observation dtype must be floating, got {next_obs.dtype}")
+    if not torch.is_floating_point(actions):
+        raise RuntimeError(f"rank {rank}: action dtype must be floating, got {actions.dtype}")
+    if not torch.is_floating_point(rewards):
+        raise RuntimeError(f"rank {rank}: reward dtype must be floating, got {rewards.dtype}")
+    if terminated.dtype != torch.bool or time_limited.dtype != torch.bool:
+        raise RuntimeError(
+            f"rank {rank}: terminal flags must be bool, got "
+            f"{terminated.dtype}/{time_limited.dtype}"
+        )
+    for name, tensor in (("observation", next_obs), ("action", actions), ("reward", rewards)):
+        if not torch.isfinite(tensor).all():
+            raise RuntimeError(f"rank {rank}: non-finite {name} tensor")
+
+
 def build_env(base_dir: Path, rank: int, num_envs: int, max_episode: int) -> VectorizedRestApiEnv:
     """Build the tiny vector REST environment for one rank."""
     mapping = write_tiny_fixtures(base_dir, rank)
@@ -178,6 +222,7 @@ def run_rollout(
     rank: int,
     world: int,
     base_dir: Path,
+    profiler: Any = None,
 ) -> RolloutStats:
     """Run one local vector-env rollout and return shape/count stats."""
     env = build_env(base_dir, rank, num_envs, max_episode=steps + 10)
@@ -195,14 +240,16 @@ def run_rollout(
             env.simulate_goal_reached(rank % num_envs)
 
         next_obs, rewards, terminated, time_limited, infos = env.step(actions)
-        if next_obs.shape[0] != num_envs:
-            raise RuntimeError(
-                f"rank {rank}: observation batch shrank from {num_envs} to {next_obs.shape[0]}"
-            )
-        if rewards.shape != (num_envs,):
-            raise RuntimeError(f"rank {rank}: reward shape mismatch {tuple(rewards.shape)}")
-        if len(infos) != num_envs:
-            raise RuntimeError(f"rank {rank}: info rows mismatch {len(infos)}")
+        validate_transition_tensors(
+            next_obs=next_obs,
+            actions=actions,
+            rewards=rewards,
+            terminated=terminated,
+            time_limited=time_limited,
+            infos=infos,
+            num_envs=num_envs,
+            rank=rank,
+        )
 
         replay.add(obs, actions, rewards, next_obs, terminated)
 
@@ -216,6 +263,8 @@ def run_rollout(
         if device.type == "cuda":
             torch.cuda.synchronize(device)
         del uploaded
+        if profiler is not None:
+            profiler.step()
 
         transitions += num_envs
         terminals += int(terminated.sum().item())
@@ -259,7 +308,11 @@ def stats_tensor(stats: RolloutStats, device: torch.device) -> torch.Tensor:
 def shape_tensor(stats: RolloutStats, device: torch.device) -> torch.Tensor:
     """Pack shape stats that must match across ranks."""
     obs_tail = stats.obs_shape[1:] if len(stats.obs_shape) > 1 else stats.obs_shape
-    state_tail = stats.sample_state_shape[-2:] if len(stats.sample_state_shape) >= 2 else stats.sample_state_shape
+    state_tail = (
+        stats.sample_state_shape[-2:]
+        if len(stats.sample_state_shape) >= 2
+        else stats.sample_state_shape
+    )
     return torch.tensor(
         [
             stats.num_envs,
@@ -302,6 +355,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--num-envs", type=int, default=4, help="vector envs per rank")
     parser.add_argument("--steps", type=int, default=4, help="rollout steps per rank")
     parser.add_argument("--allow-cpu", action="store_true", help="permit CPU-only local development")
+    parser.add_argument(
+        "--profile-dir",
+        type=Path,
+        default=None,
+        help="optional directory for one torch profiler Chrome trace per rank",
+    )
     args = parser.parse_args(argv)
 
     rank, world, local_rank, device, distributed = resolve_runtime(args.allow_cpu)
@@ -310,14 +369,39 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         with tempfile.TemporaryDirectory(prefix=f"igc-rl-env-r{rank}-") as tmp:
-            stats = run_rollout(
-                num_envs=args.num_envs,
-                steps=args.steps,
-                device=device,
-                rank=rank,
-                world=world,
-                base_dir=Path(tmp),
-            )
+            if args.profile_dir is not None:
+                from torch.profiler import ProfilerActivity, profile
+
+                args.profile_dir.mkdir(parents=True, exist_ok=True)
+                activities = [ProfilerActivity.CPU]
+                if device.type == "cuda":
+                    activities.append(ProfilerActivity.CUDA)
+                with profile(
+                    activities=activities,
+                    record_shapes=True,
+                    profile_memory=True,
+                ) as prof:
+                    stats = run_rollout(
+                        num_envs=args.num_envs,
+                        steps=args.steps,
+                        device=device,
+                        rank=rank,
+                        world=world,
+                        base_dir=Path(tmp),
+                        profiler=prof,
+                    )
+                trace_path = args.profile_dir / f"rl_env_sanity_rank{rank}.json"
+                prof.export_chrome_trace(str(trace_path))
+                print(f"[rl-env] profile={trace_path}", flush=True)
+            else:
+                stats = run_rollout(
+                    num_envs=args.num_envs,
+                    steps=args.steps,
+                    device=device,
+                    rank=rank,
+                    world=world,
+                    base_dir=Path(tmp),
+                )
 
         print(
             f"[rl-env] rank={rank}/{world} local={local_rank} device={device} "

--- a/tests/envs/test_rest_gym_batch_env_boundary.py
+++ b/tests/envs/test_rest_gym_batch_env_boundary.py
@@ -120,6 +120,36 @@ def test_vector_reset_and_step_preserve_batch_axes(vector_env: VectorizedRestApi
     assert len(infos) == 2
 
 
+def test_vector_step_limit_sets_truncated_not_terminal(vector_env: VectorizedRestApiEnv):
+    """Time-limit cuts keep bootstrap semantics: truncated true, terminal false."""
+    vector_env.max_steps = 1
+    vector_env.reset()
+    actions = torch.stack([_action(vector_env, ROOT_URI), _action(vector_env, SYSTEM_URI)])
+
+    next_obs, rewards, terminated, truncated, infos = vector_env.step(actions)
+
+    assert next_obs.shape == (2, *StubEncoder.emb_shape)
+    assert rewards.tolist() == [-1.0, -1.0]
+    assert terminated.tolist() == [False, False]
+    assert truncated.tolist() == [True, True]
+    assert len(infos) == 2
+
+
+def test_vector_http_500_sets_terminal_not_truncated(vector_env: VectorizedRestApiEnv):
+    """Dead-end server errors are true terminals and should stop bootstrapping."""
+    vector_env.reset()
+    vector_env.mock_server().set_simulate_http_500_error(True)
+    actions = torch.stack([_action(vector_env, ROOT_URI), _action(vector_env, SYSTEM_URI)])
+
+    next_obs, rewards, terminated, truncated, infos = vector_env.step(actions)
+
+    assert next_obs.shape == (2, *StubEncoder.emb_shape)
+    assert rewards.tolist() == [-0.5, -0.5]
+    assert terminated.tolist() == [True, True]
+    assert truncated.tolist() == [False, False]
+    assert len(infos) == 2
+
+
 @pytest.mark.xfail(
     reason="VectorizedRestApiEnv currently stacks only active responses after a prior done row.",
     strict=True,

--- a/tests/scripts/test_rl_env_sanity.py
+++ b/tests/scripts/test_rl_env_sanity.py
@@ -78,6 +78,75 @@ def test_run_rollout_collects_replay_and_shape_stats(tmp_path):
     assert stats.sample_done_shape == (3, 2)
 
 
+def test_validate_transition_tensors_rejects_hidden_dtype_and_nan():
+    """The live harness fails fast on hidden dtype or non-finite rollout bugs."""
+    sanity = _load_sanity()
+    good = {
+        "next_obs": torch.zeros(2, 2, 3, dtype=torch.float32),
+        "actions": torch.zeros(2, 9, dtype=torch.float32),
+        "rewards": torch.zeros(2, dtype=torch.float32),
+        "terminated": torch.zeros(2, dtype=torch.bool),
+        "time_limited": torch.zeros(2, dtype=torch.bool),
+        "infos": [{}, {}],
+        "num_envs": 2,
+        "rank": 0,
+    }
+
+    sanity.validate_transition_tensors(**good)
+
+    bad_obs = dict(good)
+    bad_obs["next_obs"] = torch.tensor([[[float("nan")]]], dtype=torch.float32).expand(2, 2, 3)
+    with pytest.raises(RuntimeError, match="non-finite observation"):
+        sanity.validate_transition_tensors(**bad_obs)
+
+    bad_action = dict(good)
+    bad_action["actions"] = torch.zeros(2, 9, dtype=torch.int64)
+    with pytest.raises(RuntimeError, match="action dtype must be floating"):
+        sanity.validate_transition_tensors(**bad_action)
+
+    bad_reward = dict(good)
+    bad_reward["rewards"] = torch.tensor([0.0, float("inf")], dtype=torch.float32)
+    with pytest.raises(RuntimeError, match="non-finite reward"):
+        sanity.validate_transition_tensors(**bad_reward)
+
+    bad_flag = dict(good)
+    bad_flag["terminated"] = torch.zeros(2, dtype=torch.float32)
+    with pytest.raises(RuntimeError, match="terminal flags must be bool"):
+        sanity.validate_transition_tensors(**bad_flag)
+
+
+def test_validate_transition_tensors_rejects_terminal_axis_drift():
+    """Terminal/truncation metadata must keep one row per vector sub-env."""
+    sanity = _load_sanity()
+    good = {
+        "next_obs": torch.zeros(2, 2, 3, dtype=torch.float32),
+        "actions": torch.zeros(2, 9, dtype=torch.float32),
+        "rewards": torch.zeros(2, dtype=torch.float32),
+        "terminated": torch.tensor([True, False], dtype=torch.bool),
+        "time_limited": torch.tensor([False, True], dtype=torch.bool),
+        "infos": [{"goal_reached": True}, {"goal_reached": False}],
+        "num_envs": 2,
+        "rank": 0,
+    }
+
+    sanity.validate_transition_tensors(**good)
+
+    shrunk_obs = dict(good)
+    shrunk_obs["next_obs"] = torch.zeros(1, 2, 3, dtype=torch.float32)
+    with pytest.raises(RuntimeError, match="observation batch shrank"):
+        sanity.validate_transition_tensors(**shrunk_obs)
+
+    bad_flags = dict(good)
+    bad_flags["time_limited"] = torch.zeros(1, dtype=torch.bool)
+    with pytest.raises(RuntimeError, match="flag shape mismatch"):
+        sanity.validate_transition_tensors(**bad_flags)
+
+    bad_infos = dict(good)
+    bad_infos["infos"] = [{"goal_reached": True}]
+    with pytest.raises(RuntimeError, match="info rows mismatch"):
+        sanity.validate_transition_tensors(**bad_infos)
+
+
 def test_stats_and_shape_tensors_are_reduction_ready(tmp_path):
     """Stats pack into tensors suitable for distributed all_reduce."""
     sanity = _load_sanity()
@@ -118,6 +187,28 @@ def test_main_allow_cpu_runs_single_process_smoke(monkeypatch, capsys):
 
     assert sanity.main(["--allow-cpu", "--num-envs", "1", "--steps", "1"]) == 0
     assert "PASS world=1" in capsys.readouterr().out
+
+
+def test_main_can_emit_cpu_profiler_trace(monkeypatch, tmp_path, capsys):
+    """The optional profiler path writes a per-rank Chrome trace."""
+    sanity = _load_sanity()
+    monkeypatch.setattr(sanity.torch.cuda, "is_available", lambda: False)
+    monkeypatch.delenv("RANK", raising=False)
+    monkeypatch.delenv("WORLD_SIZE", raising=False)
+    monkeypatch.delenv("LOCAL_RANK", raising=False)
+
+    assert sanity.main([
+        "--allow-cpu",
+        "--num-envs",
+        "1",
+        "--steps",
+        "1",
+        "--profile-dir",
+        str(tmp_path),
+    ]) == 0
+
+    assert (tmp_path / "rl_env_sanity_rank0.json").exists()
+    assert "profile=" in capsys.readouterr().out
 
 
 # Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
## Summary

- harden the opt-in RL environment sanity harness with transition tensor validation
- fail fast on hidden batch-axis, dtype, bool-flag, and non-finite rollout bugs
- add an optional `--profile-dir` path that writes one torch profiler Chrome trace per rank
- cover the new guards and CPU profiler path in offline pytest

## Verification

- `pytest -q tests/scripts/test_rl_env_sanity.py tests/envs/test_rest_gym_batch_env_boundary.py tests/modules/test_experience_buffer_done_shapes.py`
  - 12 passed, 1 xfailed
- `ruff check scripts/rl_env_sanity.py tests/scripts/test_rl_env_sanity.py`
  - All checks passed
- `python -m py_compile scripts/rl_env_sanity.py tests/scripts/test_rl_env_sanity.py`
- `python scripts/rl_env_sanity.py --allow-cpu --num-envs 1 --steps 1 --profile-dir /tmp/igc-rl-env-profile-smoke`
  - PASS world=1 and wrote `rl_env_sanity_rank0.json`
- `pytest -q`
  - 637 passed, 1 skipped, 21 deselected, 3 xfailed

## Opt-in GPU Run

On a GPU worker, run:

```bash
torchrun --nproc_per_node=4 scripts/rl_env_sanity.py
```

For a profiler trace:

```bash
torchrun --nproc_per_node=4 scripts/rl_env_sanity.py --profile-dir /tmp/igc-rl-env-profile
```

This PR does not claim training convergence or policy quality; it only validates the RL environment, replay insertion, tensor upload, distributed shape sync, and profiler plumbing.
