### PR TITLE
Fix CI docker job: run the in-image smoke test via python -m pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Build and smoke test
         run: |
           docker build -f docker/Dockerfile.test -t igc-test:ci .
-          docker run --rm igc-test:ci pytest -q
+          docker run --rm -e TRANSFORMERS_OFFLINE=1 -e HF_DATASETS_OFFLINE=1 igc-test:ci python -m pytest -q
       - name: Log in to Docker Hub
         if: env.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@v3

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -2,7 +2,7 @@
 # No GPU/CUDA, no network at test time, no HuggingFace downloads, no live Redfish host.
 #
 #   docker build -f docker/Dockerfile.test -t igc-test:cpu .
-#   docker run --rm igc-test:cpu                 # runs `pytest -q`
+#   docker run --rm igc-test:cpu                 # runs `python -m pytest -q`
 #   docker run --rm igc-test:cpu ruff check igc tests
 FROM python:3.10-slim
 
@@ -18,4 +18,6 @@ RUN pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu 
 
 COPY . /workspace/igc
 ENV PYTHONUNBUFFERED=1
-CMD ["pytest", "-q"]
+# python -m pytest (not bare pytest) so the repo root / WORKDIR is on sys.path and
+# `import igc` resolves — igc is copied in, not pip-installed.
+CMD ["python", "-m", "pytest", "-q"]


### PR DESCRIPTION
## Problem
With the offline gate green again (#100), the previously-**skipped** `docker` job finally ran on `main` and failed: `docker run --rm igc-test:ci pytest -q` → `ModuleNotFoundError: No module named 'igc'` on every test module. The `docker` job `needs: [shell, gate]`, and the gate was red for 25+ runs, so this job hadn't executed in a long time — the failure is newly *exposed*, not newly *introduced*.

## Root cause
Same `sys.path` issue #100 fixed for the host gate. `docker/Dockerfile.test` does `COPY . /workspace/igc` but never `pip install -e .`, so `igc` isn't an installed package; bare `pytest` doesn't put the WORKDIR on `sys.path`. (My #100 note assumed igc was installed in the image — it isn't.)

## Fix
Run `python -m pytest` in both the ci.yml `docker run` and the image `CMD` (WORKDIR `/workspace/igc` → on `sys.path`). Also pass `TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1` to enforce the image's documented no-network contract.

## Verification (against the real image, Docker 29.5.3)
- Built `docker/Dockerfile.test` locally. **Old** `pytest -q` → 107 collection errors (`No module named 'igc'`). **New** `python -m pytest -q` → collection resolves, suite runs.
- One test failed **only in the local arm64 image** (`test_pipeline_add_tokens`) because the arm64 CPU wheel index served a stale `torch 2.5.1`; the **amd64 CI gate** runs the same `transformers 5.13.1` and **passes that test (665 passed)**, so the amd64 `docker` job (identical amd64 wheels) will match. Treated as an arm64-only sandbox artifact, not a code issue.
- `actionlint` clean.

Note: the `docker` job only runs on push to `main` (skipped on PRs), so the post-merge `main` run is the confirmation; this PR verifies the gate stays green.

Follow-up (not in scope): `docker/requirements-test.txt` and the Dockerfile pin neither transformers nor torch — CI is non-reproducible and a future release could break a version-sensitive test. Worth a deliberate pinning decision.