### PR TITLE
Spell out D-001/D-002 in the candidate/graph docstrings for humans

### DIFF
--- a/igc/ds/sources/candidate_features.py
+++ b/igc/ds/sources/candidate_features.py
@@ -1,6 +1,14 @@
 """
 D-002 v1 action-candidate featurizer with a static per-host cache.
 
+In plain terms: a *candidate* is one action the agent could take next — a single
+(endpoint URL, HTTP method) pair. "D-002" is Decision 002 in ``docs/DECISIONS.md`` (the
+action-candidate representation decision); it chose to describe each candidate not by its raw
+URL text alone but by **text + graph features** (path tokens, HTTP method, resource type, the
+child-relation name it is reached by, and whether it exposes an invokable action), so the
+policy can rank *which API call to make next*. This module turns every node of the walked
+Redfish graph into that feature dict.
+
 Used by ``scripts/bench_hot_paths.py`` (the candidate-cache benchmark stage), feeding
 ``igc/modules/eval/zero_shot_ranking.py``. The candidate dict emitted here is a schema
 contract with that ranker's ``candidate_text`` / ``embed_candidates`` — renaming a field

--- a/igc/ds/sources/resource_graph.py
+++ b/igc/ds/sources/resource_graph.py
@@ -1,6 +1,12 @@
 """
 Redfish resource graph built from provenance-tagged capture records (D-002).
 
+"D-002" is Decision 002 in ``docs/DECISIONS.md`` (the action-candidate representation). This
+graph is the map of one host's REST surface: nodes are the resources the crawler walked, edges
+are the ways to get from one resource to another (URL containment, ``@odata.id`` links, and
+invokable action targets). It answers "from where the agent is now, what can it reach next?" —
+which is exactly the set of candidate actions the policy has to choose among.
+
 Builds the typed resource graph the D-002 candidate representation needs: nodes are walked
 resources, edges are URL-prefix containment plus ``@odata.id`` references harvested from the
 WHOLE body — the corpus census showed explicit ``Links`` sections cover only 10-14% of real

--- a/igc/modules/eval/zero_shot_ranking.py
+++ b/igc/modules/eval/zero_shot_ranking.py
@@ -1,6 +1,12 @@
 """
 D-001/D-002 zero-shot go/no-go representation check.
 
+Names, for a human: "D-001" (Decision 001 in ``docs/DECISIONS.md``) is the plan to SELECT an
+action by ranking candidates with a pointer network and taking the top one; "D-002" is how
+those candidates are REPRESENTED (text + graph features). This module is the cheap feasibility
+test for both — with NO training, can a plain text-similarity ranker already put a resource's
+true next-hops in the top-5? If yes, the learned ranker is worth building.
+
 Deterministic zero-shot ranking of legal action candidates with a frozen character-trigram
 text encoder: for each resource (state) in a walked Redfish tree, all host candidates are
 ranked by similarity to the state text, and the module measures whether the state's TRUE


### PR DESCRIPTION
The graph/candidate/ranking modules used the codes 'D-001'/'D-002' without explaining them. Adds a plain-language sentence on first mention in each: **D-002** = how a *candidate action* (one `(endpoint, HTTP method)` the agent could call next) is represented (text + graph features); **D-001** = selecting one by ranking candidates with a pointer network. Docstring-only — no logic change; imports + ruff clean.