### PR TITLE
Add RL scaling safety plan

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,8 @@ Reinforce Learner).
   its own uplink (never the VPN), git-lfs without OS changes, and the Docker Hub image flow.
 - [RUN_ORCHESTRATION_PLAN.md](RUN_ORCHESTRATION_PLAN.md) — the spec-driven Docker and Slurm
   launcher automation roadmap: image reuse, storage, checkpoints, dry-runs, sanity checks, and CI.
+- [RL_SCALING_PLAN.md](RL_SCALING_PLAN.md) — RL scaling plan: DQN/HER safety,
+  rollout/learner split, freshness, batching, parity, and profiling gates.
 - [TRAINING_OPTIMIZATION_PLAN.md](TRAINING_OPTIMIZATION_PLAN.md) — the large-model training,
   optimization, and GPU-efficiency roadmap for 3B/7B state-encoder work.
 

--- a/docs/RL_SCALING_PLAN.md
+++ b/docs/RL_SCALING_PLAN.md
@@ -1,0 +1,275 @@
+# RL Scaling Plan
+
+This plan keeps the RL phase honest before it grows from the current offline
+DQN/HER shell into a high-throughput rollout and learner system. It is
+public-safe: no private hosts, credentials, internal endpoints, captured
+payloads, or operator-only workflow details belong here.
+
+The current code path is still value-based DQN/HER over the vectorized REST
+mock environment. Future LLM-rollout or policy-gradient modes are planned
+architecture, not implemented training evidence.
+
+## State And Goal Graph Anchor
+
+The compact state and goal graph plan already lives in
+[ARCHITECTURE.md](ARCHITECTURE.md). Its `RedfishStateV0` contract describes a
+structured state with resource identity, topology, health/control fields, legal
+actions, deferred state, observation metadata, and goal context.
+
+The action-candidate graph feature decision lives in
+[DECISIONS.md](DECISIONS.md). The v1 scope uses text plus graph features for
+candidate actions; learned graph-neighborhood embeddings are deferred until the
+structured state and offline evaluation contracts are stable.
+
+This RL scaling plan assumes those state and goal graph contracts are the input
+surface. It does not replace them.
+
+## Current Safety Finding
+
+The first blocker is a current DQN/HER correctness issue, independent of any
+future distributed design.
+
+`IgcAgentTrainer.train_goal`, defined in `igc/modules/igc_train_agent.py`,
+receives `terminated` and `truncated` from `VectorizedRestApiEnv.step`, defined
+in `igc/envs/rest_gym_batch_env.py`, but does not store those flags in
+`episode_experience`. Later, `update_replay_buffer` reconstructs the terminal
+mask as:
+
+```text
+done = rewards >= 1.0
+```
+
+That is correct only for success terminals. A negative terminal, such as a
+dead-end server error with reward `-0.5`, is sampled back as `done=0` and
+therefore bootstraps through `next_q`. The correct one-step target for a true
+terminal is:
+
+```text
+target = reward
+```
+
+not:
+
+```text
+target = reward + gamma * max_a Q_target(next_state, a)
+```
+
+This is an engine-lane fix because it changes the trainer/replay tuple contract.
+The docs/tests lane pins it with an offline strict-xfail contract until the
+engine owner updates the rollout record shape.
+
+## DQN/HER Safety Contracts
+
+Before scaling RL, the current value-learning path needs these contracts green:
+
+- Negative terminals preserve `done=True`.
+  Dead ends must not bootstrap just because their reward is below success.
+  Current status: strict xfail.
+- Truncation is separate from termination.
+  Time limits may bootstrap; true terminals may not.
+  Current status: partially covered.
+- Zero legal actions are terminal dead ends.
+  Pointer/candidate mode can produce no legal candidates.
+  Current status: strict xfail.
+- Non-finite Q-values fail fast.
+  NaN/+inf should not be silently treated as a terminal.
+  Current status: strict xfail.
+- Reward/done shapes are rank-1 `[B]`.
+  This avoids accidental broadcast to `[B, B]` targets.
+  Current status: strict xfail.
+- `done` is binary.
+  Values outside `{0, 1}` invert or scale the bootstrap term.
+  Current status: strict xfail.
+- Partial-done vector env rows preserve batch axes.
+  Batched rollout accounting must keep one row per sub-env.
+  Current status: strict xfail.
+
+Promotion rule: do not treat DQN/HER curves as trustworthy until these contracts
+are passing or explicitly waived in a design review.
+
+## Scaling Principles
+
+The RL phase should scale by producing more useful trajectories, not by making
+one enormous policy replica.
+
+1. Use many rollout replicas with modest tensor parallelism, not one 72-GPU
+   rollout engine.
+2. Keep learner and rollout engines separable when throughput is the priority.
+3. Bound queues by items, tokens, bytes, age, and policy-version lag.
+4. Synchronize fresh weights through a fast broadcast/refit path, not checkpoint
+   files in the hot loop.
+5. Batch variable-length records by token budget, not trajectory count.
+6. Keep every grouped policy update homogeneous by policy version and tokenizer
+   identity.
+7. Use the same tokenizer, chat template, EOS handling, padding, generation
+   config, and attention masks on rollout and learner paths.
+8. Recompute and compare rollout logprobs against the learner before trusting a
+   policy-gradient loss.
+9. Scale dispatchers per node or per shard; do not let one Python or HTTP
+   front end feed every rollout replica.
+10. Profile one full learner/rollout/reward/update cycle before scaling to 4,
+    8, or 72 GPUs.
+
+## Target Architecture
+
+The future architecture has four independent loops with explicit contracts:
+
+- Rollout workers generate trajectories from the current policy against
+  replayable simulators or approved gated environments.
+  Required contract: stamp every record with policy version, tokenizer
+  fingerprint, generation config, env id, seed, token count, and created learner
+  step.
+- The bounded queue buffers fresh trajectory records between rollout and
+  learner.
+  Required contract: enforce max items/tokens/bytes, max age, max
+  policy-version lag, and deterministic drop/backpressure policy.
+- The learner consumes fresh records, recomputes logprobs or Q-targets, updates
+  weights, and publishes a new policy version.
+  Required contract: reject records whose version, tokenizer identity, masks, or
+  prompt group membership are incompatible with the update.
+- The weight publisher moves updated weights to rollout workers.
+  Required contract: use a measured fast path such as NCCL broadcast or runtime
+  refit when available; checkpoint files are for persistence/resume, not
+  hot-loop sync.
+
+For the current DQN/HER path, the same shape applies with Q-learning records:
+`policy_version` and `created_step` still matter for freshness, even if replay
+is intentionally off-policy.
+
+For a future grouped policy-gradient path, prompt groups must be homogeneous:
+
+```text
+same policy_version
+same tokenizer_fingerprint
+same chat_template_hash
+same generation_config_hash
+same prompt_group_id
+```
+
+Mixed groups are rejected before loss computation.
+
+## Data Model Concepts
+
+These are planned contracts. They are not claims that the implementation exists
+today.
+
+```text
+RolloutRecord
+  env_id
+  trajectory_id
+  step_index
+  policy_version
+  created_learner_step
+  tokenizer_fingerprint
+  chat_template_hash
+  generation_config_hash
+  prompt_group_id
+  input_ids
+  attention_mask
+  eos_token_id
+  action
+  reward
+  terminated
+  truncated
+  logprob
+  token_count
+```
+
+For DQN/HER, `logprob` may be absent and the required fields are state/action/
+reward/next-state plus terminal metadata. For policy-gradient modes, `logprob`
+and token/mask fields are mandatory.
+
+## Offline Test Plan
+
+The first implementation slice should stay local and deterministic.
+
+- Negative terminal replay mask:
+  a reward `-0.5`, `terminated=True`, `truncated=False` record samples back as
+  `done=1` and targets `reward`.
+- Zero-candidate target:
+  `next_q` with width zero returns `reward`, finite, with no bootstrap.
+- Non-finite target guard:
+  NaN/+inf next-Q values raise a clear error; only all `-inf` masked rows become
+  terminal.
+- Shape guard:
+  `reward`, `done`, and `next_q` batch dimensions are validated before
+  arithmetic.
+- Partial-done vector env:
+  done sub-env rows keep observation/reward/flag axes aligned with `num_envs`.
+- Freshness queue:
+  old records are dropped or excluded by max age and max policy-version lag.
+- Token batch planner:
+  variable-length records pack by total tokens and reject or isolate oversized
+  records deterministically.
+- Prompt-group integrity:
+  mixed policy versions or tokenizer fingerprints are rejected before learner
+  update.
+- Logprob parity:
+  a tiny deterministic model produces matching rollout and learner logprobs
+  over identical tokens and masks.
+
+The first five tests pin current DQN/HER safety. The remaining tests define the
+future rollout/learner boundary and should land with the modules they exercise.
+
+## Profiling Gates
+
+Scaling starts only after one complete cycle is measured:
+
+```text
+reset environment
+roll out actions
+encode observations
+compute reward/evaluator signal
+enqueue records
+sample learner batch
+compute target or logprob loss
+backward + optimizer step
+publish new policy version
+```
+
+The report must include:
+
+```text
+transitions/sec
+tokens/sec where tokens exist
+env step p50/p95
+encoder p50/p95
+mock or simulator dispatch p50/p95
+queue depth p50/p95/max
+record age p50/p95/max
+policy-version lag p50/p95/max
+learner samples/sec
+H2D/D2H transfer time
+peak memory
+per-rank skew
+```
+
+Only after the one-cycle profile is understood should runs expand to 4 GPUs,
+then 8 GPUs, and then the full fleet.
+
+## Execution Order
+
+1. Pin current DQN/HER safety with strict-xfail offline tests.
+2. Fix the trainer/replay terminal-mask contract in the engine lane.
+3. Turn negative-terminal, zero-candidate, shape, non-finite, and partial-done
+   xfails into passing tests.
+4. Add rollout profiler JSON summaries to the existing RL sanity/profiling
+   scripts.
+5. Add replay freshness metadata and bounded-queue tests.
+6. Add token-count batch planner tests and implementation.
+7. Add tokenizer/config identity and logprob parity contracts if an LLM rollout
+   learner is introduced.
+8. Run one complete 1-GPU cycle profile.
+9. Run 4-GPU and 8-GPU profiles only if the 1-GPU cycle is balanced.
+10. Scale farther only with measured queue freshness, per-rank skew, and
+    learner/rollout utilization.
+
+## Non-Goals
+
+- Do not refactor the engine in this documentation slice.
+- Do not run a live Redfish crawl, GPU job, or distributed training job as part
+  of the default tests.
+- Do not claim policy convergence or scaling efficiency without a logged command
+  and metric artifact.
+- Do not make simulator-only success a substitute for held-out replay or live
+  approval-gated validation.

--- a/tests/modules/test_q_targets.py
+++ b/tests/modules/test_q_targets.py
@@ -94,6 +94,49 @@ def test_q_learning_target_accepts_bool_done_mask():
     torch.testing.assert_close(target, torch.tensor([1.25, 0.5], dtype=torch.float64))
 
 
+@pytest.mark.xfail(
+    reason="q_learning_target does not yet reject non-finite next_q rows except all -inf masks.",
+    strict=True,
+)
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf")])
+def test_q_learning_target_rejects_non_finite_next_q_values(bad_value):
+    """NaN/+inf Q-values should fail fast instead of being treated as dead ends."""
+    reward = torch.tensor([0.0])
+    done = torch.tensor([0.0])
+    next_q = torch.tensor([[bad_value, 1.0]])
+
+    with pytest.raises(ValueError, match="non-finite"):
+        q_learning_target(reward, done, next_q, gamma=0.99)
+
+
+@pytest.mark.xfail(
+    reason="q_learning_target does not yet validate reward/done rank against next_q batch.",
+    strict=True,
+)
+def test_q_learning_target_rejects_reward_done_shape_mismatch():
+    """Reward/done must be rank-1 [B], avoiding accidental [B, B] broadcasts."""
+    reward = torch.ones(2, 1)
+    done = torch.zeros(2, 1)
+    next_q = torch.ones(2, 3)
+
+    with pytest.raises(ValueError, match="shape"):
+        q_learning_target(reward, done, next_q, gamma=0.99)
+
+
+@pytest.mark.xfail(
+    reason="q_learning_target does not yet validate done as a binary terminal mask.",
+    strict=True,
+)
+def test_q_learning_target_rejects_non_binary_done_values():
+    """Done values outside {0, 1} can invert the bootstrap term and must be rejected."""
+    reward = torch.tensor([0.0])
+    done = torch.tensor([2.0])
+    next_q = torch.tensor([[3.0, 4.0]])
+
+    with pytest.raises(ValueError, match="done"):
+        q_learning_target(reward, done, next_q, gamma=0.99)
+
+
 def _reward_match(state, goal):
     """Toy env reward: 1.0 where state equals goal elementwise, else 0.0 (shape [B])."""
     return torch.all(state == goal, dim=1).to(torch.float32)

--- a/tests/modules/test_train_goal_termination.py
+++ b/tests/modules/test_train_goal_termination.py
@@ -11,7 +11,9 @@ Author:
 Mus mbayramo@stanford.edu
 """
 import torch
+import pytest
 
+from igc.modules.rl.q_targets import q_learning_target
 from igc.modules.igc_train_agent import IgcAgentTrainer
 
 
@@ -56,6 +58,21 @@ class _FakeDataset:
         return None, None, torch.zeros(num_envs, self._api_dim)
 
 
+class _DeadEndTerminalEnv(_FakeEnv):
+    """Single-env stub: first step is a negative terminal dead end."""
+
+    def __init__(self, state_dim: int):
+        super().__init__(state_dim=state_dim, done_after=1)
+
+    def step(self, _action):
+        self.step_calls += 1
+        terminated = torch.tensor([True])
+        truncated = torch.tensor([False])
+        rewards = torch.tensor([-0.5])
+        info = [{"goal_reached": torch.tensor(False)}]
+        return self._state.clone(), rewards, terminated, truncated, info
+
+
 def _make_trainer(state_dim: int, max_episode_len: int, done_after: int):
     """Build a trainer with train_goal's dependencies stubbed (bypasses __init__)."""
     trainer = IgcAgentTrainer.__new__(IgcAgentTrainer)
@@ -85,6 +102,37 @@ def test_rollout_truncates_at_max_episode_len():
     trainer = _make_trainer(state_dim=4, max_episode_len=5, done_after=999)
     trainer.train_goal(epsilon=1.0)
     assert trainer.env.step_calls == 5
+
+
+@pytest.mark.xfail(
+    reason=(
+        "IgcAgentTrainer.train_goal drops terminated/truncated flags, so "
+        "update_replay_buffer rebuilds done from reward >= 1.0 and bootstraps "
+        "through negative terminal dead ends."
+    ),
+    strict=True,
+)
+def test_negative_terminal_mask_survives_rollout_for_replay():
+    """A negative terminal must be stored as done=True, not inferred from reward."""
+    trainer = IgcAgentTrainer.__new__(IgcAgentTrainer)
+    trainer.env = _DeadEndTerminalEnv(state_dim=4)
+    trainer.dataset = _FakeDataset(api_dim=3)
+    trainer.current_goal = {"state": torch.zeros(1, 4)}
+    trainer.max_episode_len = 10
+
+    episode, _, _ = trainer.train_goal(epsilon=1.0)
+    _, _, reward, _, _, terminated, truncated = episode[0]
+
+    assert reward.tolist() == [-0.5]
+    assert terminated.tolist() == [True]
+    assert truncated.tolist() == [False]
+    target = q_learning_target(
+        reward,
+        terminated.to(reward.dtype),
+        next_q=torch.tensor([[10.0]]),
+        gamma=0.9,
+    )
+    torch.testing.assert_close(target, reward)
 
 
 # Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
## Summary

- Add `docs/RL_SCALING_PLAN.md` for the RL rollout/learner scaling plan.
- Capture the current DQN/HER terminal-mask bug as a documented engine-lane blocker.
- Add strict-xfail offline contracts for negative terminal replay masks and q-target guardrails.
- Link the new RL scaling plan from `docs/README.md`.

## Verification

- `PYTHONPATH=/Users/spyroot/dev/igc KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1 /Users/spyroot/miniconda3/condabin/conda run -n igc-dev pytest -q tests/modules/test_q_targets.py tests/modules/test_train_goal_termination.py tests/envs/test_rest_gym_batch_env_boundary.py` -> `16 passed, 7 xfailed`
- `PYTHONPATH=/Users/spyroot/dev/igc /Users/spyroot/miniconda3/condabin/conda run -n igc-dev ruff check tests/modules/test_q_targets.py tests/modules/test_train_goal_termination.py` -> `All checks passed!`
- `git diff --check docs/README.md docs/RL_SCALING_PLAN.md tests/modules/test_q_targets.py tests/modules/test_train_goal_termination.py` -> clean
- `markdownlint-cli2 docs/RL_SCALING_PLAN.md` -> `0 error(s)`

## Notes

This PR does not refactor `igc/**` engine code. The trainer/replay tuple fix stays in the engine-owner lane; these tests pin the expected behavior until that work lands.