### PR TITLE
Explain purpose/problem of the graph+candidate modules in plain language

### DIFF
--- a/igc/ds/sources/candidate_features.py
+++ b/igc/ds/sources/candidate_features.py
@@ -9,6 +9,15 @@ child-relation name it is reached by, and whether it exposes an invokable action
 policy can rank *which API call to make next*. This module turns every node of the walked
 Redfish graph into that feature dict.
 
+The problem it solves: a Redfish host exposes hundreds of endpoints and the RIGHT next call depends
+on where the agent is. Comparing raw URL strings is too weak — URLs look alike and a model cannot
+tell a power-reset action from a log page. Describing each candidate by *what it structurally is*
+(its type, the relation it is reached by, whether it is an invokable action) is what lets one policy
+generalize ACROSS vendors: a "power-on" action has the same shape on Dell and HPE even when the URL
+differs. Without it the agent is stuck with a flat, fixed action list that neither generalizes nor
+adapts to the per-resource legal set. Who needs it: the ranker (the feasibility check today, the
+pointer policy once wired).
+
 Used by ``scripts/bench_hot_paths.py`` (the candidate-cache benchmark stage), feeding
 ``igc/modules/eval/zero_shot_ranking.py``. The candidate dict emitted here is a schema
 contract with that ranker's ``candidate_text`` / ``embed_candidates`` — renaming a field

--- a/igc/ds/sources/resource_graph.py
+++ b/igc/ds/sources/resource_graph.py
@@ -7,6 +7,12 @@ are the ways to get from one resource to another (URL containment, ``@odata.id``
 invokable action targets). It answers "from where the agent is now, what can it reach next?" —
 which is exactly the set of candidate actions the policy has to choose among.
 
+The problem it solves: the agent's legal next moves are NOT a fixed list — they depend on which
+resource it is looking at, and a real host exposes hundreds of endpoints. This graph is what turns
+a pile of captured JSON responses into "you are here, and from here you can reach these," the
+reachability the policy needs before it can even enumerate its choices. Who needs it: the candidate
+featurizer (to build the menu of next moves) and the ranking feasibility check.
+
 Builds the typed resource graph the D-002 candidate representation needs: nodes are walked
 resources, edges are URL-prefix containment plus ``@odata.id`` references harvested from the
 WHOLE body — the corpus census showed explicit ``Links`` sections cover only 10-14% of real

--- a/igc/modules/eval/zero_shot_ranking.py
+++ b/igc/modules/eval/zero_shot_ranking.py
@@ -7,6 +7,11 @@ those candidates are REPRESENTED (text + graph features). This module is the che
 test for both — with NO training, can a plain text-similarity ranker already put a resource's
 true next-hops in the top-5? If yes, the learned ranker is worth building.
 
+The problem it solves: before spending GPU time training a candidate ranker, prove the idea is sound
+cheaply. If an untrained similarity ranker already puts the true next-hop in the top-5 most of the
+time, the representation is good enough and the learned ranker is worth building; if not, fix the
+representation first. It is a go/no-go gate run offline, not a runtime component the agent uses.
+
 Deterministic zero-shot ranking of legal action candidates with a frozen character-trigram
 text encoder: for each resource (state) in a walked Redfish tree, all host candidates are
 ranked by similarity to the state text, and the module measures whether the state's TRUE


### PR DESCRIPTION
Follow-up to #95. Adds a 'the problem it solves / who needs it' block to each of the three modules so a human understands them without knowing the decision codes: **graph** = per-resource reachability (legal next moves depend on where you are); **candidate featurizer** = describe each next-call by what it structurally is, so one policy generalizes across vendors; **zero-shot ranker** = offline go/no-go before training the learned ranker. Docstring-only; ruff + imports clean.