### PR TITLE
Add run orchestration dry runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,14 @@ jobs:
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install -r docker/requirements-test.txt
           pip install ruff
+      - name: Run orchestration dry-runs
+        shell: bash
+        run: |
+          python scripts/render_run.py --spec configs/run/examples/docker-smoke.yaml >/tmp/docker-plan.txt
+          python scripts/render_run.py --spec configs/run/examples/slurm-smoke.yaml >/tmp/slurm-plan.txt
+          python scripts/launch_run.py --spec configs/run/examples/docker-smoke.yaml --dry-run >/tmp/launch-plan.txt
+          python scripts/docker_image_sync.py --spec configs/run/examples/docker-smoke.yaml --dry-run >/tmp/docker-sync-plan.txt
+          python scripts/slurm_sanity_from_spec.py --spec configs/run/examples/slurm-smoke.yaml --dry-run >/tmp/slurm-sanity-plan.txt
       - name: Lint
         run: ruff check igc tests
       - name: Offline gate with coverage

--- a/configs/run/examples/docker-smoke.yaml
+++ b/configs/run/examples/docker-smoke.yaml
@@ -1,0 +1,31 @@
+version: 1
+name: docker-smoke
+backend: docker
+image:
+  ref: igc-train:latest
+  pull_policy: if_missing
+runtime:
+  command:
+    - python
+    - igc_main.py
+    - --help
+  env:
+    WANDB_PROJECT: igc
+    WANDB_API_KEY: ${WANDB_API_KEY}
+paths:
+  code: ${IGC_CODE_DIR}
+  data: ${IGC_DATA_DIR}
+  output: ${IGC_OUTPUT_DIR}
+resources:
+  gpus: 1
+docker:
+  env_files:
+    - ${IGC_DOCKER_ENV_FILE}
+  mounts:
+    - source: ${IGC_CODE_DIR}
+      target: /workspace/igc
+    - source: ${IGC_DATA_DIR}
+      target: /root/.json_responses
+      read_only: true
+sanity:
+  dry_run: true

--- a/configs/run/examples/slurm-smoke.yaml
+++ b/configs/run/examples/slurm-smoke.yaml
@@ -1,0 +1,31 @@
+version: 1
+name: slurm-smoke
+backend: slurm
+image:
+  ref: igc-train:latest
+  pull_policy: if_missing
+runtime:
+  command:
+    - python
+    - igc_main.py
+    - --help
+paths:
+  code: ${IGC_CODE_DIR}
+  data: ${IGC_DATA_DIR}
+  output: ${IGC_OUTPUT_DIR}
+resources:
+  gpus: 1
+  nodes: 1
+  cpus_per_task: 4
+  wall_time: "00:05:00"
+slurm:
+  partition: ${IGC_SLURM_PARTITION}
+  account: ${IGC_SLURM_ACCOUNT}
+  output: ${IGC_OUTPUT_DIR}/slurm-%j.out
+sanity:
+  slurm:
+    enabled: true
+    command: "printf IGC_SLURM_SANITY_OK"
+    sentinel: IGC_SLURM_SANITY_OK
+    timeout_seconds: 120
+    poll_seconds: 5

--- a/configs/run/schema.yaml
+++ b/configs/run/schema.yaml
@@ -1,0 +1,36 @@
+# Public run-spec schema sketch for Docker and Slurm launchers.
+#
+# This file documents the committed YAML contract. The first implementation
+# validates the same fields in igc/shared/run_spec.py so default tests do not
+# depend on a separate schema-validation package.
+version: 1
+required:
+  - version
+  - name
+  - backend
+  - image
+  - runtime
+properties:
+  backend:
+    enum: [docker, slurm]
+  image:
+    required: [ref]
+    properties:
+      ref: string
+      pull_policy:
+        enum: [never, always, if_missing, build, locked_digest]
+  runtime:
+    required: [command]
+    properties:
+      command: list[string]
+      env: mapping[string, string]
+  docker:
+    properties:
+      env_files: list[string]
+      mounts: list[mapping]
+  slurm:
+    properties:
+      partition: string
+      account: string
+      output: string
+      extra_args: list[string]

--- a/igc/shared/run_spec.py
+++ b/igc/shared/run_spec.py
@@ -1,0 +1,413 @@
+"""Run-spec validation and dry-run rendering for training launchers.
+
+The module is deliberately pure: it parses YAML, validates the public run
+contract, redacts sensitive-looking values, and renders command plans without
+calling Docker, Slurm, the network, or gitignored operator files.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import re
+import shlex
+from typing import Any, Mapping
+
+import yaml
+
+
+class RunSpecError(ValueError):
+    """Raised when a run spec is invalid or unsafe to render."""
+
+
+_TOP_LEVEL_KEYS = {
+    "version",
+    "name",
+    "backend",
+    "image",
+    "runtime",
+    "paths",
+    "resources",
+    "docker",
+    "slurm",
+    "data",
+    "checkpoint",
+    "sanity",
+    "observability",
+}
+_BACKENDS = {"docker", "slurm"}
+_PULL_POLICIES = {"never", "always", "if_missing", "build", "locked_digest"}
+_SECRET_NAME = re.compile(
+    r"(TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|PRIVATE[_-]?KEY|CREDENTIAL|AUTH)",
+    re.IGNORECASE,
+)
+_SHELL_META = re.compile(r"[\n\r;&|`<>]|\$\(")
+_PLACEHOLDER = re.compile(
+    r"^\$[A-Za-z_][A-Za-z0-9_]*$|^\$\{[A-Za-z_][A-Za-z0-9_]*(?::-[^}\n]*)?\}$"
+)
+
+
+@dataclass(frozen=True)
+class RunSpec:
+    """Normalized, public-safe run specification.
+
+    :param path: source YAML file.
+    :param name: stable logical run name.
+    :param backend: launch backend, ``docker`` or ``slurm``.
+    :param image: image settings such as ``ref`` and ``pull_policy``.
+    :param runtime: command and environment allowlist.
+    :param paths: code, data, output, scratch, and artifact roots.
+    :param resources: GPU, node, CPU, memory, and wall-time knobs.
+    :param docker: Docker-specific mounts and env-file references.
+    :param slurm: Slurm-specific resource options.
+    :param data: optional data staging settings.
+    :param checkpoint: optional checkpoint publish/resume settings.
+    :param sanity: optional pre-run sanity settings.
+    :param observability: optional logging and metric settings.
+    """
+
+    path: Path
+    name: str
+    backend: str
+    image: dict[str, Any]
+    runtime: dict[str, Any]
+    paths: dict[str, Any]
+    resources: dict[str, Any]
+    docker: dict[str, Any] = field(default_factory=dict)
+    slurm: dict[str, Any] = field(default_factory=dict)
+    data: dict[str, Any] = field(default_factory=dict)
+    checkpoint: dict[str, Any] = field(default_factory=dict)
+    sanity: dict[str, Any] = field(default_factory=dict)
+    observability: dict[str, Any] = field(default_factory=dict)
+
+
+def load_run_spec(path: str | Path) -> RunSpec:
+    """Load and validate a run spec from YAML.
+
+    :param path: YAML spec path.
+    :return: normalized run spec.
+    :raises RunSpecError: if the spec is missing required fields or is unsafe.
+    """
+    spec_path = Path(path)
+    try:
+        raw = yaml.safe_load(spec_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise RunSpecError(f"cannot read spec {spec_path}: {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise RunSpecError(f"cannot parse YAML in {spec_path}: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise RunSpecError("run spec must be a YAML mapping")
+
+    unknown = sorted(set(raw) - _TOP_LEVEL_KEYS)
+    if unknown:
+        raise RunSpecError(f"unknown top-level keys: {', '.join(unknown)}")
+
+    name = _required_string(raw, "name")
+    backend = _required_string(raw, "backend")
+    if backend not in _BACKENDS:
+        raise RunSpecError("backend must be one of: docker, slurm")
+
+    image = _mapping(raw, "image", required=True)
+    runtime = _mapping(raw, "runtime", required=True)
+    paths = _mapping(raw, "paths")
+    resources = _mapping(raw, "resources")
+    docker = _mapping(raw, "docker")
+    slurm = _mapping(raw, "slurm")
+    data = _mapping(raw, "data")
+    checkpoint = _mapping(raw, "checkpoint")
+    sanity = _mapping(raw, "sanity")
+    observability = _mapping(raw, "observability")
+
+    _validate_image(image)
+    _validate_runtime(runtime)
+    _validate_backend_section(backend, docker, slurm)
+    _validate_sanity(sanity)
+
+    return RunSpec(
+        path=spec_path,
+        name=name,
+        backend=backend,
+        image=image,
+        runtime=runtime,
+        paths=paths,
+        resources=resources,
+        docker=docker,
+        slurm=slurm,
+        data=data,
+        checkpoint=checkpoint,
+        sanity=sanity,
+        observability=observability,
+    )
+
+
+def redact_value(name: str, value: Any) -> str:
+    """Return a display-safe value for dry-run output.
+
+    :param name: variable or field name.
+    :param value: value to display.
+    :return: original value, a placeholder, or ``<redacted>``.
+    """
+    text = "" if value is None else str(value)
+    if _is_placeholder(text):
+        return text
+    if _SECRET_NAME.search(name):
+        return "<redacted>"
+    return text
+
+
+def render_plan(spec: RunSpec) -> str:
+    """Render a dry-run command plan for the spec backend."""
+    if spec.backend == "docker":
+        return render_docker_plan(spec)
+    if spec.backend == "slurm":
+        return render_slurm_plan(spec)
+    raise RunSpecError(f"unsupported backend: {spec.backend}")
+
+
+def render_docker_plan(spec: RunSpec) -> str:
+    """Render the Docker dry-run plan without executing it."""
+    image = _image_ref(spec)
+    pull_policy = spec.image.get("pull_policy", "if_missing")
+    command = _command_string(spec.runtime["command"])
+    lines = [
+        "# igc run dry-run",
+        "# backend: docker",
+        "set -euo pipefail",
+    ]
+
+    if pull_policy == "always":
+        lines.append(f"docker pull {_shell(image)}")
+    elif pull_policy == "if_missing":
+        lines.append(
+            f"docker image inspect {_shell(image)} >/dev/null 2>&1 "
+            f"|| docker pull {_shell(image)}"
+        )
+    elif pull_policy == "build":
+        dockerfile = spec.image.get("dockerfile", "docker/Dockerfile.train")
+        context = spec.image.get("context", ".")
+        lines.append(
+            f"docker build -f {_shell(dockerfile)} -t {_shell(image)} {_shell(context)}"
+        )
+    elif pull_policy == "locked_digest":
+        lines.append(f"docker image inspect {_shell(image)} >/dev/null")
+
+    docker_args = ["docker run", "--rm"]
+    gpus = spec.resources.get("gpus")
+    if gpus:
+        docker_args.extend(["--gpus", "all"])
+    if spec.docker.get("ipc", "host"):
+        docker_args.append("--ipc=host")
+
+    for env_file in _string_list(spec.docker.get("env_files", []), "docker.env_files"):
+        docker_args.extend(["--env-file", _shell(env_file)])
+
+    for env_name in sorted(_mapping(spec.runtime, "env").keys()):
+        docker_args.extend(["-e", env_name])
+
+    for mount in _list(spec.docker.get("mounts", []), "docker.mounts"):
+        if not isinstance(mount, dict):
+            raise RunSpecError("docker.mounts entries must be mappings")
+        source = _required_string(mount, "source", context="docker.mounts")
+        target = _required_string(mount, "target", context="docker.mounts")
+        suffix = ":ro" if mount.get("read_only") else ""
+        docker_args.extend(["-v", f"{source}:{target}{suffix}"])
+
+    workdir = spec.runtime.get("workdir") or spec.docker.get("workdir") or "/workspace/igc"
+    docker_args.extend(["-w", _shell(str(workdir)), _shell(image), *command])
+    lines.append(_join_command(docker_args))
+    return "\n".join(lines) + "\n"
+
+
+def render_slurm_plan(spec: RunSpec) -> str:
+    """Render the Slurm dry-run plan without submitting it."""
+    command = " ".join(_command_string(spec.runtime["command"]))
+    resources = spec.resources
+    slurm = spec.slurm
+
+    args = [
+        "sbatch",
+        "--parsable",
+        f"--job-name={_slurm_value(spec.name)}",
+        f"--nodes={resources.get('nodes', 1)}",
+        f"--gres=gpu:{resources.get('gpus', 1)}",
+    ]
+    if resources.get("cpus_per_task"):
+        args.append(f"--cpus-per-task={resources['cpus_per_task']}")
+    if resources.get("wall_time"):
+        args.append(f"--time={resources['wall_time']}")
+    if slurm.get("partition"):
+        args.append(f"--partition={slurm['partition']}")
+    if slurm.get("account"):
+        args.append(f"--account={slurm['account']}")
+    if slurm.get("output"):
+        args.append(f"--output={slurm['output']}")
+    args.extend(_string_list(slurm.get("extra_args", []), "slurm.extra_args"))
+    args.append(f"--wrap={_shell(command)}")
+    return "\n".join([
+        "# igc run dry-run",
+        "# backend: slurm",
+        _join_command(args),
+        "",
+    ])
+
+
+def slurm_sanity_settings(spec: RunSpec) -> dict[str, Any]:
+    """Return normalized Slurm sanity settings from a run spec."""
+    sanity = _mapping(spec.sanity, "slurm")
+    return {
+        "enabled": bool(sanity.get("enabled", False)),
+        "command": str(sanity.get("command", "printf IGC_SLURM_SANITY_OK")),
+        "sentinel": str(sanity.get("sentinel", "IGC_SLURM_SANITY_OK")),
+        "timeout_seconds": int(sanity.get("timeout_seconds", 300)),
+        "poll_seconds": int(sanity.get("poll_seconds", 5)),
+    }
+
+
+def slurm_output_path(spec: RunSpec, job_id: str | None = None) -> str:
+    """Return the Slurm output path, replacing ``%j`` when a job id is known."""
+    output = spec.slurm.get("output")
+    if not output:
+        root = str(spec.paths.get("output", "."))
+        output = f"{root.rstrip('/')}/slurm-%j.out"
+    if job_id is not None:
+        output = str(output).replace("%j", job_id)
+    return str(output)
+
+
+def _validate_image(image: Mapping[str, Any]) -> None:
+    image_ref = _required_string(image, "ref", context="image")
+    _reject_shell_meta("image.ref", image_ref)
+    pull_policy = image.get("pull_policy", "if_missing")
+    if pull_policy not in _PULL_POLICIES:
+        raise RunSpecError(
+            "image.pull_policy must be one of: " + ", ".join(sorted(_PULL_POLICIES))
+        )
+
+
+def _validate_runtime(runtime: Mapping[str, Any]) -> None:
+    command = runtime.get("command")
+    if not isinstance(command, list) or not command:
+        raise RunSpecError("runtime.command must be a non-empty list")
+    if not all(isinstance(part, str) for part in command):
+        raise RunSpecError("runtime.command entries must be strings")
+    for part in command:
+        _reject_shell_meta("runtime.command", part)
+    env = _mapping(runtime, "env")
+    for key, value in env.items():
+        if not isinstance(key, str):
+            raise RunSpecError("runtime.env keys must be strings")
+        text = "" if value is None else str(value)
+        if _SECRET_NAME.search(key) and not _is_placeholder(text):
+            raise RunSpecError(
+                f"runtime.env.{key} must reference an environment placeholder, "
+                "not a literal value"
+            )
+
+
+def _validate_backend_section(
+        backend: str,
+        docker: Mapping[str, Any],
+        slurm: Mapping[str, Any],
+) -> None:
+    if backend == "docker":
+        for env_file in _string_list(docker.get("env_files", []), "docker.env_files"):
+            _reject_shell_meta("docker.env_files", env_file)
+    if backend == "slurm":
+        for arg in _string_list(slurm.get("extra_args", []), "slurm.extra_args"):
+            _reject_shell_meta("slurm.extra_args", arg)
+
+
+def _validate_sanity(sanity: Mapping[str, Any]) -> None:
+    slurm = _mapping(sanity, "slurm")
+    command = slurm.get("command")
+    if command is not None:
+        if not isinstance(command, str):
+            raise RunSpecError("sanity.slurm.command must be a string")
+        _reject_shell_meta("sanity.slurm.command", command)
+
+
+def _image_ref(spec: RunSpec) -> str:
+    return _required_string(spec.image, "ref", context="image")
+
+
+def _required_string(
+        mapping: Mapping[str, Any],
+        key: str,
+        *,
+        context: str = "spec",
+) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or value == "":
+        raise RunSpecError(f"{context}.{key} must be a non-empty string")
+    return value
+
+
+def _mapping(
+        mapping: Mapping[str, Any],
+        key: str,
+        *,
+        required: bool = False,
+) -> dict[str, Any]:
+    value = mapping.get(key)
+    if value is None:
+        if required:
+            raise RunSpecError(f"missing required section: {key}")
+        return {}
+    if not isinstance(value, dict):
+        raise RunSpecError(f"{key} must be a mapping")
+    return dict(value)
+
+
+def _list(value: Any, field: str) -> list[Any]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise RunSpecError(f"{field} must be a list")
+    return list(value)
+
+
+def _string_list(value: Any, field: str) -> list[str]:
+    values = _list(value, field)
+    if not all(isinstance(item, str) for item in values):
+        raise RunSpecError(f"{field} entries must be strings")
+    return values
+
+
+def _is_placeholder(value: str) -> bool:
+    return bool(_PLACEHOLDER.fullmatch(value))
+
+
+def _reject_shell_meta(field: str, value: str) -> None:
+    if _is_placeholder(value):
+        return
+    if _SHELL_META.search(value):
+        raise RunSpecError(f"{field} contains shell metacharacters")
+
+
+def _command_string(command: list[str]) -> list[str]:
+    return [_shell(part) for part in command]
+
+
+def _shell(value: Any) -> str:
+    text = str(value)
+    if _is_placeholder(text):
+        return text
+    return shlex.quote(text)
+
+
+def _join_command(parts: list[str]) -> str:
+    return " ".join(str(part) for part in parts)
+
+
+def _slurm_value(value: Any) -> str:
+    text = str(value)
+    if re.fullmatch(r"[A-Za-z0-9_.=-]+", text) or _is_placeholder(text):
+        return text
+    return _shell(text)
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/scripts/docker_image_sync.py
+++ b/scripts/docker_image_sync.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python
+"""Synchronize a Docker image according to an igc run spec.
+
+This script is safe to test offline: command execution is isolated behind a
+runner, and ``--dry-run`` prints the Docker calls without touching the daemon.
+Live mode uses only the image section of the public run spec and never reads
+private env files.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import subprocess
+import sys
+from typing import Protocol
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from igc.shared.run_spec import RunSpecError, load_run_spec
+
+
+class Runner(Protocol):
+    """Protocol for Docker command execution, mockable in tests."""
+
+    def run(self, cmd: list[str]) -> tuple[int, str, str]:
+        """Run a command and return ``(returncode, stdout, stderr)``."""
+
+
+class SubprocessRunner:
+    """Subprocess-backed runner for live Docker commands."""
+
+    def run(self, cmd: list[str]) -> tuple[int, str, str]:
+        """Run a Docker command and capture text output."""
+        result = subprocess.run(
+            cmd,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        return result.returncode, result.stdout, result.stderr
+
+
+def render_sync_plan(spec_path: str | Path, *, push: bool = False) -> str:
+    """Render Docker image-sync commands without executing them."""
+    spec = load_run_spec(spec_path)
+    image = str(spec.image["ref"])
+    policy = str(spec.image.get("pull_policy", "if_missing"))
+    lines = ["# igc docker image sync dry-run"]
+
+    if policy == "if_missing":
+        lines.append(
+            f"docker image inspect {image} >/dev/null 2>&1 "
+            f"|| docker pull {image}"
+        )
+    elif policy == "always":
+        lines.append(f"docker pull {image}")
+    elif policy == "build":
+        lines.append(_build_command(spec.image, image))
+    elif policy in {"never", "locked_digest"}:
+        lines.append(f"docker image inspect {image} >/dev/null")
+    else:
+        raise RunSpecError(f"unsupported image.pull_policy: {policy}")
+
+    if push:
+        lines.append(f"docker push {image}")
+    return "\n".join(lines) + "\n"
+
+
+def sync_image(
+        spec_path: str | Path,
+        *,
+        runner: Runner | None = None,
+        push: bool = False,
+) -> int:
+    """Synchronize the Docker image for a run spec.
+
+    :param spec_path: YAML run spec.
+    :param runner: Docker command runner, injectable for tests.
+    :param push: push the image after a successful build/pull/inspect.
+    :return: process exit code.
+    """
+    try:
+        spec = load_run_spec(spec_path)
+    except RunSpecError as exc:
+        print(f"RUN SPEC ERROR: {exc}")
+        return 2
+
+    image = str(spec.image["ref"])
+    policy = str(spec.image.get("pull_policy", "if_missing"))
+    runner = runner or SubprocessRunner()
+
+    if policy == "if_missing":
+        if _inspect(runner, image):
+            print(f"docker image present: {image}")
+        elif not _pull(runner, image):
+            return 1
+    elif policy == "always":
+        if not _pull(runner, image):
+            return 1
+    elif policy == "build":
+        if not _build(runner, spec.image, image):
+            return 1
+    elif policy in {"never", "locked_digest"}:
+        if not _inspect(runner, image):
+            print(f"BLOCKER: required docker image is not present: {image}")
+            return 1
+    else:
+        print(f"RUN SPEC ERROR: unsupported image.pull_policy: {policy}")
+        return 2
+
+    if push and not _push(runner, image):
+        return 1
+    return 0
+
+
+def _inspect(runner: Runner, image: str) -> bool:
+    rc, _, _ = runner.run(["docker", "image", "inspect", image])
+    return rc == 0
+
+
+def _pull(runner: Runner, image: str) -> bool:
+    rc, out, err = runner.run(["docker", "pull", image])
+    if rc != 0:
+        print(f"BLOCKER: docker pull failed rc={rc}: {(err or out).strip()}")
+        return False
+    print(f"docker pull OK: {image}")
+    return True
+
+
+def _build(runner: Runner, image_cfg: dict, image: str) -> bool:
+    dockerfile = str(image_cfg.get("dockerfile", "docker/Dockerfile.train"))
+    context = str(image_cfg.get("context", "."))
+    rc, out, err = runner.run(["docker", "build", "-f", dockerfile, "-t", image, context])
+    if rc != 0:
+        print(f"BLOCKER: docker build failed rc={rc}: {(err or out).strip()}")
+        return False
+    print(f"docker build OK: {image}")
+    return True
+
+
+def _push(runner: Runner, image: str) -> bool:
+    rc, out, err = runner.run(["docker", "push", image])
+    if rc != 0:
+        print(f"BLOCKER: docker push failed rc={rc}: {(err or out).strip()}")
+        return False
+    print(f"docker push OK: {image}")
+    return True
+
+
+def _build_command(image_cfg: dict, image: str) -> str:
+    dockerfile = str(image_cfg.get("dockerfile", "docker/Dockerfile.train"))
+    context = str(image_cfg.get("context", "."))
+    return f"docker build -f {dockerfile} -t {image} {context}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--spec", required=True, help="YAML run spec")
+    parser.add_argument("--dry-run", action="store_true", help="print commands only")
+    parser.add_argument("--push", action="store_true", help="push after sync")
+    args = parser.parse_args(argv)
+
+    try:
+        if args.dry_run:
+            sys.stdout.write(render_sync_plan(args.spec, push=args.push))
+            return 0
+    except RunSpecError as exc:
+        print(f"RUN SPEC ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    return sync_image(args.spec, push=args.push)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/launch_run.py
+++ b/scripts/launch_run.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+"""Safe dispatcher for spec-driven igc launch plans.
+
+This first implementation slice supports dry-run rendering only. Live Docker
+and Slurm mutation will be added behind explicit backend adapters after the
+spec contract and tests are stable.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from igc.shared.run_spec import RunSpecError, load_run_spec, render_plan
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Render or refuse a run spec."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--spec", required=True, help="YAML run spec to launch")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="render the launch plan without executing it",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.dry_run:
+        print(
+            "RUN SPEC ERROR: refusing live launch without --dry-run in this "
+            "implementation slice",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        spec = load_run_spec(args.spec)
+        sys.stdout.write(render_plan(spec))
+    except RunSpecError as exc:
+        print(f"RUN SPEC ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_run.py
+++ b/scripts/render_run.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+"""Render an igc run spec without executing Docker or Slurm."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from igc.shared.run_spec import RunSpecError, load_run_spec, render_plan
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Render a run spec and return a process exit code."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--spec", required=True, help="YAML run spec to render")
+    args = parser.parse_args(argv)
+
+    try:
+        spec = load_run_spec(args.spec)
+        sys.stdout.write(render_plan(spec))
+    except RunSpecError as exc:
+        print(f"RUN SPEC ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/slurm_sanity_from_spec.py
+++ b/scripts/slurm_sanity_from_spec.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+"""Opt-in Slurm scheduler sanity check from an igc run spec.
+
+Default mode is dry-run. Live mode submits a tiny scheduler job, polls at a
+bounded interval, verifies a sentinel in the job log, and returns a clear
+blocker instead of silently trusting scheduler state.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import subprocess
+import sys
+import time
+from typing import Callable, Protocol
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from igc.shared.run_spec import (
+    RunSpec,
+    RunSpecError,
+    load_run_spec,
+    slurm_output_path,
+    slurm_sanity_settings,
+)
+
+
+class Runner(Protocol):
+    """Protocol for Slurm command execution, mockable in unit tests."""
+
+    def run(self, cmd: list[str]) -> tuple[int, str, str]:
+        """Run a command and return ``(returncode, stdout, stderr)``."""
+
+
+class SubprocessRunner:
+    """Subprocess-backed runner for live Slurm commands."""
+
+    def run(self, cmd: list[str]) -> tuple[int, str, str]:
+        """Run a command and capture text output."""
+        result = subprocess.run(
+            cmd,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        return result.returncode, result.stdout, result.stderr
+
+
+def render_slurm_sanity(spec: RunSpec) -> str:
+    """Render the Slurm sanity commands without executing them."""
+    settings = slurm_sanity_settings(spec)
+    sbatch_cmd = _sbatch_command(spec)
+    return "\n".join([
+        "# igc slurm sanity dry-run",
+        " ".join(sbatch_cmd),
+        "# poll: sacct -n -X -j <jobid> --format=State",
+        f"# expect log sentinel: {settings['sentinel']}",
+        f"# timeout_seconds: {settings['timeout_seconds']}",
+        f"# poll_seconds: {settings['poll_seconds']}",
+        "",
+    ])
+
+
+def run_live(
+        spec_path: str | Path,
+        *,
+        runner: Runner | None = None,
+        sleep: Callable[[float], None] = time.sleep,
+        now: Callable[[], float] = time.monotonic,
+) -> int:
+    """Submit and verify a tiny Slurm sanity job.
+
+    :param spec_path: YAML run spec.
+    :param runner: command runner, injectable for tests.
+    :param sleep: sleep function, injectable for tests.
+    :param now: monotonic clock, injectable for tests.
+    :return: 0 for pass, 1 for scheduler/log blocker, 2 for spec error.
+    """
+    try:
+        spec = load_run_spec(spec_path)
+    except RunSpecError as exc:
+        print(f"RUN SPEC ERROR: {exc}")
+        return 2
+
+    if spec.backend != "slurm":
+        print("RUN SPEC ERROR: slurm sanity requires backend: slurm")
+        return 2
+
+    settings = slurm_sanity_settings(spec)
+    if not settings["enabled"]:
+        print("RUN SPEC ERROR: sanity.slurm.enabled must be true for live sanity")
+        return 2
+
+    poll_seconds = int(settings["poll_seconds"])
+    if poll_seconds < 1:
+        print("RUN SPEC ERROR: sanity.slurm.poll_seconds must be >= 1")
+        return 2
+
+    runner = runner or SubprocessRunner()
+    rc, out, err = runner.run(_sbatch_command(spec))
+    if rc != 0:
+        print(f"BLOCKER: sbatch failed rc={rc}: {(err or out).strip()}")
+        return 1
+
+    job_id = out.strip().splitlines()[0] if out.strip() else ""
+    if not job_id:
+        print("BLOCKER: sbatch did not return a job id")
+        return 1
+
+    timeout = int(settings["timeout_seconds"])
+    deadline = now() + timeout
+    terminal_failures = {"BOOT_FAIL", "CANCELLED", "DEADLINE", "FAILED", "NODE_FAIL", "OUT_OF_MEMORY", "TIMEOUT"}
+
+    while True:
+        state = _query_state(runner, job_id)
+        if state == "COMPLETED":
+            return _verify_log(spec, job_id, str(settings["sentinel"]))
+        if state in terminal_failures:
+            print(f"BLOCKER: Slurm job {job_id} ended in {state}")
+            return 1
+        sleep(poll_seconds)
+        if now() >= deadline:
+            runner.run(["scancel", job_id])
+            print(f"BLOCKER: Slurm job {job_id} timed out waiting for completion")
+            return 1
+
+
+def _sbatch_command(spec: RunSpec) -> list[str]:
+    settings = slurm_sanity_settings(spec)
+    resources = spec.resources
+    slurm = spec.slurm
+    cmd = [
+        "sbatch",
+        "--parsable",
+        f"--job-name={spec.name}-sanity",
+        f"--nodes={resources.get('nodes', 1)}",
+        f"--gres=gpu:{resources.get('gpus', 1)}",
+        f"--output={slurm_output_path(spec)}",
+        f"--wrap={settings['command']}",
+    ]
+    if resources.get("wall_time"):
+        cmd.insert(-1, f"--time={resources['wall_time']}")
+    if slurm.get("partition"):
+        cmd.insert(-1, f"--partition={slurm['partition']}")
+    if slurm.get("account"):
+        cmd.insert(-1, f"--account={slurm['account']}")
+    return cmd
+
+
+def _query_state(runner: Runner, job_id: str) -> str:
+    rc, out, err = runner.run(["sacct", "-n", "-X", "-j", job_id, "--format=State"])
+    if rc != 0:
+        print(f"BLOCKER: sacct failed rc={rc}: {(err or out).strip()}")
+        return "FAILED"
+    text = out.strip().splitlines()[0] if out.strip() else "UNKNOWN"
+    return text.split()[0]
+
+
+def _verify_log(spec: RunSpec, job_id: str, sentinel: str) -> int:
+    path = Path(slurm_output_path(spec, job_id=job_id))
+    if not path.exists():
+        print(f"BLOCKER: expected Slurm log missing: {path}")
+        return 1
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if sentinel not in text:
+        print(f"BLOCKER: Slurm log {path} missing sentinel {sentinel!r}")
+        return 1
+    print(f"slurm sanity OK job={job_id} log={path}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--spec", required=True, help="YAML run spec")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--dry-run", action="store_true")
+    mode.add_argument("--live", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        spec = load_run_spec(args.spec)
+        if args.dry_run:
+            sys.stdout.write(render_slurm_sanity(spec))
+            return 0
+    except RunSpecError as exc:
+        print(f"RUN SPEC ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    return run_live(args.spec)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/bats/run_orchestration.bats
+++ b/tests/bats/run_orchestration.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+    export REPO_ROOT
+
+    mkdir -p "${BATS_TEST_TMPDIR}/bin" "${BATS_TEST_TMPDIR}/out"
+    export PATH="${BATS_TEST_TMPDIR}/bin:${PATH}"
+    PYTHON_BIN="${PYTHON_BIN:-python3}"
+    export PYTHON_BIN
+}
+
+write_slurm_spec() {
+    cat >"${BATS_TEST_TMPDIR}/slurm.yaml" <<EOF
+version: 1
+name: bats-slurm
+backend: slurm
+image:
+  ref: igc-train:test
+runtime:
+  command: [python, igc_main.py, --help]
+paths:
+  output: ${BATS_TEST_TMPDIR}/out
+resources:
+  gpus: 1
+  nodes: 1
+slurm:
+  output: ${BATS_TEST_TMPDIR}/out/slurm-%j.out
+sanity:
+  slurm:
+    enabled: true
+    command: "printf IGC_SLURM_SANITY_OK"
+    sentinel: IGC_SLURM_SANITY_OK
+    timeout_seconds: 3
+    poll_seconds: 1
+EOF
+}
+
+install_completed_slurm_fakes() {
+    cat >"${BATS_TEST_TMPDIR}/bin/sbatch" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+out=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --output=*) out="${1#--output=}" ;;
+        --output) shift; out="$1" ;;
+    esac
+    shift || true
+done
+out="${out//%j/123}"
+mkdir -p "$(dirname "$out")"
+printf 'IGC_SLURM_SANITY_OK\n' >"$out"
+printf '123\n'
+EOF
+    chmod +x "${BATS_TEST_TMPDIR}/bin/sbatch"
+
+    cat >"${BATS_TEST_TMPDIR}/bin/sacct" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${FAKE_SLURM_STATE:-COMPLETED}"
+EOF
+    chmod +x "${BATS_TEST_TMPDIR}/bin/sacct"
+
+    cat >"${BATS_TEST_TMPDIR}/bin/scancel" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "${BATS_TEST_TMPDIR}/bin/scancel"
+}
+
+@test "render_run renders committed docker example" {
+    run "${PYTHON_BIN}" "${REPO_ROOT}/scripts/render_run.py" \
+        --spec "${REPO_ROOT}/configs/run/examples/docker-smoke.yaml"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"backend: docker"* ]]
+    [[ "$output" == *"docker run"* ]]
+    [[ "$output" == *"\${IGC_DOCKER_ENV_FILE}"* ]]
+}
+
+@test "launch_run refuses live execution without dry-run" {
+    run "${PYTHON_BIN}" "${REPO_ROOT}/scripts/launch_run.py" \
+        --spec "${REPO_ROOT}/configs/run/examples/docker-smoke.yaml"
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"refusing live launch"* ]]
+}
+
+@test "slurm sanity dry-run renders sbatch without calling scheduler" {
+    write_slurm_spec
+
+    run "${PYTHON_BIN}" "${REPO_ROOT}/scripts/slurm_sanity_from_spec.py" \
+        --spec "${BATS_TEST_TMPDIR}/slurm.yaml" --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"sbatch"* ]]
+    [[ "$output" == *"IGC_SLURM_SANITY_OK"* ]]
+}
+
+@test "slurm sanity live mode passes with mocked completed job" {
+    write_slurm_spec
+    install_completed_slurm_fakes
+
+    run env IGC_SLURM_SANITY_TEST=1 "${PYTHON_BIN}" "${REPO_ROOT}/scripts/slurm_sanity_from_spec.py" \
+        --spec "${BATS_TEST_TMPDIR}/slurm.yaml" --live
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"slurm sanity OK"* ]]
+}
+
+@test "slurm sanity live mode reports failed job gracefully" {
+    write_slurm_spec
+    install_completed_slurm_fakes
+
+    run env IGC_SLURM_SANITY_TEST=1 FAKE_SLURM_STATE=FAILED \
+        "${PYTHON_BIN}" "${REPO_ROOT}/scripts/slurm_sanity_from_spec.py" \
+        --spec "${BATS_TEST_TMPDIR}/slurm.yaml" --live
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"BLOCKER"* ]]
+    [[ "$output" == *"FAILED"* ]]
+}
+
+@test "docker image sync dry-run renders inspect and pull" {
+    run "${PYTHON_BIN}" "${REPO_ROOT}/scripts/docker_image_sync.py" \
+        --spec "${REPO_ROOT}/configs/run/examples/docker-smoke.yaml" --dry-run
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"docker image inspect igc-train:latest"* ]]
+    [[ "$output" == *"docker pull igc-train:latest"* ]]
+    [[ "$output" != *"docker build"* ]]
+}
+
+@test "docker image sync reports pull failure gracefully" {
+    cat >"${BATS_TEST_TMPDIR}/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1 $2 $3" == "image inspect igc-train:latest" ]]; then
+    exit 1
+fi
+if [[ "$1 $2" == "pull igc-train:latest" ]]; then
+    echo "registry unavailable" >&2
+    exit 42
+fi
+exit 99
+EOF
+    chmod +x "${BATS_TEST_TMPDIR}/bin/docker"
+
+    run "${PYTHON_BIN}" "${REPO_ROOT}/scripts/docker_image_sync.py" \
+        --spec "${REPO_ROOT}/configs/run/examples/docker-smoke.yaml"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"BLOCKER: docker pull failed"* ]]
+    [[ "$output" == *"registry unavailable"* ]]
+}

--- a/tests/scripts/test_docker_image_sync.py
+++ b/tests/scripts/test_docker_image_sync.py
@@ -1,0 +1,123 @@
+"""Offline tests for Docker image synchronization decisions.
+
+The image sync path is tested with a fake runner only. It never calls a real
+Docker daemon, registry, network, or private env file.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import importlib.util
+import pathlib
+import textwrap
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "docker_image_sync.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("docker_image_sync", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_spec(tmp_path, pull_policy="if_missing"):
+    path = tmp_path / "docker.yaml"
+    image_extra = ""
+    if pull_policy == "build":
+        image_extra = "  dockerfile: docker/Dockerfile.train\n  context: .\n"
+    path.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            name: docker-sync
+            backend: docker
+            image:
+              ref: igc-train:test
+              pull_policy: {pull_policy}
+            """,
+        )
+        + image_extra
+        + textwrap.dedent(
+            """
+            runtime:
+              command: [python, igc_main.py, --help]
+            paths: {}
+            resources: {}
+            """,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+class FakeDocker:
+    """Subprocess stand-in for Docker commands."""
+
+    def __init__(self, inspect_rc=0, pull_rc=0, build_rc=0, push_rc=0):
+        self.inspect_rc = inspect_rc
+        self.pull_rc = pull_rc
+        self.build_rc = build_rc
+        self.push_rc = push_rc
+        self.calls = []
+
+    def run(self, cmd):
+        self.calls.append(cmd)
+        if cmd[:3] == ["docker", "image", "inspect"]:
+            return self.inspect_rc, "", "missing"
+        if cmd[:2] == ["docker", "pull"]:
+            return self.pull_rc, "pulled", "pull failed"
+        if cmd[:2] == ["docker", "build"]:
+            return self.build_rc, "built", "build failed"
+        if cmd[:2] == ["docker", "push"]:
+            return self.push_rc, "pushed", "push failed"
+        return 127, "", f"unexpected command: {cmd}"
+
+
+def test_if_missing_uses_existing_image_without_pull(tmp_path):
+    """An existing image is reused; no pull/build happens."""
+    module = _load_module()
+    runner = FakeDocker(inspect_rc=0)
+    assert module.sync_image(_write_spec(tmp_path), runner=runner) == 0
+    assert runner.calls == [["docker", "image", "inspect", "igc-train:test"]]
+
+
+def test_if_missing_reports_pull_failure(tmp_path, capsys):
+    """A failed pull is reported as a blocker with no build fallback."""
+    module = _load_module()
+    runner = FakeDocker(inspect_rc=1, pull_rc=42)
+    assert module.sync_image(_write_spec(tmp_path), runner=runner) == 1
+    assert "BLOCKER: docker pull failed" in capsys.readouterr().out
+    assert ["docker", "build"] not in [call[:2] for call in runner.calls]
+
+
+def test_docker_command_failure_is_reported(tmp_path, capsys):
+    """Missing daemon/binary style failures still produce a blocker."""
+    module = _load_module()
+    runner = FakeDocker(inspect_rc=127, pull_rc=127)
+    assert module.sync_image(_write_spec(tmp_path), runner=runner) == 1
+    output = capsys.readouterr().out
+    assert "BLOCKER: docker pull failed rc=127" in output
+
+
+def test_build_policy_builds_and_optionally_pushes(tmp_path):
+    """Build policy builds once and pushes only when requested."""
+    module = _load_module()
+    runner = FakeDocker()
+    assert module.sync_image(_write_spec(tmp_path, pull_policy="build"), runner=runner, push=True) == 0
+    assert any(call[:2] == ["docker", "build"] for call in runner.calls)
+    assert any(call[:2] == ["docker", "push"] for call in runner.calls)
+
+
+def test_locked_digest_fails_when_image_is_absent(tmp_path, capsys):
+    """Locked images are inspected, never pulled opportunistically."""
+    module = _load_module()
+    runner = FakeDocker(inspect_rc=1)
+    assert module.sync_image(_write_spec(tmp_path, pull_policy="locked_digest"), runner=runner) == 1
+    assert "BLOCKER: required docker image is not present" in capsys.readouterr().out
+    assert not any(call[:2] == ["docker", "pull"] for call in runner.calls)
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/scripts/test_render_run.py
+++ b/tests/scripts/test_render_run.py
@@ -1,0 +1,106 @@
+"""Offline CLI tests for run rendering and launch refusal.
+
+The command-line wrappers must be safe by default: rendering is allowed, but a
+real Docker or Slurm launch requires an explicit live path added in a later PR.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write_spec(tmp_path, backend="docker"):
+    slurm = """
+      partition: ${IGC_SLURM_PARTITION}
+      output: ${IGC_OUTPUT_DIR}/slurm-%j.out
+    """ if backend == "slurm" else "{}"
+    path = tmp_path / f"{backend}.yaml"
+    path.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            name: {backend}-cli
+            backend: {backend}
+            image:
+              ref: igc-train:test
+              pull_policy: if_missing
+            runtime:
+              command:
+                - python
+                - igc_main.py
+                - --help
+            paths:
+              code: ${{IGC_CODE_DIR}}
+              data: ${{IGC_DATA_DIR}}
+              output: ${{IGC_OUTPUT_DIR}}
+            resources:
+              gpus: 1
+              nodes: 1
+            docker:
+              env_files:
+                - ${{IGC_DOCKER_ENV_FILE}}
+            slurm:
+        """
+        )
+        + textwrap.indent(textwrap.dedent(slurm).strip() + "\n", "      "),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _run(*args):
+    return subprocess.run(
+        [sys.executable, *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_render_run_prints_docker_plan(tmp_path):
+    """The renderer prints a Docker dry-run without touching Docker."""
+    result = _run("scripts/render_run.py", "--spec", str(_write_spec(tmp_path)))
+    assert result.returncode == 0, result.stderr
+    assert "backend: docker" in result.stdout
+    assert "docker run" in result.stdout
+    assert "${IGC_DOCKER_ENV_FILE}" in result.stdout
+
+
+def test_render_run_reports_validation_errors(tmp_path):
+    """Invalid specs fail gracefully with a short spec error."""
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("backend: docker\nunknown: true\n", encoding="utf-8")
+    result = _run("scripts/render_run.py", "--spec", str(bad))
+    assert result.returncode == 2
+    assert "RUN SPEC ERROR:" in result.stderr
+
+
+def test_launch_run_refuses_live_launch_without_dry_run(tmp_path):
+    """The first implementation slice cannot mutate Docker or Slurm."""
+    result = _run("scripts/launch_run.py", "--spec", str(_write_spec(tmp_path)))
+    assert result.returncode == 2
+    assert "refusing live launch" in result.stderr
+
+
+def test_launch_run_dry_run_delegates_to_renderer(tmp_path):
+    """Dry-run launch prints the same safe command plan."""
+    result = _run(
+        "scripts/launch_run.py",
+        "--spec",
+        str(_write_spec(tmp_path, backend="slurm")),
+        "--dry-run",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "backend: slurm" in result.stdout
+    assert "sbatch" in result.stdout
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/scripts/test_slurm_sanity_from_spec.py
+++ b/tests/scripts/test_slurm_sanity_from_spec.py
@@ -1,0 +1,132 @@
+"""Offline tests for the opt-in Slurm sanity checker.
+
+The live checker is exercised with fake runners and temporary log files only.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import importlib.util
+import pathlib
+import textwrap
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "slurm_sanity_from_spec.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("slurm_sanity_from_spec", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_slurm_spec(tmp_path):
+    log_path = tmp_path / "slurm-%j.out"
+    path = tmp_path / "slurm.yaml"
+    path.write_text(
+        textwrap.dedent(
+            f"""
+            version: 1
+            name: slurm-sanity
+            backend: slurm
+            image:
+              ref: igc-train:test
+            runtime:
+              command: [python, igc_main.py, --help]
+            paths:
+              output: {tmp_path}
+            resources:
+              gpus: 1
+              nodes: 1
+            slurm:
+              output: {log_path}
+            sanity:
+              slurm:
+                enabled: true
+                command: "printf IGC_SLURM_SANITY_OK"
+                sentinel: IGC_SLURM_SANITY_OK
+                timeout_seconds: 2
+                poll_seconds: 1
+            """,
+        ),
+        encoding="utf-8",
+    )
+    return path, tmp_path / "slurm-123.out"
+
+
+class FakeRunner:
+    """Tiny subprocess stand-in for Slurm commands."""
+
+    def __init__(self, state, log_path=None, sentinel="IGC_SLURM_SANITY_OK"):
+        self.state = state
+        self.log_path = log_path
+        self.sentinel = sentinel
+        self.calls = []
+
+    def run(self, cmd):
+        self.calls.append(cmd)
+        exe = pathlib.Path(cmd[0]).name
+        if exe == "sbatch":
+            if self.log_path is not None:
+                self.log_path.write_text(f"{self.sentinel}\n", encoding="utf-8")
+            return 0, "123\n", ""
+        if exe == "sacct":
+            return 0, f"{self.state}\n", ""
+        if exe == "scancel":
+            return 0, "", ""
+        return 127, "", f"unexpected command: {cmd}"
+
+
+def test_live_slurm_sanity_passes_when_job_completes_and_log_matches(tmp_path):
+    """COMPLETED plus sentinel log is a pass."""
+    module = _load_module()
+    spec_path, log_path = _write_slurm_spec(tmp_path)
+    runner = FakeRunner("COMPLETED", log_path=log_path)
+    assert module.run_live(spec_path, runner=runner, sleep=lambda _: None) == 0
+    assert any(call[0] == "sbatch" for call in runner.calls)
+
+
+def test_live_slurm_sanity_fails_on_failed_job(tmp_path):
+    """FAILED scheduler state returns a blocker status."""
+    module = _load_module()
+    spec_path, log_path = _write_slurm_spec(tmp_path)
+    runner = FakeRunner("FAILED", log_path=log_path)
+    assert module.run_live(spec_path, runner=runner, sleep=lambda _: None) == 1
+
+
+def test_live_slurm_sanity_reports_sbatch_failure(tmp_path):
+    """A scheduler submission failure is surfaced without polling."""
+    module = _load_module()
+    spec_path, _ = _write_slurm_spec(tmp_path)
+
+    class SbatchFailure(FakeRunner):
+        def run(self, cmd):
+            self.calls.append(cmd)
+            if cmd[0] == "sbatch":
+                return 12, "", "invalid partition"
+            raise AssertionError(f"unexpected poll after sbatch failure: {cmd}")
+
+    assert module.run_live(spec_path, runner=SbatchFailure("COMPLETED"), sleep=lambda _: None) == 1
+
+
+def test_live_slurm_sanity_fails_when_log_is_missing(tmp_path):
+    """A completed job without its expected log is not trusted."""
+    module = _load_module()
+    spec_path, _ = _write_slurm_spec(tmp_path)
+    runner = FakeRunner("COMPLETED", log_path=None)
+    assert module.run_live(spec_path, runner=runner, sleep=lambda _: None) == 1
+
+
+def test_live_slurm_sanity_times_out_without_hammering(tmp_path):
+    """Polling stops at the timeout and uses the configured interval."""
+    module = _load_module()
+    spec_path, log_path = _write_slurm_spec(tmp_path)
+    runner = FakeRunner("RUNNING", log_path=log_path)
+    sleeps = []
+    assert module.run_live(spec_path, runner=runner, sleep=sleeps.append, now=iter([0, 1, 3]).__next__) == 1
+    assert sleeps == [1, 1]
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/shared/test_run_spec.py
+++ b/tests/shared/test_run_spec.py
@@ -1,0 +1,284 @@
+"""Offline tests for the spec-driven run launcher contract.
+
+These tests pin the pure, non-mutating part of the run orchestration path:
+YAML parsing, validation, redaction, and command rendering. They never call
+Docker, Slurm, a GPU, a private endpoint, or a gitignored env file.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import textwrap
+
+import pytest
+
+from igc.shared.run_spec import (
+    RunSpecError,
+    load_run_spec,
+    redact_value,
+    render_docker_plan,
+    render_slurm_plan,
+)
+
+
+def _write_spec(tmp_path, body: str):
+    path = tmp_path / "run.yaml"
+    path.write_text(textwrap.dedent(body), encoding="utf-8")
+    return path
+
+
+def _docker_spec(tmp_path):
+    return _write_spec(
+        tmp_path,
+        """
+        version: 1
+        name: docker-smoke
+        backend: docker
+        image:
+          ref: igc-train:test
+          pull_policy: if_missing
+        runtime:
+          command:
+            - python
+            - igc_main.py
+            - --help
+          env:
+            WANDB_PROJECT: igc
+            WANDB_API_KEY: ${WANDB_API_KEY}
+        paths:
+          code: ${IGC_CODE_DIR}
+          data: ${IGC_DATA_DIR}
+          output: ${IGC_OUTPUT_DIR}
+        resources:
+          gpus: 4
+        docker:
+          env_files:
+            - ${IGC_DOCKER_ENV_FILE}
+          mounts:
+            - source: ${IGC_CODE_DIR}
+              target: /workspace/igc
+            - source: ${IGC_DATA_DIR}
+              target: /root/.json_responses
+              read_only: true
+        sanity:
+          dry_run: true
+        """,
+    )
+
+
+def _slurm_spec(tmp_path):
+    return _write_spec(
+        tmp_path,
+        """
+        version: 1
+        name: slurm-smoke
+        backend: slurm
+        image:
+          ref: igc-train:test
+          pull_policy: if_missing
+        runtime:
+          command:
+            - python
+            - igc_main.py
+            - --help
+        paths:
+          code: ${IGC_CODE_DIR}
+          data: ${IGC_DATA_DIR}
+          output: ${IGC_OUTPUT_DIR}
+        resources:
+          gpus: 4
+          nodes: 15
+          cpus_per_task: 16
+          wall_time: "00:10:00"
+        slurm:
+          partition: ${IGC_SLURM_PARTITION}
+          account: ${IGC_SLURM_ACCOUNT}
+          output: ${IGC_OUTPUT_DIR}/slurm-%j.out
+          extra_args:
+            - --exclusive
+        sanity:
+          slurm:
+            enabled: true
+            sentinel: IGC_SLURM_SANITY_OK
+            poll_seconds: 5
+            timeout_seconds: 120
+        """,
+    )
+
+
+def test_load_docker_spec_preserves_private_env_file_placeholder(tmp_path):
+    """Docker env files are referenced but never read by the parser."""
+    spec = load_run_spec(_docker_spec(tmp_path))
+    assert spec.backend == "docker"
+    assert spec.docker["env_files"] == ["${IGC_DOCKER_ENV_FILE}"]
+    assert spec.resources["gpus"] == 4
+
+
+def test_unknown_top_level_key_is_rejected(tmp_path):
+    """Unknown keys fail early so misspelled knobs do not silently noop."""
+    path = _write_spec(
+        tmp_path,
+        """
+        version: 1
+        name: bad
+        backend: docker
+        image: {ref: igc:test}
+        runtime: {command: [python, --version]}
+        paths: {}
+        resources: {}
+        typo_key: nope
+        """,
+    )
+    with pytest.raises(RunSpecError, match="unknown top-level keys"):
+        load_run_spec(path)
+
+
+def test_literal_secret_value_is_rejected(tmp_path):
+    """Secret-looking env names must use runtime placeholders, not literals."""
+    path = _write_spec(
+        tmp_path,
+        """
+        version: 1
+        name: bad-secret
+        backend: docker
+        image: {ref: igc:test}
+        runtime:
+          command: [python, --version]
+          env:
+            WANDB_API_KEY: plain-text-token
+        paths: {}
+        resources: {}
+        """,
+    )
+    with pytest.raises(RunSpecError, match="WANDB_API_KEY"):
+        load_run_spec(path)
+
+
+def test_unsupported_backend_is_rejected(tmp_path):
+    """Backend selection is explicit and closed over docker/slurm."""
+    path = _write_spec(
+        tmp_path,
+        """
+        version: 1
+        name: bad-backend
+        backend: local
+        image: {ref: igc:test}
+        runtime: {command: [python, --version]}
+        paths: {}
+        resources: {}
+        """,
+    )
+    with pytest.raises(RunSpecError, match="backend"):
+        load_run_spec(path)
+
+
+def test_dangerous_image_ref_is_rejected(tmp_path):
+    """Image refs are names, not shell snippets."""
+    path = _write_spec(
+        tmp_path,
+        """
+        version: 1
+        name: bad-image
+        backend: docker
+        image: {ref: "igc:latest; echo bad"}
+        runtime: {command: [python, --version]}
+        paths: {}
+        resources: {}
+        """,
+    )
+    with pytest.raises(RunSpecError, match="image.ref"):
+        load_run_spec(path)
+
+
+def test_dangerous_docker_env_file_is_rejected(tmp_path):
+    """Docker env-file entries may be placeholders, but not shell snippets."""
+    path = _write_spec(
+        tmp_path,
+        """
+        version: 1
+        name: bad-env-file
+        backend: docker
+        image: {ref: igc:test}
+        runtime: {command: [python, --version]}
+        paths: {}
+        resources: {}
+        docker:
+          env_files:
+            - "$(cat secret)"
+        """,
+    )
+    with pytest.raises(RunSpecError, match="docker.env_files"):
+        load_run_spec(path)
+
+
+def test_dangerous_runtime_command_is_rejected(tmp_path):
+    """Runtime command entries are argv tokens, not shell snippets."""
+    path = _write_spec(
+        tmp_path,
+        """
+        version: 1
+        name: bad-command
+        backend: slurm
+        image: {ref: igc:test}
+        runtime: {command: [echo, "$(whoami)"]}
+        paths: {}
+        resources: {}
+        """,
+    )
+    with pytest.raises(RunSpecError, match="runtime.command"):
+        load_run_spec(path)
+
+
+def test_dangerous_slurm_sanity_command_is_rejected(tmp_path):
+    """The scheduler sanity command is tiny and must not be a shell program."""
+    path = _write_spec(
+        tmp_path,
+        """
+        version: 1
+        name: bad-sanity
+        backend: slurm
+        image: {ref: igc:test}
+        runtime: {command: [python, --version]}
+        paths: {}
+        resources: {}
+        sanity:
+          slurm:
+            enabled: true
+            command: "printf ok; scancel all"
+        """,
+    )
+    with pytest.raises(RunSpecError, match="sanity.slurm.command"):
+        load_run_spec(path)
+
+
+def test_redact_value_hides_secret_like_content():
+    """Dry-run renderers redact secret-like values before display."""
+    assert redact_value("WANDB_API_KEY", "plain-text") == "<redacted>"
+    assert redact_value("WANDB_PROJECT", "igc") == "igc"
+    assert redact_value("WANDB_API_KEY", "${WANDB_API_KEY}") == "${WANDB_API_KEY}"
+
+
+def test_docker_render_reuses_or_pulls_image_without_build(tmp_path):
+    """if_missing policy inspects first, then pulls, and never builds."""
+    spec = load_run_spec(_docker_spec(tmp_path))
+    rendered = render_docker_plan(spec)
+    assert "docker image inspect igc-train:test" in rendered
+    assert "docker pull igc-train:test" in rendered
+    assert "docker build" not in rendered
+    assert "--env-file ${IGC_DOCKER_ENV_FILE}" in rendered
+    assert "-e WANDB_API_KEY" in rendered
+    assert "plain-text-token" not in rendered
+
+
+def test_slurm_render_scales_resources_from_spec(tmp_path):
+    """Large GPU counts come from the spec, not hardcoded launcher defaults."""
+    spec = load_run_spec(_slurm_spec(tmp_path))
+    rendered = render_slurm_plan(spec)
+    assert "--nodes=15" in rendered
+    assert "--gres=gpu:4" in rendered
+    assert "--cpus-per-task=16" in rendered
+    assert "--time=00:10:00" in rendered
+    assert "--exclusive" in rendered
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
## Summary

- Add a public run-spec loader/validator for Docker and Slurm launch specs.
- Add dry-run renderers and safe wrappers: `render_run.py`, `launch_run.py`, `docker_image_sync.py`, and `slurm_sanity_from_spec.py`.
- Add public-safe example specs under `configs/run/examples/` and a schema sketch under `configs/run/schema.yaml`.
- Add pytest and Bats coverage for spec validation, command rendering, live-launch refusal, Docker pull/build/push decisions, Docker failure blockers, Slurm submission failure, failed jobs, timeouts, missing logs, and shell-injection rejection.
- Wire CI to run the dry-run renderers before the existing repo-wide lint step.

## Safety

- Default path is offline/dry-run only.
- `launch_run.py` refuses live launch without `--dry-run` in this slice.
- Docker env files are referenced only by placeholder, never read by tests or renderers.
- Slurm sanity live mode is opt-in and submits only the tiny configured sentinel job.
- No private hosts, endpoints, credentials, captured payloads, or internal env-file contents are committed.

## Validation

- `pytest -q tests/shared/test_run_spec.py tests/scripts/test_render_run.py tests/scripts/test_slurm_sanity_from_spec.py tests/scripts/test_docker_image_sync.py tests/core` -> 68 passed
- `bats tests/bats` -> 14 passed
- `ruff check` on changed Python files plus `igc/core tests/core` -> all checks passed
- `shellcheck scripts/*.sh scripts/*.sbatch tests/bats/*.bats`
- `bash -n scripts/*.sh scripts/*.sbatch tests/bats/*.bats`
- `actionlint .github/workflows/ci.yml`
- `python -m py_compile` on changed Python files
- dry-run examples for Docker, Slurm, Docker image sync, and Slurm sanity
- `git diff --check`

## Note

The repository still has the previously documented whole-repo CI lint debt. This PR keeps changed-file ruff clean and places the new dry-run CI step before that lint gate so the launcher checks still execute.