### PR TITLE
Ship the committed datasets/ fixtures into the CI test image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,13 @@ __pycache__/
 .idea/
 # datasets, captures, tarballs, numpy maps — never bake into an image
 datasets/
+# ...but keep the small committed fixtures the offline gate loads: the slow
+# tokenizer (igc_default_tokenizer_dir() -> datasets/tokenizer: vocab.json/
+# merges.txt/…) and the model-specs file (igc_base_module -> datasets/models.json).
+# These are the only git-tracked files under datasets/; the heavy untracked data
+# (tarballs/*.npy/raw/*.pt and the big tokenizer.json) stays excluded.
+!datasets/tokenizer/
+!datasets/models.json
 test_datasets/
 tests/datasets/
 *.tar.gz


### PR DESCRIPTION
## Problem
With the docker CI job finally running (#100 fixed the gate, #101 fixed the in-image import), it still failed **4 offline tests** on amd64 (`4 failed, 662 passed`):
```
tests/ds/test_pipeline_add_tokens.py::test_build_tokens_accepts_allowable_values
tests/test_igc_base_module.py::TestRestApiEnv::test_download
tests/test_igc_base_module.py::TestRestApiEnv::test_we_don_download
tests/test_llm_shared.py::TestFromPretrainedDefault::test_load_igc_tokenizer_without_path
```

## Root cause
These tests load **committed fixtures** under `datasets/`: `datasets/tokenizer/` (the slow igc tokenizer, via `igc_default_tokenizer_dir()`) and `datasets/models.json` (model specs, via `igc_base_module`). `.dockerignore` excluded **all** of `datasets/` to keep heavy data out of the image — which also dropped these small tracked fixtures. So the image couldn't run the same offline suite the host `gate` job runs (the gate passes because its full checkout has them). These are the **only** git-tracked files under `datasets/` (`models.json` = 1.4 KB, the 5 tokenizer files ≈ 1.66 MB).

## Fix
Re-include exactly the two tracked fixture paths in `.dockerignore`; the heavy untracked data (tarballs, `*.npy`, `raw/*.pt`, the 4 MB `tokenizer.json`) stays excluded.

## Verification (real image, Docker 29.5.3)
Rebuilt `docker/Dockerfile.test` locally:
- `datasets/models.json` + `datasets/tokenizer/{vocab,merges,…}` present; `tokenizer.json` and `*.tar.gz` correctly absent.
- the 4 previously-failing tests: **4 passed**; the 3 affected files in full: **5 passed, 10 deselected**, 0 failed.

The `docker` job is `if: push` (skipped on PRs), so the post-merge `main` run confirms; this replaces my earlier incorrect call on #101 that the arm64-local failure was just a torch-wheel artifact — it was in fact this `.dockerignore` exclusion, reproduced identically on amd64.