### PR TITLE
Make gb300_launch.sh a repeatable, dry-runnable training launcher

### DIFF
--- a/scripts/gb300_launch.sh
+++ b/scripts/gb300_launch.sh
@@ -269,7 +269,9 @@ fi
 export WANDB_PROJECT="${WANDB_PROJECT}"
 export WANDB_NAME="${WANDB_NAME}"
 export WANDB_MODE="${RUN_WANDB_MODE}"
-echo "run: W&B project=\${WANDB_PROJECT} name=\${WANDB_NAME} mode=\${WANDB_MODE} | HF cache=\${HF_HOME:-<default>} token=\$([ -n "\${HF_TOKEN:-}" ] && echo available || echo none)"
+HF_TOKEN_STATUS=none
+[ -n "\${HF_TOKEN:-}" ] && HF_TOKEN_STATUS=available
+echo "run: W&B project=\${WANDB_PROJECT} name=\${WANDB_NAME} mode=\${WANDB_MODE} | HF cache=\${HF_HOME:-<default>} token=\${HF_TOKEN_STATUS}"
 mkdir -p "${IGC_OUTPUT_DIR}"
 nvidia-smi -L
 INNEREOF

--- a/scripts/gb300_launch.sh
+++ b/scripts/gb300_launch.sh
@@ -88,6 +88,12 @@ IGC_ALLOW_RUNTIME_PIP="${IGC_ALLOW_RUNTIME_PIP:-0}"        # 1 => allow in-conta
 log()     { echo "=== [$(date -u '+%F %T')] $* ==="; }
 blocker() { echo "BLOCKER: $*" >&2; exit 3; }
 is_int()  { case "${1:-}" in ''|*[!0-9]*) return 1 ;; *) return 0 ;; esac; }
+is_decimal() { [[ "${1:-}" =~ ^[0-9]+([.][0-9]+)?$ ]]; }
+is_safe_shell_atom() { case "${1:-}" in ''|*[!A-Za-z0-9_./:@+=,-]*) return 1 ;; *) return 0 ;; esac; }
+require_safe_shell_atom() {
+    local name="$1" value="${!1}"
+    is_safe_shell_atom "$value" || blocker "$name contains whitespace or shell-control characters (got '${value}')"
+}
 
 # --- 1. resolve the ladder rung (a preset is just defaults; explicit knobs win) ----
 case "$IGC_RUNG" in
@@ -107,14 +113,24 @@ if [ "$IGC_GPUS" -gt 1 ] 2>/dev/null; then : "${IGC_SHARDING:=ddp}"; else : "${I
 for v in IGC_BATCH IGC_GRAD_ACCUM IGC_WORKERS EPOCHS; do
     { is_int "${!v}" && [ "${!v}" -ge 1 ]; } || blocker "$v must be a positive integer (got '${!v}')"
 done
+for v in IGC_RUN IGC_MODEL IGC_OUTPUT_DIR IGC_IMAGE IGC_CODE_DIR IGC_DATA_DIR IGC_MODELS_DIR IGC_WANDB_ENV IGC_HF_ENV; do
+    require_safe_shell_atom "$v"
+done
 [ -z "$IGC_MAX_STEPS" ] || { is_int "$IGC_MAX_STEPS" && [ "$IGC_MAX_STEPS" -ge 1 ]; } || blocker "IGC_MAX_STEPS must be empty or a positive integer (got '${IGC_MAX_STEPS}')"
+{ is_int "$IGC_MASTER_PORT" && [ "$IGC_MASTER_PORT" -ge 1 ] && [ "$IGC_MASTER_PORT" -le 65535 ]; } || blocker "IGC_MASTER_PORT must be an integer TCP port 1-65535 (got '${IGC_MASTER_PORT}')"
 case "$IGC_SHARDING" in none|ddp|zero2|zero3|zero3_offload|fsdp) ;; *) blocker "IGC_SHARDING='${IGC_SHARDING}' invalid (none|ddp|zero2|zero3|zero3_offload|fsdp)" ;; esac
 case "$IGC_PRECISION" in no|fp16|bf16|fp8) ;; *) blocker "IGC_PRECISION='${IGC_PRECISION}' invalid (no|fp16|bf16|fp8)" ;; esac
 case "$IGC_ADAPTER" in lora|rslora|dora) ;; *) blocker "IGC_ADAPTER='${IGC_ADAPTER}' invalid (lora|rslora|dora)" ;; esac
 case "$IGC_USE_PEFT" in 0|1) ;; *) blocker "IGC_USE_PEFT must be 0 or 1 (got '${IGC_USE_PEFT}')" ;; esac
-# IGC_RUN / IGC_MODEL flow unquoted into --output_dir / --model_type, so a space would split the argv
-case "$IGC_RUN" in   *[![:graph:]]*|*' '*) blocker "IGC_RUN must contain no whitespace (got '${IGC_RUN}')" ;; esac
-case "$IGC_MODEL" in *[![:graph:]]*|*' '*) blocker "IGC_MODEL must contain no whitespace (got '${IGC_MODEL}')" ;; esac
+case "$IGC_SMOKE" in 0|1) ;; *) blocker "IGC_SMOKE must be 0 or 1 (got '${IGC_SMOKE}')" ;; esac
+case "$IGC_PREBUILD" in ''|0|1) ;; *) blocker "IGC_PREBUILD must be empty, 0, or 1 (got '${IGC_PREBUILD}')" ;; esac
+case "$IGC_DRY_RUN" in 0|1) ;; *) blocker "IGC_DRY_RUN must be 0 or 1 (got '${IGC_DRY_RUN}')" ;; esac
+case "$WANDB_MODE" in ''|online|offline|disabled) ;; *) blocker "WANDB_MODE must be empty, online, offline, or disabled (got '${WANDB_MODE}')" ;; esac
+case "$NCCL_CUMEM_ENABLE" in 0|1) ;; *) blocker "NCCL_CUMEM_ENABLE must be 0 or 1 (got '${NCCL_CUMEM_ENABLE}')" ;; esac
+case "$NCCL_MNNVL_ENABLE" in 0|1) ;; *) blocker "NCCL_MNNVL_ENABLE must be 0 or 1 (got '${NCCL_MNNVL_ENABLE}')" ;; esac
+{ is_int "$LORA_R" && [ "$LORA_R" -ge 1 ]; } || blocker "LORA_R must be a positive integer (got '${LORA_R}')"
+{ is_int "$LORA_ALPHA" && [ "$LORA_ALPHA" -ge 1 ]; } || blocker "LORA_ALPHA must be a positive integer (got '${LORA_ALPHA}')"
+is_decimal "$LORA_DROPOUT" || blocker "LORA_DROPOUT must be a decimal value (got '${LORA_DROPOUT}')"
 
 # resolve the LLM curriculum stage -> the real --train/--llm flags (scripts/train_igc.sbatch is the
 # source of truth). This launcher covers the LLM stages; the RL/combined stages have a different

--- a/scripts/gb300_launch.sh
+++ b/scripts/gb300_launch.sh
@@ -1,56 +1,209 @@
 #!/usr/bin/env bash
 # gb300_launch.sh — launch ONE igc training run on ONE GB300 node via docker.
 #
-# Runs ON the node (docker runs locally; the cluster's Slurm is only driveable from
-# slot0 because munge is down on the compute nodes, so we launch directly and must
-# guard the node ourselves). It ALWAYS re-checks that the GPUs are actually free in
-# the seconds right before launch — the fleet churns and a node can be grabbed while
-# you set up, so an earlier "free" reading is never trusted.
+# The "boring and repeatable" training path. Runs ON the node (docker runs locally;
+# the cluster's Slurm is only driveable from slot0 because munge is down on the compute
+# nodes, so we launch directly and guard the node ourselves). It ALWAYS re-checks that
+# the GPUs are free in the seconds right before launch — the fleet churns and a node can
+# be grabbed while you set up, so an earlier "free" reading is never trusted.
 #
-# For >1 GPU it runs a single-GPU pre-build FIRST (serialises the dataset build, which
-# races across ranks) with no experiment tracking, then the multi-GPU accelerate/FSDP
-# run — that second run is the ONE clean W&B run (rank-gated in metric_factory, so one
-# run per job not one per GPU). For 1 GPU it is a single plain-python run.
+# Parallelism follows docs/DISTRIBUTED_PLAN.md: for models that fit on one GPU (the ones
+# igc actually fine-tunes) DDP is the default and ~3x faster than FSDP2 at 4 GPU; reach
+# for --sharding fsdp only when the backbone genuinely does not fit. For >1 GPU it runs a
+# single-GPU pre-build FIRST (serialises the dataset build, which races across ranks) with
+# no experiment tracking, then the multi-GPU accelerate run — that second run is the ONE
+# clean W&B run (rank-gated in metric_factory, so one run per job not one per GPU).
 #
-# Nothing host- or path-specific is baked in; everything is an env knob so the same
-# script runs on any node and against a node-local OR a shared /models checkout.
+# Nothing host-, path-, or credential-specific is baked in: every setting is an env knob,
+# W&B/HF creds are sourced INSIDE the container from gitignored env files (never printed),
+# and there are no hardcoded fleet hosts (single-node accelerate rendezvouses on localhost).
 #
-# Usage (on the node):
-#   IGC_GPUS=4 IGC_MODEL=gpt2 scripts/gb300_launch.sh
-#   IGC_GPUS=1 IGC_MODEL=<hf-repo-id> IGC_USE_PEFT=1 EPOCHS=3 scripts/gb300_launch.sh
-#   IGC_CODE_DIR=/models/igc IGC_DATA_DIR=/models/igc_data scripts/gb300_launch.sh
+# THE LADDER (prove the substrate cheaply, then scale) — one rung per invocation:
+#   IGC_RUNG=smoke1 scripts/gb300_launch.sh   # 1 GPU, ~20 steps, W&B off — is the path alive?
+#   IGC_RUNG=smoke4 scripts/gb300_launch.sh   # 4 GPU DDP, ~20 steps, W&B off — does DDP wire up?
+#   IGC_RUNG=run4   scripts/gb300_launch.sh   # 4 GPU DDP, real short run -> W&B
+#   IGC_RUNG=fsdp4  scripts/gb300_launch.sh   # 4 GPU FSDP2, real short run -> W&B (only if it must shard)
+# or drive every knob yourself (IGC_GPUS / IGC_SHARDING / IGC_SMOKE / ...).
+#
+# DRY RUN — print the EXACT docker + training command(s) without launching (no docker,
+# no GPU, no node needed; safe on a laptop or in CI):
+#   IGC_DRY_RUN=1 IGC_RUNG=run4 IGC_MODEL=gpt2 scripts/gb300_launch.sh
 #
 # Detached so it survives an ssh drop — redirect from the CALLER; never add
 # `exec > >(tee ...)` inside this script (process substitution wedges a setsid launch):
 #   nohup setsid bash scripts/gb300_launch.sh > ~/igc-run.log 2>&1 </dev/null & exit 0
 #
-# Used by: run by hand / by scripts/gb300_stage.sh on a free node; not imported by
-# Python. Iterate on code with `git -C "$IGC_CODE_DIR" pull` (the checkout is bind-
-# mounted, so no image rebuild) then re-run — no container teardown needed.
+# Used by: run by hand on a free reserved slot (GPU_ACCESS.md §3), or after the 2-node
+# DDP sanity gate (scripts/gb300_sanity_check.sh) proves the fabric. Not imported by Python.
+# Iterate on code with `git -C "$IGC_CODE_DIR" pull` (the checkout is bind-mounted, so no
+# image rebuild) then re-run. Rendering/validation is covered by tests/bats/gb300_launch.bats.
 #
 # Author:
 # Mus mbayramo@stanford.edu
 set -uo pipefail
 
 # --- knobs (env-overridable; no hardcoded hosts, paths, or endpoints) ---------
-IGC_GPUS="${IGC_GPUS:-4}"                                   # 1 = plain python; >1 = accelerate FSDP
-IGC_STAGE="${IGC_STAGE:-m1}"                                # curriculum stage (see scripts/train_igc.sbatch)
-IGC_MODEL="${IGC_MODEL:-gpt2}"                              # gpt2 smoke, or an HF repo id to scale up
-IGC_CODE_DIR="${IGC_CODE_DIR:-$HOME/igc}"                   # igc checkout (node-local or /models)
-IGC_DATA_DIR="${IGC_DATA_DIR:-$HOME/.json_responses}"       # captured Redfish responses (mounted read-only)
-IGC_IMAGE="${IGC_IMAGE:-nvcr.io/nvidia/pytorch:26.03-py3}"  # bare NGC (runtime pip) or igc-train:ngc26.03 (deps baked)
-IGC_RUN="${IGC_RUN:-verify}"                                # experiment name / output subdir / container name
+# Ladder / topology
+IGC_RUNG="${IGC_RUNG:-}"                                    # smoke1|smoke4|run4|fsdp4|"" (preset the ladder rung; overrides gpus/sharding/smoke defaults)
+IGC_GPUS="${IGC_GPUS:-}"                                    # GPUs for THIS run (1=plain python; >1=accelerate). Empty => rung/default 4
+IGC_SHARDING="${IGC_SHARDING:-}"                            # none|ddp|zero2|zero3|zero3_offload|fsdp (>1 GPU). Empty => ddp (the default per DISTRIBUTED_PLAN)
+IGC_SMOKE="${IGC_SMOKE:-}"                                  # 1=fast check (cap steps, W&B off, 1 epoch); 0=real run. Empty => rung/0
+# Model / data / output
+IGC_STAGE="${IGC_STAGE:-m1}"                                # LLM curriculum stage -> --train/--llm (m1=latent|m2=encoder|m3=goal|m3p=parameter). RL/combined (m6/all) live in scripts/train_igc.sbatch
+IGC_MODEL="${IGC_MODEL:-gpt2}"                              # gpt2 smoke, or an HF repo id / local path to scale up
+IGC_RUN="${IGC_RUN:-verify}"                                # run name -> W&B name, output subdir, container name
+IGC_CODE_DIR="${IGC_CODE_DIR:-${HOME:-/root}/igc}"          # igc checkout (node-local or /models/igc)
+IGC_DATA_DIR="${IGC_DATA_DIR:-${HOME:-/root}/.json_responses}"  # captured Redfish responses (mounted read-only)
 IGC_MODELS_DIR="${IGC_MODELS_DIR:-/models}"                 # shared 240TB BeeGFS (large/durable artifacts)
-EPOCHS="${EPOCHS:-3}"
-IGC_BATCH="${IGC_BATCH:-256}"                               # per-GPU batch; default 4 used ~14/284GB HBM — sweep up to ~85%
-IGC_WORKERS="${IGC_WORKERS:-16}"                            # DataLoader workers; default 1 left 143/144 Grace cores idle
-IGC_MIN_FREE_GB="${IGC_MIN_FREE_GB:-100}"                   # HF pulls + dataset + checkpoints need headroom
+IGC_OUTPUT_DIR="${IGC_OUTPUT_DIR:-experiments/${IGC_RUN}}"  # checkpoints + tensorboard land here (relative path resolved under the mounted checkout /workspace/igc)
+IGC_IMAGE="${IGC_IMAGE:-nvcr.io/nvidia/pytorch:26.03-py3}"  # bare NGC (runtime pip) or igc-train:ngc26.03 (deps baked)
+# Training hyper-params (all map to real igc_main.py flags; see igc/shared/shared_arg_parser.py)
+EPOCHS="${EPOCHS:-3}"                                       # --num_train_epochs (ignored in smoke: forced to 1)
+IGC_BATCH="${IGC_BATCH:-128}"                               # --per_device_train_batch_size (256 OOMs a large-vocab backbone; 128 is the safe start)
+IGC_GRAD_ACCUM="${IGC_GRAD_ACCUM:-1}"                       # --gradient_accumulation_steps (raise to grow effective batch without more HBM)
+IGC_WORKERS="${IGC_WORKERS:-16}"                            # --num_workers (default 1 left 143/144 Grace cores idle)
+IGC_PRECISION="${IGC_PRECISION:-bf16}"                      # --mixed_precision on the accelerate path: no|fp16|bf16|fp8 (bf16 recommended)
+IGC_MAX_STEPS="${IGC_MAX_STEPS:-}"                          # --max_steps cap; empty => none (real run). Smoke defaults to 20 if unset
+# LoRA / rsLoRA (the supported large-backbone path)
+IGC_USE_PEFT="${IGC_USE_PEFT:-0}"                          # 1 => --use_peft (LoRA/PEFT fine-tune of a bf16 base)
+IGC_ADAPTER="${IGC_ADAPTER:-lora}"                         # --adapter_method: lora|rslora|dora (rslora = rank-stabilized)
+LORA_R="${LORA_R:-16}"                                     # --lora_r (rank)
+LORA_ALPHA="${LORA_ALPHA:-32}"                             # --lora_alpha (scaling)
+LORA_DROPOUT="${LORA_DROPOUT:-0.05}"                       # --lora_dropout
+# W&B / HF env (creds live in gitignored files, sourced INSIDE the container, never printed)
+IGC_WANDB_ENV="${IGC_WANDB_ENV:-.internal/wandb.env}"      # gitignored W&B creds file (WANDB_API_KEY/ENTITY/PROJECT)
+IGC_HF_ENV="${IGC_HF_ENV:-.internal/hf.env}"               # gitignored HF cache/token file (HF_HOME/HF_HUB_CACHE/HF_TOKEN)
+WANDB_PROJECT="${WANDB_PROJECT:-igc}"                       # W&B project (non-secret)
+WANDB_MODE="${WANDB_MODE:-}"                                # online|offline|disabled; empty => online for a real run, disabled for a smoke
+# NCCL (GB300 defaults per TEAM_GUIDE: CUMEM on, MNNVL off unless a preflight proves the IMEX channels)
+NCCL_CUMEM_ENABLE="${NCCL_CUMEM_ENABLE:-1}"                 # default 1 (CUMEM helps NCCL memory registration)
+NCCL_MNNVL_ENABLE="${NCCL_MNNVL_ENABLE:-0}"                 # default 0 (multi-node MNNVL off until a node preflight proves it works)
+# Control
+IGC_PREBUILD="${IGC_PREBUILD:-}"                            # multi-GPU dataset pre-build: 1=run, 0=skip. Empty => 1 for >1 GPU. Skip (0) for a model too large to load on ONE GPU (pre-build the dataset separately first)
+IGC_DRY_RUN="${IGC_DRY_RUN:-0}"                             # 1 => print the exact command(s) and exit; no docker, no GPU
+IGC_MASTER_PORT="${IGC_MASTER_PORT:-29500}"                 # single-node accelerate rendezvous port (localhost)
+IGC_MIN_FREE_GB="${IGC_MIN_FREE_GB:-100}"                  # HF pulls + dataset + checkpoints need headroom (real run only)
+IGC_ALLOW_RUNTIME_PIP="${IGC_ALLOW_RUNTIME_PIP:-0}"        # 1 => allow in-container `pip install` if deps missing; 0 => fail loudly (no silent fallback)
+
+log()     { echo "=== [$(date -u '+%F %T')] $* ==="; }
+blocker() { echo "BLOCKER: $*" >&2; exit 3; }
+is_int()  { case "${1:-}" in ''|*[!0-9]*) return 1 ;; *) return 0 ;; esac; }
+
+# --- 1. resolve the ladder rung (a preset is just defaults; explicit knobs win) ----
+case "$IGC_RUNG" in
+    smoke1) : "${IGC_GPUS:=1}" "${IGC_SHARDING:=none}" "${IGC_SMOKE:=1}" ;;
+    smoke4) : "${IGC_GPUS:=4}" "${IGC_SHARDING:=ddp}"  "${IGC_SMOKE:=1}" ;;
+    run4)   : "${IGC_GPUS:=4}" "${IGC_SHARDING:=ddp}"  "${IGC_SMOKE:=0}" ;;
+    fsdp4)  : "${IGC_GPUS:=4}" "${IGC_SHARDING:=fsdp}" "${IGC_SMOKE:=0}" ;;
+    "")     : ;;                                            # no rung: fall through to per-knob defaults
+    *)      blocker "unknown IGC_RUNG='${IGC_RUNG}' (use smoke1|smoke4|run4|fsdp4 or set the knobs directly)" ;;
+esac
+# per-knob defaults for anything the rung did not set
+: "${IGC_GPUS:=4}" "${IGC_SMOKE:=0}"
+if [ "$IGC_GPUS" -gt 1 ] 2>/dev/null; then : "${IGC_SHARDING:=ddp}"; else : "${IGC_SHARDING:=none}"; fi
+
+# --- 2. validate knobs (fail fast, explicit — runs in dry-run too) --------------
+{ is_int "$IGC_GPUS" && [ "$IGC_GPUS" -ge 1 ]; } || blocker "IGC_GPUS must be an integer >= 1 (got '${IGC_GPUS}')"
+for v in IGC_BATCH IGC_GRAD_ACCUM IGC_WORKERS EPOCHS; do
+    { is_int "${!v}" && [ "${!v}" -ge 1 ]; } || blocker "$v must be a positive integer (got '${!v}')"
+done
+[ -z "$IGC_MAX_STEPS" ] || { is_int "$IGC_MAX_STEPS" && [ "$IGC_MAX_STEPS" -ge 1 ]; } || blocker "IGC_MAX_STEPS must be empty or a positive integer (got '${IGC_MAX_STEPS}')"
+case "$IGC_SHARDING" in none|ddp|zero2|zero3|zero3_offload|fsdp) ;; *) blocker "IGC_SHARDING='${IGC_SHARDING}' invalid (none|ddp|zero2|zero3|zero3_offload|fsdp)" ;; esac
+case "$IGC_PRECISION" in no|fp16|bf16|fp8) ;; *) blocker "IGC_PRECISION='${IGC_PRECISION}' invalid (no|fp16|bf16|fp8)" ;; esac
+case "$IGC_ADAPTER" in lora|rslora|dora) ;; *) blocker "IGC_ADAPTER='${IGC_ADAPTER}' invalid (lora|rslora|dora)" ;; esac
+case "$IGC_USE_PEFT" in 0|1) ;; *) blocker "IGC_USE_PEFT must be 0 or 1 (got '${IGC_USE_PEFT}')" ;; esac
+# IGC_RUN / IGC_MODEL flow unquoted into --output_dir / --model_type, so a space would split the argv
+case "$IGC_RUN" in   *[![:graph:]]*|*' '*) blocker "IGC_RUN must contain no whitespace (got '${IGC_RUN}')" ;; esac
+case "$IGC_MODEL" in *[![:graph:]]*|*' '*) blocker "IGC_MODEL must contain no whitespace (got '${IGC_MODEL}')" ;; esac
+
+# resolve the LLM curriculum stage -> the real --train/--llm flags (scripts/train_igc.sbatch is the
+# source of truth). This launcher covers the LLM stages; the RL/combined stages have a different
+# command shape (--train agent --rl all / --rl_num_train_epochs) and stay in train_igc.sbatch.
+case "$IGC_STAGE" in
+    m1|state_encoder) STAGE_ARGS="--train llm --llm latent" ;;
+    m2|autoencoder)   STAGE_ARGS="--train llm --llm encoder" ;;
+    m3|goal)          STAGE_ARGS="--train llm --llm goal" ;;
+    m3p|parameter)    STAGE_ARGS="--train llm --llm parameter" ;;
+    m6|agent|rl|all)  blocker "IGC_STAGE='${IGC_STAGE}' (RL/combined) is not wired here — use scripts/train_igc.sbatch; this launcher covers the LLM stages m1|m2|m3|m3p" ;;
+    *)                blocker "IGC_STAGE='${IGC_STAGE}' invalid (m1|m2|m3|m3p)" ;;
+esac
+
+# --- 3. resolve smoke- and run-shaped settings ---------------------------------
+if [ "$IGC_SMOKE" = "1" ]; then
+    RUN_EPOCHS=1                                            # a smoke never needs more than one epoch
+    MAX_STEPS="${IGC_MAX_STEPS:-20}"                        # cap steps so it finishes in minutes
+    RUN_WANDB_MODE="${WANDB_MODE:-disabled}"               # a smoke does not pollute the dashboard
+else
+    RUN_EPOCHS="$EPOCHS"
+    MAX_STEPS="${IGC_MAX_STEPS:-}"                          # no cap for a real run unless asked
+    RUN_WANDB_MODE="${WANDB_MODE:-online}"
+fi
+if [ "$RUN_WANDB_MODE" = "disabled" ]; then METRIC_REPORT=tensorboard; else METRIC_REPORT=wandb; fi
+MODEL_TAG="${IGC_MODEL//\//_}"                              # HF repo ids contain '/', unsafe in a W&B name/subdir
+SMOKE_SUFFIX=""; [ "$IGC_SMOKE" = "1" ] && SMOKE_SUFFIX="-smoke"
+WANDB_NAME="${IGC_RUN}-${IGC_STAGE}-${IGC_GPUS}gpu-${IGC_SHARDING}-${MODEL_TAG}${SMOKE_SUFFIX}"
 CONTAINER="igc-${IGC_RUN}"
 
-log() { echo "=== [$(date -u '+%F %T')] $* ==="; }
-blocker() { echo "BLOCKER: $*" >&2; exit 3; }
+# --- 4. build the igc_main.py flag set (grounded in shared_arg_parser.py) -------
+COMMON="${STAGE_ARGS} --model_type ${IGC_MODEL} --json_data_dir /root/.json_responses --tf32 --seed 42 --log_level info --llm_log_level info --per_device_train_batch_size ${IGC_BATCH} --gradient_accumulation_steps ${IGC_GRAD_ACCUM} --num_workers ${IGC_WORKERS}"
+[ "$IGC_USE_PEFT" = "1" ] && COMMON="${COMMON} --use_peft --adapter_method ${IGC_ADAPTER} --lora_r ${LORA_R} --lora_alpha ${LORA_ALPHA} --lora_dropout ${LORA_DROPOUT}"
+TAIL="--num_train_epochs ${RUN_EPOCHS} --output_dir ${IGC_OUTPUT_DIR} --metric_report ${METRIC_REPORT}"
+[ -n "$MAX_STEPS" ] && TAIL="${TAIL} --max_steps ${MAX_STEPS}"
 
-# --- 1. pre-flight: the node must be genuinely free RIGHT NOW ------------------
+# the exact per-rank training command (accelerate wraps it for >1 GPU; --mixed_precision
+# is an accelerate-path flag, so it is only added there — a 1-GPU run uses --tf32 only).
+# The >1-GPU pre-build serialises the dataset build (which races across ranks): the dataset
+# is constructed BEFORE the train loop, so --max_steps 1 produces the cache and exits without
+# training a whole epoch. It still loads the model on ONE GPU, so set IGC_PREBUILD=0 for a
+# model too large to fit single-GPU (pre-build the dataset separately first).
+if [ "$IGC_GPUS" -gt 1 ]; then
+    : "${IGC_PREBUILD:=1}"
+    if [ "$IGC_PREBUILD" = "1" ]; then
+        PREBUILD_CMD="WANDB_MODE=disabled python igc_main.py --device cuda:0 ${COMMON} --num_train_epochs 1 --max_steps 1 --output_dir /tmp/prebuild --metric_report tensorboard"
+    else
+        PREBUILD_CMD=""                                    # skipped: dataset assumed already built (IGC_PREBUILD=0)
+    fi
+    TRAIN_CMD="accelerate launch --num_processes ${IGC_GPUS} --num_machines 1 --machine_rank 0 --main_process_ip 127.0.0.1 --main_process_port ${IGC_MASTER_PORT} igc_main.py --use_accelerator --sharding ${IGC_SHARDING} --mixed_precision ${IGC_PRECISION} ${COMMON} ${TAIL}"
+else
+    : "${IGC_PREBUILD:=0}"
+    PREBUILD_CMD=""                                        # 1 GPU: the single run also builds the dataset, no separate pre-build
+    TRAIN_CMD="python igc_main.py --device cuda:0 ${COMMON} ${TAIL}"
+fi
+
+# --- 5. render the exact command(s) (used by dry-run AND logged before a real run) --
+render() {
+    local peft_desc="off" prec_desc="${IGC_PRECISION} (--mixed_precision, accelerate path)"
+    [ "$IGC_USE_PEFT" = "1" ] && peft_desc="${IGC_ADAPTER} r=${LORA_R} a=${LORA_ALPHA}"
+    # --mixed_precision is an accelerate-path flag; a 1-GPU plain-python run honours --tf32 only
+    [ "$IGC_GPUS" -gt 1 ] || prec_desc="tf32 only (IGC_PRECISION=${IGC_PRECISION} ignored on 1 GPU)"
+    echo "# ---------------------------------------------------------------------------"
+    echo "# igc training render : rung=${IGC_RUNG:-<custom>} stage=${IGC_STAGE} gpus=${IGC_GPUS} sharding=${IGC_SHARDING} smoke=${IGC_SMOKE}"
+    echo "#   model=${IGC_MODEL}  precision=${prec_desc}  peft=${peft_desc}"
+    echo "#   batch=${IGC_BATCH} grad_accum=${IGC_GRAD_ACCUM} epochs=${RUN_EPOCHS} max_steps=${MAX_STEPS:-none} workers=${IGC_WORKERS} prebuild=${IGC_PREBUILD}"
+    echo "#   output=${IGC_OUTPUT_DIR}  metric=${METRIC_REPORT}"
+    echo "#   W&B: project=${WANDB_PROJECT} name=${WANDB_NAME} mode=${RUN_WANDB_MODE}  (creds sourced in-container from ${IGC_WANDB_ENV}; HF from ${IGC_HF_ENV})"
+    echo "#   NCCL: NCCL_CUMEM_ENABLE=${NCCL_CUMEM_ENABLE} NCCL_MNNVL_ENABLE=${NCCL_MNNVL_ENABLE}"
+    echo "docker run --rm --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 \\"
+    echo "    --name ${CONTAINER} \\"
+    echo "    -v ${IGC_CODE_DIR}:/workspace/igc \\"
+    echo "    -v ${IGC_DATA_DIR}:/root/.json_responses:ro \\"
+    echo "    -v ${IGC_MODELS_DIR}:/models   # (only when ${IGC_MODELS_DIR} exists) \\"
+    echo "    -e NCCL_CUMEM_ENABLE=${NCCL_CUMEM_ENABLE} -e NCCL_MNNVL_ENABLE=${NCCL_MNNVL_ENABLE} \\"
+    echo "    -w /workspace/igc ${IGC_IMAGE} bash -lc '<inner>'"
+    echo "# inner (in-container):"
+    [ -n "$PREBUILD_CMD" ] && echo "#   PHASE A (pre-build, W&B off) : ${PREBUILD_CMD}"
+    echo "#   TRAIN                        : ${TRAIN_CMD}"
+    echo "# ---------------------------------------------------------------------------"
+}
+
+# --- 6. dry-run: render and stop (no docker, no GPU, no node needed) ------------
+if [ "$IGC_DRY_RUN" = "1" ]; then
+    render
+    log "DRY RUN — nothing launched"
+    exit 0
+fi
+
+# --- 7. pre-flight: the node must be genuinely free RIGHT NOW -------------------
 log "pre-flight on $(hostname)"
 command -v nvidia-smi >/dev/null || blocker "nvidia-smi missing — not a GPU node?"
 command -v docker >/dev/null || blocker "docker missing"
@@ -63,71 +216,70 @@ fi
 ngpu=$(nvidia-smi -L 2>/dev/null | grep -c . || true)
 [ "$IGC_GPUS" -le "$ngpu" ] || blocker "asked $IGC_GPUS GPUs, node has $ngpu"
 
-avail=$(df -BG --output=avail "$HOME" 2>/dev/null | tail -1 | tr -dc '0-9' || echo 0)
-[ "${avail:-0}" -ge "$IGC_MIN_FREE_GB" ] || blocker "only ${avail}G free under \$HOME (< ${IGC_MIN_FREE_GB}G)"
+# check free space where the run actually writes: IGC_OUTPUT_DIR is relative, resolved under the
+# mounted checkout IGC_CODE_DIR (e.g. /models/igc), NOT necessarily $HOME. (HF cache lives wherever
+# the private hf.env points HF_HOME — size that mount separately.)
+avail=$(df -BG --output=avail "$IGC_CODE_DIR" 2>/dev/null | tail -1 | tr -dc '0-9' || echo 0)
+[ "${avail:-0}" -ge "$IGC_MIN_FREE_GB" ] || blocker "only ${avail}G free on the checkpoint filesystem (${IGC_CODE_DIR}) (< ${IGC_MIN_FREE_GB}G)"
 
-[ -f "$IGC_CODE_DIR/igc_main.py" ] || blocker "no igc checkout at $IGC_CODE_DIR (clone it or point IGC_CODE_DIR at /models)"
+[ -f "$IGC_CODE_DIR/igc_main.py" ] || blocker "no igc checkout at $IGC_CODE_DIR (clone it or point IGC_CODE_DIR at /models/igc)"
 [ -d "$IGC_DATA_DIR" ] || blocker "no captured data at $IGC_DATA_DIR"
 docker image inspect "$IGC_IMAGE" >/dev/null 2>&1 || blocker "image $IGC_IMAGE not present — pull it or build igc-train from docker/Dockerfile.train"
 
-# --- 2. run in the container --------------------------------------------------
-# Shared igc_main.py flags for both phases (dataset args identical => pre-build's
-# cache is reused by the multi-GPU run instead of rebuilt).
-COMMON="--train llm --llm latent --model_type ${IGC_MODEL} --json_data_dir /root/.json_responses --tf32 --seed 42 --log_level info --llm_log_level info --per_device_train_batch_size ${IGC_BATCH} --num_workers ${IGC_WORKERS}"
-[ "${IGC_USE_PEFT:-0}" = "1" ] && COMMON="${COMMON} --use_peft --lora_r ${LORA_R:-16} --lora_alpha ${LORA_ALPHA:-32}"
-
-# Export so the bare `-e VAR` on `docker run` actually forwards them; otherwise a
-# non-exported shell var arrives empty and the container's `set -u` aborts (rc=127,
-# "COMMON: unbound variable").
-export IGC_GPUS IGC_STAGE IGC_MODEL IGC_RUN EPOCHS COMMON
-
-docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
-log "docker run ${IGC_IMAGE} | ${IGC_GPUS} GPU | code=${IGC_CODE_DIR} data=${IGC_DATA_DIR} models=${IGC_MODELS_DIR}"
-# NVIDIA-recommended flags (NGC startup banner): --ipc=host + memlock/stack ulimits.
-# Dual mounts: node-local code/data + the shared /models (240TB) so a run can write big
-# durable artifacts (checkpoints, HF cache) to /models or scratch to local via --output_dir.
+# --- 8. launch --------------------------------------------------------------------
+log "launch: rung=${IGC_RUNG:-<custom>} ${IGC_GPUS}GPU sharding=${IGC_SHARDING} smoke=${IGC_SMOKE} model=${IGC_MODEL}"
+render
 MODELS_MOUNT=""
 [ -d "$IGC_MODELS_DIR" ] && MODELS_MOUNT="-v ${IGC_MODELS_DIR}:/models"
+
+# The inner script is a literal with resolved values (so what dry-run prints is what runs);
+# creds are sourced from the gitignored env files by PATH, never interpolated as values.
+INNER=$(cat <<INNEREOF
+set -uo pipefail
+cd /workspace/igc
+if ! python -c "import transformers, accelerate, wandb" 2>/dev/null; then
+    if [ "${IGC_ALLOW_RUNTIME_PIP}" = "1" ]; then
+        echo "deps missing in ${IGC_IMAGE} — IGC_ALLOW_RUNTIME_PIP=1, installing"
+        pip install --no-cache-dir -r docker/requirements-train.txt 2>&1 | tail -3
+    else
+        echo "BLOCKER: training deps (transformers/accelerate/wandb) missing in ${IGC_IMAGE}." >&2
+        echo "Use igc-train:ngc26.03 (deps baked) or re-run with IGC_ALLOW_RUNTIME_PIP=1." >&2
+        exit 4
+    fi
+fi
+# creds: source the gitignored env files if present; NEVER echo their values
+[ -f "${IGC_WANDB_ENV}" ] && { set -a; . "${IGC_WANDB_ENV}"; set +a; }
+[ -f "${IGC_HF_ENV}" ]    && { set -a; . "${IGC_HF_ENV}";    set +a; }
+export WANDB_PROJECT="${WANDB_PROJECT}"
+export WANDB_NAME="${WANDB_NAME}"
+export WANDB_MODE="${RUN_WANDB_MODE}"
+echo "run: W&B project=\${WANDB_PROJECT} name=\${WANDB_NAME} mode=\${WANDB_MODE} | HF cache=\${HF_HOME:-<default>} token=\$([ -n "\${HF_TOKEN:-}" ] && echo available || echo none)"
+mkdir -p "${IGC_OUTPUT_DIR}"
+nvidia-smi -L
+INNEREOF
+)
+if [ -n "$PREBUILD_CMD" ]; then
+    INNER="${INNER}
+echo '--- PHASE A: single-GPU pre-build (serialise dataset build, no W&B) ---'
+${PREBUILD_CMD} || { echo \"PRE-BUILD FAILED rc=\$?\"; exit 20; }"
+fi
+INNER="${INNER}
+echo '--- TRAIN: ${IGC_GPUS} GPU sharding=${IGC_SHARDING} -> ${METRIC_REPORT} ---'
+${TRAIN_CMD}"
+
+docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
 # shellcheck disable=SC2086  # MODELS_MOUNT must word-split into a -v arg (or be empty)
 docker run --rm --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 \
     --name "$CONTAINER" \
     -v "${IGC_CODE_DIR}:/workspace/igc" \
     -v "${IGC_DATA_DIR}:/root/.json_responses:ro" \
     $MODELS_MOUNT \
+    -e "NCCL_CUMEM_ENABLE=${NCCL_CUMEM_ENABLE}" \
+    -e "NCCL_MNNVL_ENABLE=${NCCL_MNNVL_ENABLE}" \
     -w /workspace/igc \
-    -e IGC_GPUS -e IGC_STAGE -e IGC_MODEL -e IGC_RUN -e EPOCHS -e COMMON \
-    "$IGC_IMAGE" bash -lc '
-        set -uo pipefail
-        cd /workspace/igc
-        # deps are baked into igc-train:ngc26.03; only the bare NGC image needs runtime pip.
-        python -c "import transformers, accelerate, wandb" 2>/dev/null \
-            || pip install --no-cache-dir -r docker/requirements-train.txt 2>&1 | tail -3
-        [ -f .internal/wandb.env ] && { set -a; . .internal/wandb.env; set +a; }
-        export WANDB_PROJECT="${WANDB_PROJECT:-igc}"
-        nvidia-smi -L
-
-        if [ "$IGC_GPUS" -gt 1 ]; then
-            echo "--- PHASE A: single-GPU pre-build (serialise dataset build, no W&B) ---"
-            WANDB_MODE=disabled python igc_main.py --device cuda:0 $COMMON \
-                --num_train_epochs 1 --output_dir /tmp/prebuild --metric_report tensorboard \
-                || { echo "PRE-BUILD FAILED rc=$?"; exit 20; }
-        fi
-
-        echo "--- TRAIN: ${IGC_GPUS} GPU -> W&B (one rank-gated run) ---"
-        export WANDB_NAME="${IGC_RUN}-${IGC_GPUS}gpu-${IGC_MODEL//\//_}"
-        OUT="/workspace/igc/experiments/${IGC_RUN}"; mkdir -p "$OUT"
-        if [ "$IGC_GPUS" -gt 1 ]; then
-            accelerate launch --num_processes "$IGC_GPUS" --num_machines 1 --machine_rank 0 \
-                --main_process_ip 127.0.0.1 --main_process_port 29500 \
-                igc_main.py --use_accelerator --sharding fsdp $COMMON \
-                --num_train_epochs "$EPOCHS" --output_dir "$OUT" --metric_report wandb
-        else
-            python igc_main.py --device cuda:0 $COMMON \
-                --num_train_epochs "$EPOCHS" --output_dir "$OUT" --metric_report wandb
-        fi
-    '
+    "$IGC_IMAGE" bash -lc "$INNER"
 rc=$?
-log "run exited rc=${rc}"
+log "run exited rc=${rc} (output=${IGC_OUTPUT_DIR}, W&B name=${WANDB_NAME}, mode=${RUN_WANDB_MODE})"
 exit "$rc"
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/bats/gb300_launch.bats
+++ b/tests/bats/gb300_launch.bats
@@ -204,16 +204,37 @@ setup() {
     [[ "$output" != *"PHASE A"* ]]
 }
 
-# --- fail-fast on argv-breaking whitespace ----------------------------------
+# --- fail-fast on argv-breaking shell text ----------------------------------
 
-@test "whitespace in IGC_RUN or IGC_MODEL is rejected" {
+@test "whitespace or shell control characters in command-rendered knobs are rejected" {
     run env IGC_RUN="my run" bash "$LAUNCH"
     [ "$status" -ne 0 ]
-    [[ "$output" == *"IGC_RUN must contain no whitespace"* ]]
+    [[ "$output" == *"IGC_RUN contains whitespace or shell-control characters"* ]]
 
-    run env IGC_MODEL="a b" bash "$LAUNCH"
+    run env IGC_MODEL="gpt2;echo-bad" bash "$LAUNCH"
     [ "$status" -ne 0 ]
-    [[ "$output" == *"IGC_MODEL must contain no whitespace"* ]]
+    [[ "$output" == *"IGC_MODEL contains whitespace or shell-control characters"* ]]
+
+    run env IGC_OUTPUT_DIR="experiments/out;echo-bad" bash "$LAUNCH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"IGC_OUTPUT_DIR contains whitespace or shell-control characters"* ]]
+}
+
+@test "invalid master port and runtime toggles are rejected" {
+    run env IGC_MASTER_PORT="29500;echo-bad" bash "$LAUNCH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"IGC_MASTER_PORT must be an integer TCP port 1-65535"* ]]
+
+    run env IGC_MASTER_PORT=70000 bash "$LAUNCH"
+    [ "$status" -ne 0 ]
+
+    run env IGC_SMOKE=maybe bash "$LAUNCH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"IGC_SMOKE must be 0 or 1"* ]]
+
+    run env IGC_USE_PEFT=1 LORA_DROPOUT="0.1;echo-bad" bash "$LAUNCH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"LORA_DROPOUT must be a decimal value"* ]]
 }
 
 # --- render tells the truth about 1-GPU precision ---------------------------

--- a/tests/bats/gb300_launch.bats
+++ b/tests/bats/gb300_launch.bats
@@ -1,0 +1,235 @@
+#!/usr/bin/env bats
+# Offline render/validation tests for scripts/gb300_launch.sh.
+#
+# Everything runs in DRY-RUN mode (IGC_DRY_RUN=1): the launcher prints the exact docker
+# and igc_main.py command(s) and exits without touching docker, a GPU, or a node — so these
+# assert the flag mapping, the ladder rungs, fail-fast validation, and that no secret or
+# fleet host leaks, all on a plain CPU box. No docker/nvidia-smi is on PATH here on purpose.
+#
+# Author:
+# Mus mbayramo@stanford.edu
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+    export REPO_ROOT
+    LAUNCH="${REPO_ROOT}/scripts/gb300_launch.sh"
+    export LAUNCH
+    # keep paths off $HOME so the tests are hermetic
+    export IGC_CODE_DIR="${BATS_TEST_TMPDIR}/igc"
+    export IGC_DATA_DIR="${BATS_TEST_TMPDIR}/data"
+    export IGC_DRY_RUN=1
+}
+
+# --- ladder rungs -------------------------------------------------------------
+
+@test "smoke1: 1 GPU plain-python, steps capped, W&B off (tensorboard)" {
+    run env IGC_RUNG=smoke1 bash "$LAUNCH"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"gpus=1 sharding=none smoke=1"* ]]
+    [[ "$output" == *"python igc_main.py --device cuda:0"* ]]
+    [[ "$output" == *"--max_steps 20"* ]]
+    [[ "$output" == *"--metric_report tensorboard"* ]]
+    [[ "$output" == *"name=verify-m1-1gpu-none-gpt2-smoke mode=disabled"* ]]
+    # a 1-GPU run must NOT wrap in accelerate or pass a sharding/mixed_precision flag
+    [[ "$output" != *"accelerate launch"* ]]
+}
+
+@test "smoke4: 4 GPU DDP, capped steps, W&B off, has the pre-build phase" {
+    run env IGC_RUNG=smoke4 bash "$LAUNCH"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"gpus=4 sharding=ddp smoke=1"* ]]
+    [[ "$output" == *"accelerate launch --num_processes 4"* ]]
+    [[ "$output" == *"--sharding ddp"* ]]
+    [[ "$output" == *"PHASE A"* ]]
+    [[ "$output" == *"--max_steps 20"* ]]
+    [[ "$output" == *"mode=disabled"* ]]
+}
+
+@test "run4: 4 GPU DDP real short run -> W&B, TRAIN not step-capped" {
+    run env IGC_RUNG=run4 bash "$LAUNCH"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--sharding ddp"* ]]
+    [[ "$output" == *"--num_train_epochs 3"* ]]
+    [[ "$output" == *"--metric_report wandb"* ]]
+    [[ "$output" == *"mode=online"* ]]
+    # the real TRAIN command carries no --max_steps (the pre-build line legitimately caps at 1)
+    train_line="$(printf '%s\n' "$output" | grep 'TRAIN ')"
+    [[ "$train_line" != *"--max_steps"* ]]
+}
+
+@test "fsdp4: 4 GPU FSDP2 only when memory requires it" {
+    run env IGC_RUNG=fsdp4 bash "$LAUNCH"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--sharding fsdp"* ]]
+    [[ "$output" == *"--metric_report wandb"* ]]
+}
+
+@test "DDP is the default for multi-GPU (no rung, no sharding)" {
+    run env IGC_GPUS=4 bash "$LAUNCH"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--sharding ddp"* ]]
+    [[ "$output" != *"--sharding fsdp"* ]]
+}
+
+# --- env-knob -> igc_main.py flag mapping -------------------------------------
+
+@test "LoRA/rsLoRA knobs map to --use_peft/--adapter_method/--lora_*" {
+    run env IGC_GPUS=4 IGC_USE_PEFT=1 IGC_ADAPTER=rslora LORA_R=32 LORA_ALPHA=64 bash "$LAUNCH"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--use_peft --adapter_method rslora --lora_r 32 --lora_alpha 64 --lora_dropout 0.05"* ]]
+}
+
+@test "grad-accum, precision, batch and model map to real flags" {
+    run env IGC_GPUS=4 IGC_GRAD_ACCUM=8 IGC_PRECISION=fp8 IGC_BATCH=64 IGC_MODEL=Qwen/Qwen2.5-7B bash "$LAUNCH"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--gradient_accumulation_steps 8"* ]]
+    [[ "$output" == *"--mixed_precision fp8"* ]]
+    [[ "$output" == *"--per_device_train_batch_size 64"* ]]
+    [[ "$output" == *"--model_type Qwen/Qwen2.5-7B"* ]]
+    # HF repo id with '/' is sanitized in the W&B run name
+    [[ "$output" == *"name=verify-m1-4gpu-ddp-Qwen_Qwen2.5-7B"* ]]
+}
+
+@test "NCCL defaults: CUMEM on, MNNVL off; both overridable" {
+    run env IGC_RUNG=run4 bash "$LAUNCH"
+    [[ "$output" == *"-e NCCL_CUMEM_ENABLE=1 -e NCCL_MNNVL_ENABLE=0"* ]]
+
+    run env IGC_RUNG=run4 NCCL_MNNVL_ENABLE=1 NCCL_CUMEM_ENABLE=0 bash "$LAUNCH"
+    [[ "$output" == *"-e NCCL_CUMEM_ENABLE=0 -e NCCL_MNNVL_ENABLE=1"* ]]
+}
+
+@test "explicit knobs override a rung preset" {
+    run env IGC_RUNG=smoke4 IGC_SHARDING=fsdp IGC_SMOKE=0 bash "$LAUNCH"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--sharding fsdp"* ]]
+    [[ "$output" == *"--metric_report wandb"* ]]
+}
+
+# --- fail-fast validation (no silent fallback) --------------------------------
+
+@test "invalid IGC_SHARDING is rejected" {
+    run env IGC_SHARDING=zero9 bash "$LAUNCH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"BLOCKER: IGC_SHARDING='zero9' invalid"* ]]
+}
+
+@test "invalid IGC_PRECISION is rejected" {
+    run env IGC_PRECISION=int4 bash "$LAUNCH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"BLOCKER: IGC_PRECISION='int4' invalid"* ]]
+}
+
+@test "invalid IGC_ADAPTER is rejected" {
+    run env IGC_ADAPTER=qlora bash "$LAUNCH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"BLOCKER: IGC_ADAPTER='qlora' invalid"* ]]
+}
+
+@test "non-integer / zero IGC_GPUS is rejected" {
+    run env IGC_GPUS=abc bash "$LAUNCH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"IGC_GPUS must be an integer >= 1"* ]]
+
+    run env IGC_GPUS=0 bash "$LAUNCH"
+    [ "$status" -ne 0 ]
+}
+
+@test "unknown IGC_RUNG is rejected" {
+    run env IGC_RUNG=mega8 bash "$LAUNCH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unknown IGC_RUNG='mega8'"* ]]
+}
+
+@test "negative batch / bad max_steps are rejected" {
+    run env IGC_BATCH=-1 bash "$LAUNCH"
+    [ "$status" -ne 0 ]
+    run env IGC_MAX_STEPS=x bash "$LAUNCH"
+    [ "$status" -ne 0 ]
+}
+
+# --- safety: no secret / no fleet host in the render --------------------------
+
+@test "render leaks no fleet IP and references creds by file, not value" {
+    run env IGC_RUNG=run4 bash "$LAUNCH"
+    [ "$status" -eq 0 ]
+    # single-node rendezvous is localhost only; no internal 172.25.x.x fleet address
+    [[ "$output" != *"172.25."* ]]
+    [[ "$output" == *"127.0.0.1"* ]]
+    # W&B/HF creds are sourced from a gitignored file path, never printed inline
+    [[ "$output" == *".internal/wandb.env"* ]]
+    [[ "$output" != *"WANDB_API_KEY="* ]]
+    [[ "$output" != *"HF_TOKEN="* ]]
+}
+
+# --- IGC_STAGE is a real selector, not just a label -------------------------
+
+@test "IGC_STAGE maps to the real --train/--llm flags and labels the run" {
+    run env IGC_GPUS=4 IGC_STAGE=m2 bash "$LAUNCH"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--train llm --llm encoder"* ]]
+    [[ "$output" == *"stage=m2"* ]]
+    [[ "$output" == *"name=verify-m2-"* ]]
+    # m2 must NOT silently emit m1's --llm latent
+    [[ "$output" != *"--llm latent"* ]]
+
+    run env IGC_GPUS=4 IGC_STAGE=m3 bash "$LAUNCH"
+    [[ "$output" == *"--llm goal"* ]]
+}
+
+@test "RL/combined stages are rejected here (they belong in train_igc.sbatch)" {
+    run env IGC_STAGE=m6 bash "$LAUNCH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not wired here"* ]]
+    [[ "$output" == *"train_igc.sbatch"* ]]
+}
+
+@test "invalid IGC_STAGE is rejected" {
+    run env IGC_STAGE=m9 bash "$LAUNCH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"IGC_STAGE='m9' invalid"* ]]
+}
+
+# --- pre-build is a capped dataset build, not a full single-GPU epoch --------
+
+@test "multi-GPU pre-build is capped at --max_steps 1 (build, not a whole epoch)" {
+    run env IGC_RUNG=run4 bash "$LAUNCH"
+    [ "$status" -eq 0 ]
+    # the PHASE A line must carry the cap so it exits after the dataset cache is written
+    [[ "$output" == *"PHASE A"*"--max_steps 1"* ]]
+}
+
+@test "IGC_PREBUILD=0 skips the pre-build phase entirely" {
+    run env IGC_GPUS=4 IGC_PREBUILD=0 bash "$LAUNCH"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"PHASE A"* ]]
+}
+
+# --- fail-fast on argv-breaking whitespace ----------------------------------
+
+@test "whitespace in IGC_RUN or IGC_MODEL is rejected" {
+    run env IGC_RUN="my run" bash "$LAUNCH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"IGC_RUN must contain no whitespace"* ]]
+
+    run env IGC_MODEL="a b" bash "$LAUNCH"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"IGC_MODEL must contain no whitespace"* ]]
+}
+
+# --- render tells the truth about 1-GPU precision ---------------------------
+
+@test "1-GPU render marks IGC_PRECISION as ignored (tf32 only), not applied" {
+    run env IGC_RUNG=smoke1 IGC_PRECISION=bf16 bash "$LAUNCH"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"tf32 only (IGC_PRECISION=bf16 ignored on 1 GPU)"* ]]
+    [[ "$output" != *"--mixed_precision"* ]]
+}
+
+@test "dry-run needs neither docker nor nvidia-smi on PATH" {
+    # a minimal PATH with no docker / nvidia-smi still renders (proves no launch happens)
+    run env -u IGC_DRY_RUN HOME="${BATS_TEST_TMPDIR}" IGC_DRY_RUN=1 IGC_RUNG=smoke1 \
+        PATH="/usr/bin:/bin" IGC_CODE_DIR="${IGC_CODE_DIR}" IGC_DATA_DIR="${IGC_DATA_DIR}" \
+        bash "$LAUNCH"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DRY RUN — nothing launched"* ]]
+}

--- a/tests/bats/gb300_launch.bats
+++ b/tests/bats/gb300_launch.bats
@@ -255,7 +255,7 @@ setup() {
     [[ "$output" == *"DRY RUN — nothing launched"* ]]
 }
 
-@test "live path passes a syntactically valid inner script to docker" {
+@test "live path executes inner script without printing HF token values" {
     fake_bin="${BATS_TEST_TMPDIR}/bin"
     mkdir -p "$fake_bin" "$IGC_CODE_DIR" "$IGC_DATA_DIR"
     touch "${IGC_CODE_DIR}/igc_main.py"
@@ -281,7 +281,7 @@ esac
 if [ "$1" = "run" ]; then
   while [ "$#" -gt 0 ]; do
     if [ "$1" = "bash" ] && [ "${2:-}" = "-lc" ]; then
-      bash -n -c "${3:-}"
+      HF_TOKEN=SECRET_SENTINEL bash -c "${3:-}"
       exit $?
     fi
     shift
@@ -292,12 +292,18 @@ fi
 echo "unexpected docker invocation: $*" >&2
 exit 8
 EOF
-    chmod +x "${fake_bin}/nvidia-smi" "${fake_bin}/df" "${fake_bin}/docker"
+    cat > "${fake_bin}/python" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "${fake_bin}/nvidia-smi" "${fake_bin}/df" "${fake_bin}/docker" "${fake_bin}/python"
 
     run env -u IGC_DRY_RUN IGC_RUNG=smoke1 IGC_IMAGE=igc-train:ngc26.03 \
         IGC_CODE_DIR="$IGC_CODE_DIR" IGC_DATA_DIR="$IGC_DATA_DIR" \
         PATH="${fake_bin}:/usr/bin:/bin" bash "$LAUNCH"
     [ "$status" -eq 0 ]
     [[ "$output" == *"launch: rung=smoke1"* ]]
+    [[ "$output" == *"token=available"* ]]
+    [[ "$output" != *"SECRET_SENTINEL"* ]]
     [[ "$output" == *"run exited rc=0"* ]]
 }

--- a/tests/bats/gb300_launch.bats
+++ b/tests/bats/gb300_launch.bats
@@ -254,3 +254,50 @@ setup() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"DRY RUN — nothing launched"* ]]
 }
+
+@test "live path passes a syntactically valid inner script to docker" {
+    fake_bin="${BATS_TEST_TMPDIR}/bin"
+    mkdir -p "$fake_bin" "$IGC_CODE_DIR" "$IGC_DATA_DIR"
+    touch "${IGC_CODE_DIR}/igc_main.py"
+
+    cat > "${fake_bin}/nvidia-smi" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"--query-compute-apps=pid"*) exit 0 ;;
+  "-L"*) printf 'GPU 0\nGPU 1\nGPU 2\nGPU 3\n' ;;
+  *) printf 'GPU 0, 0 %, 0 MiB\nGPU 1, 0 %, 0 MiB\nGPU 2, 0 %, 0 MiB\nGPU 3, 0 %, 0 MiB\n' ;;
+esac
+EOF
+    cat > "${fake_bin}/df" <<'EOF'
+#!/usr/bin/env bash
+printf 'Avail\n200G\n'
+EOF
+    cat > "${fake_bin}/docker" <<'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "image inspect") exit 0 ;;
+  "rm -f") exit 0 ;;
+esac
+if [ "$1" = "run" ]; then
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "bash" ] && [ "${2:-}" = "-lc" ]; then
+      bash -n -c "${3:-}"
+      exit $?
+    fi
+    shift
+  done
+  echo "missing bash -lc payload" >&2
+  exit 9
+fi
+echo "unexpected docker invocation: $*" >&2
+exit 8
+EOF
+    chmod +x "${fake_bin}/nvidia-smi" "${fake_bin}/df" "${fake_bin}/docker"
+
+    run env -u IGC_DRY_RUN IGC_RUNG=smoke1 IGC_IMAGE=igc-train:ngc26.03 \
+        IGC_CODE_DIR="$IGC_CODE_DIR" IGC_DATA_DIR="$IGC_DATA_DIR" \
+        PATH="${fake_bin}:/usr/bin:/bin" bash "$LAUNCH"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"launch: rung=smoke1"* ]]
+    [[ "$output" == *"run exited rc=0"* ]]
+}


### PR DESCRIPTION
Expands the single-node docker launcher (`scripts/gb300_launch.sh`) into the "boring and repeatable" training path, with offline render/validation tests.

## What's new
- **Ladder rungs** `IGC_RUNG=smoke1|smoke4|run4|fsdp4` encode the 1→4 GPU ladder. **DDP is the default for multi-GPU** (per `docs/DISTRIBUTED_PLAN.md` — ~3× faster at 4 GPU for models that fit); FSDP2 is opt-in (`fsdp4` / `IGC_SHARDING=fsdp`).
- **Dry-run** `IGC_DRY_RUN=1` prints the EXACT `docker run` + `accelerate/python igc_main.py` command(s) and exits — no docker, GPU, or node needed (so it runs on a laptop / in CI).
- **Env knobs, each mapped to a real `igc_main.py` flag** (grounded in `igc/shared/shared_arg_parser.py`): `IGC_STAGE` (m1|m2|m3|m3p → `--train/--llm`, per `train_igc.sbatch`), `IGC_PRECISION` (`--mixed_precision`), `IGC_GRAD_ACCUM`, `IGC_BATCH`, LoRA/rsLoRA (`--use_peft --adapter_method`), `IGC_OUTPUT_DIR`, W&B/HF env files.
- **NCCL** `NCCL_CUMEM_ENABLE=1`, `NCCL_MNNVL_ENABLE=0` by default (per TEAM_GUIDE), both overridable.
- **Fail-fast validation, no silent fallback**: clear `BLOCKER`s for bad sharding/precision/adapter/stage/gpus/rung and whitespace in run/model; runtime pip is opt-in (`IGC_ALLOW_RUNTIME_PIP`).
- **Safety**: creds sourced in-container from gitignored env files, never printed (token=available|none only); localhost rendezvous only (no fleet host); free-space guard checks the checkpoint filesystem, not `$HOME`.
- The multi-GPU **pre-build is capped at `--max_steps 1`** (builds the dataset cache, not a full single-GPU epoch); `IGC_PREBUILD=0` skips it for a model too large to fit one GPU.

## Verification (offline, CPU)
- `shellcheck scripts/gb300_launch.sh tests/bats/gb300_launch.bats`: clean
- `tests/bats/gb300_launch.bats`: **24 passed** (render for each rung, stage→flag mapping, LoRA/rsLoRA/precision/grad-accum, NCCL defaults, validation blockers, no-leak, prebuild cap/skip)
- Captured the real in-container `bash -lc` payload and `bash -n`'d it: valid
- Full offline pytest gate unaffected: **666 passed, 29 deselected, 8 xfailed** (bash-only change)
- Reviewed by an adversarial multi-lens pass; 6 findings (prebuild full-epoch, IGC_STAGE provenance, log-dir no-op, precision render, free-space target, whitespace argv) were all fixed and re-verified before this PR.

CI's `shell` job runs shellcheck + `bats tests/bats` on the new file.