### PR TITLE
Add multi-GPU per-section profiler for the training step

### DIFF
--- a/scripts/gpu_train_profile.py
+++ b/scripts/gpu_train_profile.py
@@ -1,0 +1,255 @@
+"""
+Multi-GPU per-section profiler for the state-encoder training step (S0/M1 backbone).
+
+igc has offline CPU hot-path benchmarks (``scripts/bench_hot_paths.py`` — the RL decision path)
+and a distributed dataset-isolation harness (``scripts/gpu_dataset_isolation.py`` — the epoch-2
+deadlock guard), but nothing that answers "where does the GPU time actually go in one training
+step, on 4 or 8 GPUs?" This script fills that gap: it reconstructs the exact training step of
+``LlmEmbeddingsTrainer._train`` (data move -> forward -> backward incl. gradient sync -> optimizer)
+with the same ``Accelerator.prepare`` / ``accelerator.backward`` path, and times each section with
+CUDA events over N steps, plus a ``torch.profiler`` op-level trace.
+
+It is offline-safe: the backbone is built from an ``AutoConfig`` (random weights) so no HF download
+is needed — profiling times the compute+comms, which do not depend on weight values. The batch is
+synthetic (real shape ``batch x seq_len``); this isolates the compute/comms step from the data
+pipeline, whose throughput is measured separately by the dataset-isolation harness / a real run.
+
+Used by: run on a GB300 node before a real training run to size batch/precision/grad-accum and to
+see the forward/backward/optimizer/comms split. Not imported by any runtime module; a standalone
+operator tool. See ``scripts/gpu_train_profile.sh`` for the 4- and 8-GPU sweep recipe.
+
+Run (one process, smoke): ``python scripts/gpu_train_profile.py --steps 5 --warmup 2``
+Run (4 GPU, faithful):    ``accelerate launch --multi_gpu --num_processes 4 \
+                              scripts/gpu_train_profile.py --model_type gpt2 --batch_size 8 \
+                              --seq_len 1024 --precision bf16 --steps 20 --warmup 5``
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import time
+from contextlib import nullcontext
+from typing import Dict, List, Optional
+
+import torch
+
+
+# The training step decomposes into exactly these sections (mirrors _train's inner loop). "backward"
+# includes the gradient all-reduce (DDP) / reduce-scatter (FSDP) since that comm overlaps backward.
+SECTIONS = ("data", "forward", "backward", "optimizer")
+
+
+def _dtype(precision: str) -> torch.dtype:
+    """Map a --precision string to a torch dtype (fp32 default)."""
+    return {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}[precision]
+
+
+def build_backbone(model_type: str, seq_len: int):
+    """Build a CausalLM backbone from config only (random weights, no download).
+
+    Timing the forward/backward is independent of the trained weight values, so a config-built
+    model gives a faithful compute profile while staying fully offline.
+
+    :param model_type: HF model type, e.g. ``gpt2`` (or a repo id whose config is cached).
+    :param seq_len: max position embeddings the profiled sequence needs to fit.
+    :return: an ``AutoModelForCausalLM`` on CPU (the caller / accelerate moves it to device).
+    """
+    from transformers import AutoConfig, AutoModelForCausalLM
+
+    # Build from a known type so no network is touched; widen positions to cover seq_len for the
+    # legacy learned-positional backbones (a GPT-2 with n_positions < seq_len would index-error —
+    # exactly the 1024 limit D-003 retires; here we just size the config to the requested seq_len).
+    try:
+        config = AutoConfig.from_pretrained(model_type)
+    except Exception:
+        config = AutoConfig.for_model(model_type)
+    for attr in ("n_positions", "max_position_embeddings"):
+        if hasattr(config, attr) and getattr(config, attr) < seq_len:
+            setattr(config, attr, seq_len)
+    return AutoModelForCausalLM.from_config(config)
+
+
+def _synthetic_batch(batch_size: int, seq_len: int, vocab_size: int, device) -> Dict[str, torch.Tensor]:
+    """A real-shape synthetic batch (input_ids/attention_mask/labels), all on device.
+
+    Deterministic (fixed generator) so the profile is reproducible across ranks and runs.
+    """
+    gen = torch.Generator().manual_seed(0)
+    input_ids = torch.randint(0, vocab_size, (batch_size, seq_len), generator=gen)
+    batch = {
+        "input_ids": input_ids.to(device),
+        "attention_mask": torch.ones(batch_size, seq_len, dtype=torch.long, device=device),
+        "labels": input_ids.to(device),
+    }
+    return batch
+
+
+class _Timers:
+    """Per-section CUDA-event timers; falls back to wall clock on CPU."""
+
+    def __init__(self, use_cuda: bool):
+        self.use_cuda = use_cuda
+        self.samples: Dict[str, List[float]] = {s: [] for s in SECTIONS}
+        self.step_samples: List[float] = []
+
+    def time(self, section: str):
+        return _Section(self, section)
+
+
+class _Section:
+    def __init__(self, timers: _Timers, name: str):
+        self.t, self.name = timers, name
+
+    def __enter__(self):
+        if self.t.use_cuda:
+            self.start = torch.cuda.Event(enable_timing=True)
+            self.end = torch.cuda.Event(enable_timing=True)
+            self.start.record()
+        else:
+            self.start = time.perf_counter()
+        return self
+
+    def __exit__(self, *exc):
+        if self.t.use_cuda:
+            self.end.record()
+            torch.cuda.synchronize()
+            self.t.samples[self.name].append(self.start.elapsed_time(self.end))  # ms
+        else:
+            self.t.samples[self.name].append((time.perf_counter() - self.start) * 1e3)
+        return False
+
+
+def run(args) -> Optional[dict]:
+    """Profile ``args.steps`` training steps and return the rank-0 summary dict (None off rank 0)."""
+    from accelerate import Accelerator
+    from accelerate.utils import set_seed
+
+    set_seed(0)
+    accelerator = Accelerator(mixed_precision=None if args.precision == "fp32" else args.precision)
+    device = accelerator.device
+    use_cuda = device.type == "cuda"
+    is_main = accelerator.is_main_process
+    world = accelerator.num_processes
+
+    model = build_backbone(args.model_type, args.seq_len)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4)
+    model, optimizer = accelerator.prepare(model, optimizer)
+    vocab_size = getattr(getattr(model, "config", None), "vocab_size", 50257)
+    batch = _synthetic_batch(args.batch_size, args.seq_len, vocab_size, device)
+
+    if is_main:
+        print(f"[profile] world={world} device={device} precision={args.precision} "
+              f"model={args.model_type} batch={args.batch_size} seq_len={args.seq_len} "
+              f"warmup={args.warmup} steps={args.steps}", flush=True)
+
+    def one_step(timers: Optional[_Timers]):
+        """A single train step mirroring _train (accumulate -> fwd -> backward -> step)."""
+        ctx = timers.time if timers else (lambda _n: nullcontext())
+        model.train()
+        with accelerator.accumulate(model):
+            with ctx("data"):
+                moved = {k: v for k, v in batch.items()}  # already on device; marks the section
+            with ctx("forward"):
+                loss = model(**moved).loss
+            with ctx("backward"):
+                accelerator.backward(loss)
+            with ctx("optimizer"):
+                optimizer.step()
+                optimizer.zero_grad(set_to_none=True)
+        return loss
+
+    # Warmup — allocator, cudnn autotune, and (FSDP) the first all-gather are not representative.
+    for _ in range(args.warmup):
+        one_step(None)
+    if use_cuda:
+        torch.cuda.synchronize()
+        torch.cuda.reset_peak_memory_stats(device)
+
+    timers = _Timers(use_cuda)
+    profiler_ctx = nullcontext()
+    prof = None
+    if args.trace and is_main:
+        from torch.profiler import ProfilerActivity, profile
+        acts = [ProfilerActivity.CPU] + ([ProfilerActivity.CUDA] if use_cuda else [])
+        prof = profile(activities=acts, record_shapes=False, profile_memory=True, with_stack=False)
+        profiler_ctx = prof
+
+    with profiler_ctx:
+        for _ in range(args.steps):
+            step_start = time.perf_counter()
+            one_step(timers)
+            if use_cuda:
+                torch.cuda.synchronize()
+            timers.step_samples.append((time.perf_counter() - step_start) * 1e3)
+            if prof is not None:
+                prof.step()
+
+    if not is_main:
+        return None
+
+    # Per-section + throughput summary (rank 0). Throughput counts the whole cluster's samples.
+    def stats(xs: List[float]) -> Dict[str, float]:
+        return {"mean_ms": statistics.mean(xs), "p50_ms": statistics.median(xs),
+                "max_ms": max(xs), "min_ms": min(xs)}
+
+    step_ms = statistics.mean(timers.step_samples)
+    global_bs = args.batch_size * world
+    summary = {
+        "world": world, "precision": args.precision, "model_type": args.model_type,
+        "batch_size_per_rank": args.batch_size, "global_batch_size": global_bs,
+        "seq_len": args.seq_len, "steps": args.steps,
+        "step_ms": stats(timers.step_samples),
+        "samples_per_sec": global_bs / (step_ms / 1e3),
+        "sections": {s: stats(timers.samples[s]) for s in SECTIONS},
+        "peak_mem_gb": (torch.cuda.max_memory_allocated(device) / 1e9) if use_cuda else None,
+    }
+
+    print("\n===== per-section timing (mean ms/step, rank 0) =====")
+    for s in SECTIONS:
+        m = summary["sections"][s]["mean_ms"]
+        pct = 100.0 * m / sum(summary["sections"][x]["mean_ms"] for x in SECTIONS)
+        print(f"  {s:10s} {m:8.2f} ms  ({pct:4.1f}%)")
+    print(f"  {'STEP':10s} {step_ms:8.2f} ms/step")
+    print(f"\n  throughput : {summary['samples_per_sec']:.1f} samples/sec (global, {world} rank(s))")
+    if summary["peak_mem_gb"] is not None:
+        print(f"  peak mem   : {summary['peak_mem_gb']:.2f} GB/rank")
+
+    if prof is not None:
+        sort_key = "cuda_time_total" if use_cuda else "cpu_time_total"
+        print("\n===== torch.profiler top ops =====")
+        print(prof.key_averages().table(sort_by=sort_key, row_limit=15))
+        if args.output_dir:
+            os.makedirs(args.output_dir, exist_ok=True)
+            prof.export_chrome_trace(os.path.join(args.output_dir, "trace.json"))
+
+    if args.output_dir:
+        os.makedirs(args.output_dir, exist_ok=True)
+        with open(os.path.join(args.output_dir, "profile_summary.json"), "w") as fh:
+            json.dump(summary, fh, indent=2)
+        print(f"\n  wrote {args.output_dir}/profile_summary.json", flush=True)
+    return summary
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model_type", default="gpt2", help="HF model type/id (config-built, no download)")
+    ap.add_argument("--batch_size", type=int, default=8, help="per-rank batch size")
+    ap.add_argument("--seq_len", type=int, default=1024)
+    ap.add_argument("--precision", choices=("fp32", "fp16", "bf16"), default="bf16")
+    ap.add_argument("--steps", type=int, default=20, help="profiled optimizer steps")
+    ap.add_argument("--warmup", type=int, default=5, help="unprofiled warmup steps")
+    ap.add_argument("--trace", action="store_true", help="also capture a torch.profiler op trace")
+    ap.add_argument("--output_dir", default="", help="write profile_summary.json (+ trace.json)")
+    run(ap.parse_args())
+
+
+if __name__ == "__main__":
+    main()
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/scripts/gpu_train_profile.sh
+++ b/scripts/gpu_train_profile.sh
@@ -1,0 +1,79 @@
+#!/opt/homebrew/bin/bash
+# Sweep the per-section training-step profiler across GPU counts / batch sizes on a GB300 node.
+#
+# Mirrors scripts/gpu_dataset_isolation.sh: one profiled configuration per accelerate launch, each
+# writing profile_summary.json under a per-config dir, so you can compare the forward/backward/
+# optimizer/comms split and samples/sec as you scale 4 -> 8 GPUs or change batch/precision. This is
+# the "profile each section on multi-GPU, see where we can do better" pass before a real run.
+#
+# Usage (on the node, inside the igc container/env):
+#   scripts/gpu_train_profile.sh                       # default sweep: {4,8} GPU x {4,8} batch, bf16
+#   GPUS="4" BATCHES="8 16" MODEL=gpt2 scripts/gpu_train_profile.sh
+#
+# Env knobs:
+#   GPUS      space-separated world sizes to try   (default "4 8")
+#   BATCHES   space-separated per-rank batch sizes (default "4 8")
+#   MODEL     backbone model_type/id               (default gpt2)
+#   SEQ_LEN   sequence length                      (default 1024)
+#   PRECISION fp32|fp16|bf16                        (default bf16)
+#   STEPS / WARMUP                                  (default 20 / 5)
+#   OUT       output root                          (default ./profile_out)
+#
+# Author:
+# Mus mbayramo@stanford.edu
+set -euo pipefail
+
+GPUS="${GPUS:-4 8}"
+BATCHES="${BATCHES:-4 8}"
+MODEL="${MODEL:-gpt2}"
+SEQ_LEN="${SEQ_LEN:-1024}"
+PRECISION="${PRECISION:-bf16}"
+STEPS="${STEPS:-20}"
+WARMUP="${WARMUP:-5}"
+OUT="${OUT:-./profile_out}"
+export TRANSFORMERS_OFFLINE="${TRANSFORMERS_OFFLINE:-1}"
+export HF_DATASETS_OFFLINE="${HF_DATASETS_OFFLINE:-1}"
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ngpu="$(python -c 'import torch;print(torch.cuda.device_count())' 2>/dev/null || echo 0)"
+echo "node has ${ngpu} visible CUDA device(s); sweeping GPUS='${GPUS}' BATCHES='${BATCHES}'"
+
+for g in $GPUS; do
+    if [ "$g" -gt "$ngpu" ]; then
+        echo "SKIP world=${g}: node has only ${ngpu} GPU(s)"
+        continue
+    fi
+    for b in $BATCHES; do
+        tag="w${g}_b${b}_${PRECISION}"
+        odir="${OUT}/${tag}"
+        echo "===== profile ${tag} (${g} GPU x batch ${b}) ====="
+        accelerate launch --multi_gpu --num_processes "$g" --num_machines 1 --mixed_precision "$PRECISION" \
+            "${here}/scripts/gpu_train_profile.py" \
+            --model_type "$MODEL" --batch_size "$b" --seq_len "$SEQ_LEN" \
+            --precision "$PRECISION" --steps "$STEPS" --warmup "$WARMUP" \
+            --trace --output_dir "$odir" || echo "FAILED ${tag} (see output above)"
+    done
+done
+
+echo ""
+echo "===== sweep summary (samples/sec + section split) ====="
+python - "$OUT" <<'PY'
+import json, os, sys
+root = sys.argv[1]
+rows = []
+for d in sorted(os.listdir(root)) if os.path.isdir(root) else []:
+    p = os.path.join(root, d, "profile_summary.json")
+    if not os.path.exists(p):
+        continue
+    s = json.load(open(p))
+    sec = s["sections"]
+    rows.append((d, s["samples_per_sec"], s["step_ms"]["mean_ms"],
+                 sec["forward"]["mean_ms"], sec["backward"]["mean_ms"],
+                 sec["optimizer"]["mean_ms"], s.get("peak_mem_gb")))
+hdr = ("config", "samp/s", "step_ms", "fwd_ms", "bwd_ms", "opt_ms", "mem_gb")
+print("{:<16}{:>10}{:>10}{:>9}{:>9}{:>9}{:>9}".format(*hdr))
+for r in rows:
+    mem = f"{r[6]:.2f}" if r[6] is not None else "-"
+    print("{:<16}{:>10.1f}{:>10.2f}{:>9.2f}{:>9.2f}{:>9.2f}{:>9}".format(
+        r[0], r[1], r[2], r[3], r[4], r[5], mem))
+PY

--- a/tests/scripts/test_gpu_train_profile.py
+++ b/tests/scripts/test_gpu_train_profile.py
@@ -1,0 +1,72 @@
+"""
+Offline smoke tests for the multi-GPU training-step profiler (``scripts/gpu_train_profile.py``).
+
+The profiler's value is on a GB300 node under ``accelerate launch``; these CPU tests just guard that
+the section decomposition, the timer, and a single-process run stay wired — so a refactor cannot
+silently break the harness before it reaches the node. No GPU, no HF download (config-built backbone,
+``TRANSFORMERS_OFFLINE``).
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "gpu_train_profile",
+    Path(__file__).resolve().parents[2] / "scripts" / "gpu_train_profile.py",
+)
+gtp = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(gtp)
+
+
+def test_sections_and_dtype_mapping():
+    """The step decomposes into the four named sections and precision maps to a torch dtype."""
+    import torch
+    assert gtp.SECTIONS == ("data", "forward", "backward", "optimizer")
+    assert gtp._dtype("bf16") is torch.bfloat16
+    assert gtp._dtype("fp32") is torch.float32
+
+
+def test_timer_records_every_section_on_cpu():
+    """The CPU timer path records one sample per section entered (no CUDA required)."""
+    timers = gtp._Timers(use_cuda=False)
+    for s in gtp.SECTIONS:
+        with timers.time(s):
+            _ = sum(range(1000))
+    for s in gtp.SECTIONS:
+        assert len(timers.samples[s]) == 1
+        assert timers.samples[s][0] >= 0.0
+
+
+def test_synthetic_batch_shapes():
+    """The synthetic batch has the real (batch, seq_len) shape and matching labels."""
+    import torch
+    batch = gtp._synthetic_batch(3, 16, vocab_size=100, device=torch.device("cpu"))
+    assert batch["input_ids"].shape == (3, 16)
+    assert batch["attention_mask"].shape == (3, 16)
+    assert torch.equal(batch["input_ids"], batch["labels"])
+    assert batch["attention_mask"].sum().item() == 3 * 16
+
+
+@pytest.mark.slow
+def test_single_process_run_produces_summary(tmp_path):
+    """A tiny single-process CPU run returns a summary with per-section stats and throughput."""
+    os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+    args = gtp.argparse.Namespace(
+        model_type="gpt2", batch_size=2, seq_len=32, precision="fp32",
+        steps=2, warmup=1, trace=False, output_dir=str(tmp_path),
+    )
+    summary = gtp.run(args)
+    assert summary is not None
+    assert summary["samples_per_sec"] > 0.0
+    assert set(summary["sections"]) == set(gtp.SECTIONS)
+    assert (tmp_path / "profile_summary.json").exists()
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
## What
A standalone profiler that answers "where does the GPU time go in one training step, on 4 or 8 GPUs?" — the piece missing between the offline CPU hot-path benchmarks and the dataset-isolation harness.

`scripts/gpu_train_profile.py` reconstructs the exact `LlmEmbeddingsTrainer._train` step (data move → forward → backward incl. gradient sync → optimizer) using the same `Accelerator.prepare` / `accelerator.backward` path, and times each section with CUDA events over N steps, plus a `torch.profiler` op-level trace. Reports per-section ms, **samples/sec**, and peak memory per rank.

`scripts/gpu_train_profile.sh` sweeps it across GPU counts / batch sizes and prints a comparison table (samples/sec + section split as you scale 4→8 GPUs).

## Why
No real CUDA run has been profiled yet — all prior work was offline/CPU. Before the first real multi-epoch run (now unblocked by the epoch-2 deadlock fix in #76), this sizes batch/precision/grad-accum and shows the forward/backward/optimizer/comms split so we know where to optimize.

## Offline-safe
Backbone built from `AutoConfig` (random weights, no HF download — timing is weight-independent); synthetic real-shape batch isolates compute+comms from the data pipeline. CPU smoke tests guard the section decomposition, timer, and a single-process run.

## Verification
- `ruff check` clean on all three files
- `pytest tests/scripts/test_gpu_train_profile.py` — 3 passed (default gate), slow single-process run passes with `-m slow`
- End-to-end CPU run confirmed: emits per-section table, samples/sec, op trace, `profile_summary.json`