### PR TITLE
Gather eval metric across ranks to fix the epoch-boundary NCCL hang

### DIFF
--- a/igc/modules/llm_train_state_encoder.py
+++ b/igc/modules/llm_train_state_encoder.py
@@ -348,6 +348,17 @@ class LlmEmbeddingsTrainer(LlmModule):
                 correct_predictions += compute_accuracy * batch_size
                 total_predictions += batch_size
 
+        # Global metric: each rank validates only its own eval shard, so a rank-LOCAL accuracy makes
+        # ranks disagree on "best" and enter the epoch-boundary save collective asymmetrically — the
+        # observed epoch-8 _ALLGATHER_BASE NCCL watchdog hang. Reduce the counts so EVERY rank
+        # computes the SAME global accuracy (accelerate's reduce is an all-reduce: sum lands on all).
+        if self.is_accelerator:
+            stats = torch.tensor(
+                [float(correct_predictions), float(total_predictions)],
+                dtype=torch.float64, device=self.device)
+            stats = self.accelerator.reduce(stats, reduction="sum")
+            correct_predictions, total_predictions = stats[0].item(), stats[1].item()
+
         # Guard: with drop_last + a small eval shard a rank can get 0 eval batches; a
         # bare division would crash (and take the fleet down mid-epoch) — return 0.0.
         accuracy = (correct_predictions / total_predictions * 100.0) if total_predictions else 0.0
@@ -745,9 +756,13 @@ class LlmEmbeddingsTrainer(LlmModule):
                 should_save = broadcast_flag(self.accelerator, should_save)
                 if should_save:
                     gathered_state = self.accelerator.get_state_dict(self.model)
+            # Every rank tracks the SAME best now that validation_accuracy is a global metric, so
+            # is_best_accuracy is computed identically across ranks next epoch and no rank diverges
+            # into the save collective alone (the _ALLGATHER_BASE hang). Update on improvement only.
+            if is_best_accuracy:
+                self._best_validation_metric = validation_accuracy
             if self.is_rank_zero():
                 if should_save:
-                    self._best_validation_metric = validation_accuracy
                     if self._module_checkpoint_dir is not None:
                         if self.is_accelerator:
                             model = self.accelerator.unwrap_model(self.model)

--- a/tests/modules/test_eval_metric_gather.py
+++ b/tests/modules/test_eval_metric_gather.py
@@ -1,0 +1,49 @@
+"""
+Regression guard for the distributed eval-metric gather fix.
+
+A 4-GPU FSDP run hung at ~epoch 8 on an ``_ALLGATHER_BASE`` NCCL collective (600s watchdog): each
+rank validated only its own eval shard, so ``validate()`` returned a RANK-LOCAL accuracy, the ranks
+disagreed on the "best" metric, and they entered the epoch-boundary save collective asymmetrically.
+The fix all-reduces the eval counts so every rank computes the SAME global accuracy, and tracks the
+best on every rank (not only rank 0). These source-inspection guards mirror the existing
+``test_dist_batch_invariant`` pattern — they keep the fix from silently regressing without needing a
+multi-GPU box in the offline gate.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import inspect
+
+from igc.modules.llm_train_state_encoder import LlmEmbeddingsTrainer
+
+
+def test_validate_all_reduces_the_metric():
+    """validate() must all-reduce the eval counts so accuracy is a single global value."""
+    src = inspect.getsource(LlmEmbeddingsTrainer.validate)
+    assert "accelerator.reduce" in src, (
+        "validate() must reduce (correct, total) across ranks so every rank computes the same "
+        "global accuracy; a rank-local accuracy makes ranks disagree on 'best' and deadlock the save."
+    )
+
+
+def test_best_metric_tracked_on_all_ranks_not_only_rank_zero():
+    """The best-metric update must run on ALL ranks (gated on is_best_accuracy), not under is_rank_zero.
+
+    If only rank 0 tracks the best, the non-zero ranks keep -inf, compute is_best_accuracy
+    differently, and enter the save collective asymmetrically -> the _ALLGATHER_BASE hang.
+    """
+    src = inspect.getsource(LlmEmbeddingsTrainer)
+    assert src.count("self._best_validation_metric = validation_accuracy") == 1, (
+        "expected exactly one best-metric assignment (the rank-0-only one was removed)"
+    )
+    idx = src.index("self._best_validation_metric = validation_accuracy")
+    preceding = src[:idx]
+    assert preceding.rfind("if is_best_accuracy:") > preceding.rfind("if self.is_rank_zero()"), (
+        "the best-metric update must be gated on is_best_accuracy on every rank, i.e. BEFORE / "
+        "outside the is_rank_zero() block, so all ranks agree on 'best'."
+    )
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
## What
A live 4-GPU FSDP run hung at ~epoch 8 on an `_ALLGATHER_BASE` collective (600s NCCL watchdog → abort). Root cause: `validate()` returned a **rank-local** accuracy (each rank validates only its own eval shard) and only rank 0 updated `_best_validation_metric`. So the ranks disagreed on the "best" metric, computed `is_best_accuracy` differently, and entered the epoch-boundary save collective asymmetrically → deadlock.

## Fix
- `validate()` now all-reduces `(correct, total)` so every rank computes the **same global accuracy**.
- The best-metric update runs on **every rank** (gated on `is_best_accuracy`), not only under `is_rank_zero()`, so the save decision is uniform.

## Verification
- `ruff` clean on touched files.
- Offline gate: `tests/modules/test_eval_metric_gather.py` (2 new source-inspection guards, matching the existing `test_dist_batch_invariant` pattern) + the existing dist tests — **9 passed**.
- Real multi-GPU re-run is the final verification (the hang only reproduces distributed); this lands the fix the audit + the live traceback both point to.

Found via a grounded GB300 code audit; this is the correctness blocker for multi-node training.