### PR TITLE
sanity: NCCL_MNNVL_ENABLE=0 default for GB300 multi-node

### DIFF
--- a/scripts/gb300_sanity_check.sh
+++ b/scripts/gb300_sanity_check.sh
@@ -52,7 +52,8 @@ node_free() {  # ip -> 0 if no GPU compute process is running
 run_on() {  # node_ip nnodes node_rank master_ip nproc mode
     $SSH "nvidia@$1" \
         "docker run --rm --network host $NV_FLAGS $MOUNTS \
-             -e SANITY_MODE=$6 -e SANITY_STEPS=1 -e SANITY_HUGE_GB=${SANITY_HUGE_GB:-0} -e IGC_MODEL=$IGC_MODEL -e IGC_DATASET_DIR=$IGC_DATASET_DIR \
+             -e SANITY_MODE=$6 -e SANITY_STEPS=1 -e SANITY_HUGE_GB=${SANITY_HUGE_GB:-0} \
+             -e NCCL_MNNVL_ENABLE=${NCCL_MNNVL_ENABLE:-0} -e IGC_MODEL=$IGC_MODEL -e IGC_DATASET_DIR=$IGC_DATASET_DIR \
              -w /workspace/igc $IMAGE \
              torchrun --nnodes=$2 --node_rank=$3 --nproc_per_node=$5 \
                       --master_addr=$4 --master_port=$PORT $SCRIPT"


### PR DESCRIPTION
8-GPU cross-node NCCL failed — GB300 MNNVL (multi-node NVLink) detected but IMEX channels unconfigured. Forward NCCL_MNNVL_ENABLE (default 0) so cross-node falls back to RoCE. Configuring IMEX for the fast NVLink path is a separate operator task. shellcheck clean.