### PR TITLE
Quote Docker sync dry-run commands in the render output

### DIFF
--- a/scripts/docker_image_sync.py
+++ b/scripts/docker_image_sync.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import shlex
 import subprocess
 import sys
 from typing import Protocol
@@ -50,20 +51,20 @@ def render_sync_plan(spec_path: str | Path, *, push: bool = False) -> str:
 
     if policy == "if_missing":
         lines.append(
-            f"docker image inspect {image} >/dev/null 2>&1 "
-            f"|| docker pull {image}"
+            f"docker image inspect {_shell(image)} >/dev/null 2>&1 "
+            f"|| docker pull {_shell(image)}"
         )
     elif policy == "always":
-        lines.append(f"docker pull {image}")
+        lines.append(f"docker pull {_shell(image)}")
     elif policy == "build":
         lines.append(_build_command(spec.image, image))
     elif policy in {"never", "locked_digest"}:
-        lines.append(f"docker image inspect {image} >/dev/null")
+        lines.append(f"docker image inspect {_shell(image)} >/dev/null")
     else:
         raise RunSpecError(f"unsupported image.pull_policy: {policy}")
 
     if push:
-        lines.append(f"docker push {image}")
+        lines.append(f"docker push {_shell(image)}")
     return "\n".join(lines) + "\n"
 
 
@@ -151,7 +152,15 @@ def _push(runner: Runner, image: str) -> bool:
 def _build_command(image_cfg: dict, image: str) -> str:
     dockerfile = str(image_cfg.get("dockerfile", "docker/Dockerfile.train"))
     context = str(image_cfg.get("context", "."))
-    return f"docker build -f {dockerfile} -t {image} {context}"
+    return (
+        f"docker build -f {_shell(dockerfile)} "
+        f"-t {_shell(image)} {_shell(context)}"
+    )
+
+
+def _shell(value: str) -> str:
+    """Return a copy/paste-safe shell token for dry-run output."""
+    return shlex.quote(str(value))
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/scripts/test_docker_image_sync.py
+++ b/tests/scripts/test_docker_image_sync.py
@@ -23,11 +23,16 @@ def _load_module():
     return module
 
 
-def _write_spec(tmp_path, pull_policy="if_missing"):
+def _write_spec(
+        tmp_path,
+        pull_policy="if_missing",
+        dockerfile="docker/Dockerfile.train",
+        context=".",
+):
     path = tmp_path / "docker.yaml"
     image_extra = ""
     if pull_policy == "build":
-        image_extra = "  dockerfile: docker/Dockerfile.train\n  context: .\n"
+        image_extra = f"  dockerfile: {dockerfile!r}\n  context: {context!r}\n"
     path.write_text(
         textwrap.dedent(
             f"""
@@ -109,6 +114,23 @@ def test_build_policy_builds_and_optionally_pushes(tmp_path):
     assert module.sync_image(_write_spec(tmp_path, pull_policy="build"), runner=runner, push=True) == 0
     assert any(call[:2] == ["docker", "build"] for call in runner.calls)
     assert any(call[:2] == ["docker", "push"] for call in runner.calls)
+
+
+def test_build_policy_dry_run_quotes_build_paths(tmp_path):
+    """Dry-run build commands keep metacharacters inside quoted arguments."""
+    module = _load_module()
+    spec_path = _write_spec(
+        tmp_path,
+        pull_policy="build",
+        dockerfile="docker/Dockerfile.train; echo BAD",
+        context="build context",
+    )
+
+    rendered = module.render_sync_plan(spec_path)
+
+    assert "docker/Dockerfile.train; echo BAD" in rendered
+    assert "docker build -f 'docker/Dockerfile.train; echo BAD'" in rendered
+    assert "'build context'" in rendered
 
 
 def test_locked_digest_fails_when_image_is_absent(tmp_path, capsys):


### PR DESCRIPTION
Codex fix on top of the run-orchestration slice (#89): `scripts/docker_image_sync.py` now shell-quotes the commands it renders in dry-run mode, with coverage in `tests/scripts/test_docker_image_sync.py`.

Offline gate GREEN on a local test-merge into current `origin/main` (`efea293`):
- `ruff check` on both changed files: All checks passed
- `tests/scripts/test_docker_image_sync.py`: 6 passed
- `tests/bats/run_orchestration.bats`: 7/7 ok
- CI dry-run invocation (`docker_image_sync.py --spec … --dry-run`) executes cleanly
- full offline suite: 666 passed, 29 deselected, 8 xfailed

Auto-merge into main is clean (no conflicts).