### PR TITLE
Fix CI: make the offline gate green (import path, deps, offline test taxonomy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           set -o pipefail
           KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1 \
-            pytest -q --cov=igc --cov-report=term --cov-report=xml --cov-report=json
+            python -m pytest -q --cov=igc --cov-report=term --cov-report=xml --cov-report=json
       - name: Metrics snapshot
         shell: bash
         run: |
@@ -103,7 +103,7 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 pytest -m perf -q
+          KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 python -m pytest -m perf -q
 
   docker:
     needs: [shell, gate]

--- a/docker/requirements-test.txt
+++ b/docker/requirements-test.txt
@@ -20,6 +20,9 @@ aniso8601
 itsdangerous
 Werkzeug
 # metrics / utilities
+# imported at module load by igc/shared/shared_torch_utils.py (nvmlInit is
+# only called lazily at runtime, so the import is safe on a CPU-only runner)
+pynvml
 tabulate
 prettytable
 tensorboard

--- a/igc/shared/shared_huggingface_utils.py
+++ b/igc/shared/shared_huggingface_utils.py
@@ -11,7 +11,6 @@ import torch
 import transformers
 from transformers import TrainerCallback
 from transformers.models.auto.auto_factory import _BaseAutoModelClass
-import deepspeed
 import accelerate
 
 
@@ -43,6 +42,9 @@ def hugging_face_info():
     """
     print(transformers.__version__)
     print(transformers.__file__)
+    # lazy: deepspeed is a cluster-only training dep, kept out of the offline
+    # import path so the CPU test/import path does not require it
+    import deepspeed
     print(f"Deepspeed version: {deepspeed.__version__}")
     print(f"Deepspeed location: {deepspeed.__file__}")
     print(f"Accelerate version: {accelerate.__version__}")

--- a/tests/test_igc_base_module.py
+++ b/tests/test_igc_base_module.py
@@ -99,6 +99,7 @@ class TestRestApiEnv(unittest.TestCase):
         self.assertEqual(module.optimizer, None)
         self.assertEqual(module._save_strategy, SaveStrategy.EPOCH)
 
+    @pytest.mark.download  # constructs the module, which loads the gpt2 backbone from HF
     def test_dirs(self):
         """
 
@@ -220,6 +221,7 @@ class TestRestApiEnv(unittest.TestCase):
         with self.assertRaises(ValueError):
             IgcModule.model_file("wrong", module_name)
 
+    @pytest.mark.download  # constructs the module, which loads the gpt2 backbone from HF
     def test_save_and_load_model(self):
         """
         Test saving and loading the model.
@@ -265,6 +267,7 @@ class TestRestApiEnv(unittest.TestCase):
             self.assertTrue(success)
             self.assertTrue(module._is_trained)
 
+    @pytest.mark.download  # constructs the module, which loads the gpt2 backbone from HF
     def test_save_and_without_opt_sched(self):
         """
         Test saving and loading checkpoints with optimizer and scheduler.

--- a/tests/test_llm_shared.py
+++ b/tests/test_llm_shared.py
@@ -7,6 +7,8 @@ import argparse
 import os
 import tempfile
 import unittest
+
+import pytest
 from transformers import (
     GPT2LMHeadModel, GPT2Tokenizer
 )
@@ -20,6 +22,7 @@ from igc.modules.shared.llm_shared import (
 
 class TestFromPretrainedDefault(unittest.TestCase):
 
+    @pytest.mark.download  # from_pretrained_default("gpt2") pulls the model from HF
     def test_from_pretrained_default_with_string(self):
         """Test we can create from string
         :return:
@@ -41,6 +44,7 @@ class TestFromPretrainedDefault(unittest.TestCase):
         self.assertIsInstance(model, GPT2LMHeadModel)
         self.assertIsInstance(tokenizer, GPT2Tokenizer)
 
+    @pytest.mark.download  # loads the gpt2 tokenizer from HF
     def test_from_pretrained_default_with_namespace(self):
         """Test we can create from argparse.Namespace
         :return:
@@ -62,6 +66,7 @@ class TestFromPretrainedDefault(unittest.TestCase):
         self.assertIsNone(model)
         self.assertIsInstance(tokenizer, GPT2Tokenizer)
 
+    @pytest.mark.download  # GPT2LMHeadModel.from_pretrained("gpt2") pulls from HF
     def test_save_and_load_pretrained_default(self):
         """Test pre-trained model saving and loading
         :return:


### PR DESCRIPTION
## Problem
Every CI run has been red — the `gate` job failed on all Python versions, so CI provided no signal (doc PRs merged red). The failures cascaded through four independent issues, each masking the next.

## Root causes + fixes (each verified)
1. **`ModuleNotFoundError: No module named 'igc'`** on every test module. The gate ran **bare `pytest`**, which does not put the repo root on `sys.path`; the job neither installs the package nor has a root `conftest.py`. → Run the gate/perf steps via **`python -m pytest`** (adds CWD). Reproduced on clean `main`: bare `pytest` → `No module named 'igc'`; `python -m pytest` → collects.
2. **`No module named 'pynvml'`** (surfaced once igc imported). `igc/shared/shared_torch_utils.py` imports pynvml at module load; it was in `requirements.txt` but not the CI test deps. → Add `pynvml` to `docker/requirements-test.txt`.
3. **`No module named 'deepspeed'`** would surface next. `shared_huggingface_utils.py` imported deepspeed at module top level, used only to print its version in a diagnostic. → Import it **lazily** inside `hugging_face_info` (cluster-only dep, matches the existing pattern in `shared_arg_parser.py`).
4. **`LocalEntryNotFoundError` for gpt2** on 6 tests. They load the real gpt2 backbone/tokenizer via `from_pretrained` but were unmarked, so they ran in the offline set and failed in a clean env (`TRANSFORMERS_OFFLINE=1` blocks the download; they pass locally only via a warm cache). → Mark the 6 `@pytest.mark.download`.

## Verification
- Reproduced #1 on clean `main`, and confirmed CI progressed from *0 tests collected* → full suite running after #1–#3 (install + lint steps pass on the PR run).
- Exact gate command locally (igc-dev): `python -m pytest -q --cov=igc` → **665 passed, 29 deselected, 8 xfailed**, coverage 55%.
- The 6 download-marked tests deselect under the offline addopts and collect only under `-m download`.
- `ruff check igc tests` and `actionlint`: clean.