### PR TITLE
Support redfish_ctl dataset manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Infrastructure Goal-Condition Reinforce Learner (`igc`) is a Python research project for training a
 goal-conditioned reinforcement-learning agent to operate Redfish-exposed infrastructure as a Markov
 Decision Process. The agent observes Redfish GET/HEAD responses, chooses REST actions, and learns
-from captured Redfish data collected by the `idrac_ctl/` git submodule.
+from captured Redfish data produced by `redfish_ctl`.
 
 ## Start here: local CPU smoke gate
 
@@ -41,7 +41,7 @@ and verification guide.
 
 - `igc/ds/` contains the Redfish dataset pipeline, including JSON response loading, tokenizer input
   construction, masked datasets, and the `rest_api_map.npy` loader for the map written by
-  `idrac_ctl/` discovery.
+  `redfish_ctl` discovery.
 - `igc/envs/` contains the mock REST environment and Gym-style wrappers used for offline simulation.
 - `igc/interfaces/` contains the REST mapping interface that binds URLs to captured response files.
 - `igc/modules/` contains model and training code for the language model, state encoder, value head,
@@ -49,24 +49,37 @@ and verification guide.
 - `igc/shared/` contains shared argument parsing and utility code.
 - `igc/core/` contains typed contracts for the generic tool-use agent architecture.
 - `tests/` contains pytest coverage. Default tests must stay offline: no GPU, network, HuggingFace
-  download, live Redfish host, or real `idrac_ctl` crawl.
+  download, live Redfish host, or real `redfish_ctl` crawl.
 - `docs/` contains the deeper design and environment material. Start with
   [docs/README.md](docs/README.md).
-- `idrac_ctl/` is a git submodule for Redfish data collection. Do not edit it from this repository.
 
 ## Data flow
 
-`idrac_ctl/`, the pinned data-collection submodule, discovers Redfish resources and writes captured
-JSON to `~/.json_responses/<host>/...`. The same discovery step writes `rest_api_map.npy`, a numpy map
-with `url_file_mapping` and `allowed_methods_mapping`. `igc/ds/ds_rest_trajectories.py` loads that map
-with `np.load(..., allow_pickle=True).item()`; those keys are the binding contract between the two
-repositories.
+The preferred input is a materialized `redfish_ctl` dataset artifact. Pull and verify the selected
+dataset archives in `redfish_ctl`, then materialize them into a stable vendor/model/capture layout:
+
+```bash
+git lfs install
+python tools/corpus.py pull --kind dataset --vendor dell --model xr8620t
+python tools/corpus.py verify --kind dataset --vendor dell --model xr8620t --require-materialized
+python tools/corpus.py materialize --kind dataset --vendor dell --model xr8620t --dest ./build/corpus
+python -m igc.ds.sources.redfish_fixture_source \
+  --corpus-manifest ./corpora/manifest.v1.json \
+  --corpus-root ./build/corpus
+```
+
+The legacy compatibility input is still supported: `redfish_ctl discovery` writes captured JSON to
+`~/.json_responses/<host>/...` and writes `rest_api_map.npy`, a NumPy map with `url_file_mapping` and
+`allowed_methods_mapping`. `igc/ds/ds_rest_trajectories.py` loads that map with
+`np.load(..., allow_pickle=True).item()`; those keys are the binding legacy contract between the two
+repositories. New dataset consumers should prefer `rest_api_map.v1.json`, whose file paths are
+relative to the materialized capture root.
 
 The default development path does not run discovery. Use captured data or the mock REST server in
 `igc/envs/` for offline tests. A live Redfish crawl can affect real management controllers, so it
 requires explicit current-task approval, an approved non-production host, credentials passed through
-environment variables or flags, and pacing. Never hardcode or print `IDRAC_IP`, `IDRAC_USERNAME`, or
-`IDRAC_PASSWORD` values.
+environment variables or flags, and pacing. Never hardcode or print `REDFISH_IP`,
+`REDFISH_USERNAME`, or `REDFISH_PASSWORD` values.
 
 `HUGGINGFACE_TOKEN`, when set by the developer for opt-in model downloads, is not needed for the
 local smoke gate and must not be logged or committed.
@@ -90,8 +103,8 @@ representation. The full plan and model curriculum live in
 - Mark GPU, HuggingFace download, slow, or live Redfish tests so they skip by default.
 - Do not commit credentials, captured responses, datasets, checkpoints, tokenizers, tarballs, or
   generated raw model output.
-- Do not edit `idrac_ctl/` here. Changes to that tool belong in the `spyroot/idrac_ctl` repository,
-  followed by a deliberate submodule bump in `igc`.
+- Changes to the capture tool belong in the `spyroot/redfish_ctl` repository and should be consumed
+  here through a released artifact or an explicit dataset materialization step.
 
 ## Next reading
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -250,7 +250,7 @@ The design makes the hypothesis concrete, layer by layer:
 1. **Extract the goal.** The planner (the "casting" layer) maps a high-level instruction to a `Goal`
    and an ordered sub-goal `plan` (the hierarchical decomposition above).
 2. **Discover the action space.** A new backend exposes its tools/ops through `ToolCatalog` +
-   `available_actions(obs)` (for Redfish, derived from the `idrac_ctl` crawl + the `.npy` map). The
+   `available_actions(obs)` (for Redfish, derived from the `redfish_ctl` crawl + the `.npy` map). The
    agent never needs a fixed, pre-enumerated action set — it reads what is legal *now*.
 3. **Act zero/few-shot.** Because the policy is the **pointer / candidate-scoring** head (§1), a tool
    it has never seen is still scorable: its `tool_name/op/schema` text is embedded by the shared
@@ -371,8 +371,8 @@ Found in-tree during design review:
    reward). `truncated` is a budget/time cut → bootstrapping continues. The DQN mask
    is `(1 - terminated)` only; a transition is terminal iff the env goal was reached.
 3. **legal-action source of truth** — merged catalog. The `.npy`
-   `allowed_methods_mapping` is authoritative for *verb legality* per URL (the binding
-   `idrac_ctl` contract); the JSON `Actions` / `@Redfish.ActionInfo` blocks supply the
+   `allowed_methods_mapping` is authoritative for *verb legality* per URL (the binding legacy
+   `redfish_ctl` discovery contract); the JSON `Actions` / `@Redfish.ActionInfo` blocks supply the
    *parameter space* (enums) consumed by the stage-2 argument decoder. CSDL schema is a
    later enrichment.
 4. **credential logging** — redacted before any live canary

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -21,7 +21,7 @@ reflects it, or the agent learns a degenerate read-only policy. Today the shippe
 for every POST/PATCH/DELETE — the stateful mechanism exists (`register_callback`/`new_state`/
 `callback_dispatcher` in `igc/envs/rest_mock_server.py`) but is wired only in tests, and there is no
 ordered mutation trace. Separately, `rest_mock_server.py` is a 769-line **home-grown Redfish client +
-mock** built when `idrac_ctl` was only a data collector: it re-implements Redfish HTTP transport,
+mock** built when the capture tool was only a data collector: it re-implements Redfish HTTP transport,
 auth, captured-response serving, error modelling, and a **live-BMC proxy** — duplicating what the
 renamed, full multi-vendor **redfish_ctl** now provides, and putting a live-write path in the RL
 codebase that the safety contract says must go through redfish_ctl.

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -47,7 +47,7 @@ A green local run currently ends with `29 passed` for `tests/core` and `All chec
 The intended integration gate is `pytest -q` plus `ruff check <changed files>` after GPU/download/live
 tests are marked and the shared fixtures are in place. Until then, new tests should name their safe
 node ids or files directly and must not require a GPU, network, HuggingFace download, live Redfish
-host, or real `idrac_ctl` crawl.
+host, or real `redfish_ctl` crawl.
 
 ## 2. Reproducible test image
 
@@ -61,7 +61,7 @@ docker run --rm igc-test:cpu ruff check igc/core tests/core
 ```
 
 The Docker build context is trimmed by `.dockerignore`, which excludes datasets, tarballs, `.npy`
-files, checkpoints, the `idrac_ctl` submodule, and local-only coordination files.
+files, checkpoints, and local-only coordination files.
 
 ## 3. Training on the GB300 NVL72
 

--- a/docs/HOW_TO_PROFILE.md
+++ b/docs/HOW_TO_PROFILE.md
@@ -18,16 +18,15 @@ python scripts/bench_hot_paths.py
 python scripts/bench_hot_paths.py --section rl
 
 # just the data-gen path over a specific corpus
-python scripts/bench_hot_paths.py --section data --corpus idrac_ctl/tests/hpe_fixtures
+python scripts/bench_hot_paths.py --section data --corpus tests/hpe_fixtures
 
 # add cProfile: prints the top cumulative-time functions (the critical sections)
 python scripts/bench_hot_paths.py --profile
 ```
 
 Local runs use the project env (`conda activate igc-dev`, or call its Python directly). The
-data-gen section reads fixture corpora from the `idrac_ctl` submodule, so
-`git submodule update --init && git -C idrac_ctl lfs pull` first if you want that section; the RL
-section needs nothing but the repo.
+data-gen section reads fixture corpora from the checkout or a materialized `redfish_ctl` dataset; the
+RL section needs nothing but the repo.
 
 ### Reading the output
 

--- a/docs/REDFISH_ENUM_SPACES.md
+++ b/docs/REDFISH_ENUM_SPACES.md
@@ -17,10 +17,11 @@ contain the real value spaces; this layer extracts them offline.
 
 ## What discovery captures vs. what was ingested
 
-`redfish_ctl` (>= 1.1.3) discovery preserves the `idrac_ctl` output contract — one JSON
-file per resource plus `rest_api_map.npy` holding `url_file_mapping` and
-`allowed_methods_mapping` (the binding `.npy` contract loaded by
-`igc/ds/ds_rest_trajectories.py`, unchanged by this work). The generic adapter
+`redfish_ctl` discovery preserves the legacy output contract — one JSON file per resource plus
+`rest_api_map.npy` holding `url_file_mapping` and `allowed_methods_mapping` (the binding `.npy`
+contract loaded by `igc/ds/ds_rest_trajectories.py`, unchanged by this work). Materialized dataset
+artifacts also provide `rest_api_map.v1.json` with relative paths for portable consumers. The generic
+adapter
 `RedfishFixtureSource` (in `igc/ds/sources/redfish_fixture_source.py`) already streams
 every captured body as a provenance-tagged `SourceRecord`; what was missing is semantic
 extraction of the value spaces inside these resource types:
@@ -80,8 +81,8 @@ distinguishable `TrainingExample` records without re-parsing bodies.
 
 ## Validation on real corpora
 
-Running the index over the three vendor fixture corpora
-(`idrac_ctl/tests/{idrac,supermicro,hpe}_fixtures`) plus one live HPE capture tree
+Running the index over the vendor fixture corpora
+(`tests/{dell,supermicro,hpe}_fixtures`) plus one live HPE capture tree
 (2,030 records, zero parse skips) yields 380 patchable slots — 97 of them categorical
 with real enum spaces (e.g. `ProcCStates`, `BootMode`) — 9 action parameters
 (`ResetType` with the full DMTF reset set, Dell OEM job parameters, SecureBoot /
@@ -100,4 +101,4 @@ external registry pointers.
 * **HPE registry payloads are external** (`Location[].Uri` under a registry store);
   ingesting them needs either a targeted capture of those URIs or the vendor tree they
   ship in.
-* The `.npy` contract and the `idrac_ctl` submodule are untouched.
+* The legacy `.npy` contract is retained while portable dataset maps are added.

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -40,12 +40,25 @@ values into repo files.
 
 ## 2. Data
 
-Training reads captured Redfish JSON from `~/.json_responses` (collected by `idrac_ctl`; the
-`.npy` map is the binding contract). The cluster has a shared filesystem mounted at `/models` on
-every node — stage large shared artifacts (staged weights, checkpoints, built corpora) there, in
-packed form (tarballs, JSONL) rather than many small files. Keep per-run scratch (the igc checkout,
-a run's working dataset copy) on the target node's local NVMe, and pin the job to that node with
-the scheduler's node-selection flag.
+Training reads captured Redfish JSON from a materialized `redfish_ctl` dataset artifact. Use
+`redfish_ctl` to pull, strictly verify, and materialize the selected dataset into a stable
+vendor/model/capture layout, then point IGC at the manifest and materialized root:
+
+```bash
+python tools/corpus.py pull --kind dataset --vendor dell --model xr8620t
+python tools/corpus.py verify --kind dataset --vendor dell --model xr8620t --require-materialized
+python tools/corpus.py materialize --kind dataset --vendor dell --model xr8620t --dest ./build/corpus
+python -m igc.ds.sources.redfish_fixture_source \
+  --corpus-manifest ./corpora/manifest.v1.json \
+  --corpus-root ./build/corpus
+```
+
+The legacy `~/.json_responses` capture layout remains a compatibility input; its `.npy` map is the
+binding legacy contract. The cluster has a shared filesystem mounted at `/models` on every node —
+stage large shared artifacts (staged weights, checkpoints, built corpora) there, in packed form
+(tarballs, JSONL) rather than many small files. Keep per-run scratch (the igc checkout, a run's
+working dataset copy) on the target node's local NVMe, and pin the job to that node with the
+scheduler's node-selection flag.
 
 ## 3. Experiment tracking (Weights & Biases)
 

--- a/igc/ds/redfish_dataset.py
+++ b/igc/ds/redfish_dataset.py
@@ -1430,7 +1430,7 @@ class JSONDataset(
                     return
                 if not self.respond_to_api_contains(_file_path):
                     # Tolerate partial captures: a response file with no entry in the
-                    # rest_api_map is skipped, not fatal (idrac_ctl crawls can be partial,
+                    # rest_api_map is skipped, not fatal (redfish_ctl crawls can be partial,
                     # e.g. a Settings.json whose parent URL was not recorded in the .npy map).
                     self.logger.warning(
                         f"Skipping {_file_path}: no corresponding rest api in the map "

--- a/igc/ds/sources/base.py
+++ b/igc/ds/sources/base.py
@@ -1,13 +1,13 @@
 """
 Data-source contracts for the IGC training pipeline.
 
-A :class:`SourceAdapter` turns a corpus of Redfish observations — real captures
-under ``~/.json_responses`` (written by ``idrac_ctl`` discovery), the DMTF
-mockup replay tree, a vendor emulator, or a synthetic generator — into a stream
-of provenance-tagged :class:`SourceRecord` objects. Every record carries where
-it came from (``source``) and how much it can be trusted (:class:`TrustLevel`),
-so the training/eval split can hold out real data as ground truth and weight or
-filter the more synthetic tiers.
+A :class:`SourceAdapter` turns a corpus of Redfish observations — materialized
+``redfish_ctl`` dataset artifacts, legacy captures under ``~/.json_responses``,
+the DMTF mockup replay tree, a vendor emulator, or a synthetic generator — into
+a stream of provenance-tagged :class:`SourceRecord` objects. Every record
+carries where it came from (``source``) and how much it can be trusted
+(:class:`TrustLevel`), so the training/eval split can hold out real data as
+ground truth and weight or filter the more synthetic tiers.
 
 The trust ordering (real > replay > sim-vendor > sim-generic > sim-drift)
 mirrors the data-provenance design: real captures validate semantics, while the

--- a/igc/ds/sources/redfish_fixture_source.py
+++ b/igc/ds/sources/redfish_fixture_source.py
@@ -2,10 +2,10 @@
 Filesystem source adapter for captured Redfish JSON corpora.
 
 :class:`RedfishFixtureSource` reads a directory of per-resource Redfish JSON
-files — the layout ``idrac_ctl`` discovery writes to ``~/.json_responses/<host>/``,
-and the same one-file-per-resource layout used by the vendor fixture corpora
-(``idrac_ctl/tests/{idrac,supermicro,hpe}_fixtures``) and the DMTF mockup tree —
-and yields provenance-tagged :class:`SourceRecord` objects.
+files, including a dataset artifact materialized by ``redfish_ctl corpus materialize``.
+It also supports older capture roots such as ``~/.json_responses/<host>/`` and
+the one-file-per-resource vendor fixture corpora, and yields provenance-tagged
+:class:`SourceRecord` objects.
 
 It keys each record on the resource's canonical ``@odata.id`` (present on the
 large majority of captures and vendor-neutral); when a file lacks one it falls
@@ -23,7 +23,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Dict, Iterator, List, Optional, Tuple
+from typing import Dict, Iterator, List, Optional, Sequence, Tuple
 
 from igc.ds.sources.base import SourceAdapter, SourceRecord, TrustLevel
 
@@ -31,14 +31,17 @@ from igc.ds.sources.base import SourceAdapter, SourceRecord, TrustLevel
 class RedfishFixtureSource(SourceAdapter):
     """Yield provenance-tagged records from a directory of Redfish JSON files.
 
-    :param root: directory holding ``*.json`` resource captures (``~`` expanded).
+    :param root: directory holding resource captures (``~`` expanded).
     :param source: source label stamped on every record (e.g. ``"real_dell"``).
     :param trust_level: provenance tier for every record (see :class:`TrustLevel`).
     :param vendor: originating vendor when known (``dell`` / ``hpe`` / ``supermicro``).
     :param allowed_methods_map: optional ``{url: [methods]}`` taken from the
         ``allowed_methods_mapping`` half of the ``.npy`` contract; when given,
         methods are matched to a record by its canonical URL.
-    :param glob_pattern: filename glob selecting captures (default ``*.json``).
+    :param glob_pattern: filename glob selecting captures (default ``**/*.json``).
+    :param corpus_id: stable corpus identity for provenance; defaults to ``source``.
+    :param capture_id: optional capture identity from the manifest.
+    :param model: optional hardware model from the manifest.
     """
 
     def __init__(
@@ -48,13 +51,19 @@ class RedfishFixtureSource(SourceAdapter):
         trust_level: TrustLevel,
         vendor: Optional[str] = None,
         allowed_methods_map: Optional[Dict[str, List[str]]] = None,
-        glob_pattern: str = "*.json",
+        glob_pattern: str = "**/*.json",
+        corpus_id: Optional[str] = None,
+        capture_id: Optional[str] = None,
+        model: Optional[str] = None,
     ):
         super().__init__(module_name=f"RedfishFixtureSource[{source}]")
         self.root = Path(os.path.expanduser(root))
         self.source = source
         self.trust_level = trust_level
         self.vendor = vendor
+        self.corpus_id = corpus_id or source
+        self.capture_id = capture_id
+        self.model = model
         self._allowed = allowed_methods_map or {}
         self._glob = glob_pattern
         # Exposed after iteration for reporting / eval bookkeeping.
@@ -62,10 +71,98 @@ class RedfishFixtureSource(SourceAdapter):
         self.num_skipped = 0
 
     @staticmethod
+    def _archive_slug(entry: Dict) -> str:
+        """Return the materialized directory slug for one redfish_ctl manifest row."""
+        archive = entry.get("archive") or entry.get("archive_path")
+        if isinstance(archive, str) and archive:
+            name = Path(archive).name
+            if name.endswith(".tar.gz"):
+                return name[:-7]
+            return Path(name).stem
+        vendor = str(entry.get("vendor", "")).strip()
+        model = str(entry.get("model", "")).strip()
+        return f"{vendor}_{model}".strip("_")
+
+    @staticmethod
+    def _normalize_kind(kind: str) -> str:
+        """Accept the former selector name as the dataset artifact kind."""
+        return {"full": "dataset"}.get(str(kind).lower(), str(kind).lower())
+
+    @staticmethod
+    def _load_allowed_methods(root: Path) -> Dict[str, List[str]]:
+        """Load the per-capture allowed-method map from portable JSON or legacy NPY."""
+        portable = root / "rest_api_map.v1.json"
+        if portable.is_file():
+            with portable.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            methods = data.get("allowed_methods_mapping", {})
+            return methods if isinstance(methods, dict) else {}
+
+        legacy = root / "rest_api_map.npy"
+        if legacy.is_file():
+            import numpy as np
+
+            data = np.load(legacy, allow_pickle=True).item()
+            methods = data.get("allowed_methods_mapping", {})
+            return methods if isinstance(methods, dict) else {}
+        return {}
+
+    @classmethod
+    def from_redfish_ctl_manifest(
+        cls,
+        manifest_path: str,
+        materialized_root: str,
+        trust_level: TrustLevel = TrustLevel.REAL,
+        kind: str = "dataset",
+        corpus_ids: Optional[Sequence[str]] = None,
+    ) -> List["RedfishFixtureSource"]:
+        """Create sources for a materialized redfish_ctl corpus manifest.
+
+        :param manifest_path: path to ``corpora/manifest.v1.json``.
+        :param materialized_root: output root from ``redfish_ctl corpus materialize``.
+        :param trust_level: provenance tier stamped on emitted records.
+        :param kind: corpus kind to consume, normally ``"dataset"``.
+        :param corpus_ids: optional allow-list of manifest IDs.
+        :return: one source per selected, materialized manifest row.
+        """
+        manifest_file = Path(os.path.expanduser(manifest_path))
+        materialized = Path(os.path.expanduser(materialized_root))
+        with manifest_file.open("r", encoding="utf-8") as fh:
+            manifest = json.load(fh)
+        entries = manifest.get("corpora", [])
+        selected = set(corpus_ids or [])
+        normalized_kind = cls._normalize_kind(kind)
+        sources: List[RedfishFixtureSource] = []
+        for entry in entries:
+            corpus_id = str(entry.get("id") or entry.get("corpus_id") or "")
+            entry_kind = cls._normalize_kind(str(entry.get("kind", "")))
+            if entry_kind != normalized_kind:
+                continue
+            if selected and corpus_id not in selected:
+                continue
+            slug = cls._archive_slug(entry)
+            root = materialized / normalized_kind / slug
+            if not root.is_dir():
+                root = materialized / slug
+            sources.append(
+                cls(
+                    str(root),
+                    corpus_id or slug,
+                    trust_level,
+                    vendor=entry.get("vendor"),
+                    allowed_methods_map=cls._load_allowed_methods(root),
+                    corpus_id=corpus_id or slug,
+                    capture_id=entry.get("capture_id"),
+                    model=entry.get("model"),
+                )
+            )
+        return sources
+
+    @staticmethod
     def url_from_filename(name: str) -> str:
         """Reconstruct a Redfish URL from a discovery filename.
 
-        idrac_ctl encodes ``/redfish/v1/Systems/1`` as
+        redfish_ctl discovery encodes ``/redfish/v1/Systems/1`` as
         ``_redfish_v1_Systems_1.json``. This is a best-effort fallback used only
         when a file carries no ``@odata.id`` — segment IDs that themselves
         contain underscores cannot be recovered unambiguously this way.
@@ -88,6 +185,18 @@ class RedfishFixtureSource(SourceAdapter):
         if isinstance(odata, str) and odata:
             return odata, "odata"
         return self.url_from_filename(path.name), "filename"
+
+    @staticmethod
+    def _is_metadata_json(path: Path, body: Dict) -> bool:
+        """Return true for corpus metadata sidecars that are not Redfish resources."""
+        if "@odata.id" in body:
+            return False
+        return path.name in {
+            "corpus.json",
+            "manifest.json",
+            "manifest.v1.json",
+            "rest_api_map.v1.json",
+        }
 
     def iter_records(self) -> Iterator[SourceRecord]:
         """Walk the corpus and yield one record per parsable resource object.
@@ -115,7 +224,20 @@ class RedfishFixtureSource(SourceAdapter):
             if not isinstance(body, dict):
                 self.num_skipped += 1
                 continue
+            if self._is_metadata_json(path, body):
+                self.num_skipped += 1
+                continue
             url, url_source = self._resolve_url(body, path)
+            rel_path = path.relative_to(self.root).as_posix()
+            provenance = {
+                "file": rel_path,
+                "url_from": url_source,
+                "corpus_id": self.corpus_id,
+            }
+            if self.capture_id:
+                provenance["capture_id"] = self.capture_id
+            if self.model:
+                provenance["model"] = self.model
             self.num_emitted += 1
             yield SourceRecord(
                 url=url,
@@ -126,7 +248,7 @@ class RedfishFixtureSource(SourceAdapter):
                 allowed_methods=self._allowed.get(url),
                 vendor=self.vendor,
                 schema_version=str(body.get("@odata.type", "")),
-                provenance={"file": path.name, "url_from": url_source},
+                provenance=provenance,
             )
 
 

--- a/igc/modules/igc_main.py
+++ b/igc/modules/igc_main.py
@@ -7,6 +7,7 @@ Author:Mus mbayramo@stanford.edu
 """
 import argparse
 import os
+from pathlib import Path
 from typing import Optional, Union, List, Dict
 
 import torch
@@ -81,11 +82,8 @@ class IgcMain:
         :return:
         """
         if self._dataset is None:
-            corpus_dir = getattr(self._specs, "corpus_dir", "") or ""
+            corpus_dir = self._corpus_dataset_dir()
             if corpus_dir:
-                # --corpus_dir selects the provenance-tagged JSONL corpus written by
-                # igc.ds.sources.write_corpus (trust-tier split + manifest) instead of
-                # rebuilding from raw ~/.json_responses captures.
                 from igc.ds.corpus_dataset import CorpusJSONLDataset
                 self._dataset = CorpusJSONLDataset(
                     corpus_dir,
@@ -101,6 +99,53 @@ class IgcMain:
                     do_consistency_check=self._specs.do_consistency_check
                 )
         return self._dataset
+
+    def _corpus_dataset_dir(self) -> str:
+        """Return a written corpus dir, materializing one from a manifest if needed.
+
+        ``--corpus_dir`` points directly at an existing ``examples.jsonl`` corpus.
+        ``--corpus_manifest`` + ``--corpus_root`` point at redfish_ctl's materialized
+        corpus manifest; this method composes those sources into the same written
+        corpus format so the tokenizer bridge has one live input contract.
+
+        :return: a corpus directory path, or ``""`` for the legacy raw-capture path.
+        :raises ValueError: when manifest inputs are incomplete or select no sources.
+        """
+        corpus_dir = getattr(self._specs, "corpus_dir", "") or ""
+        if corpus_dir:
+            return corpus_dir
+
+        manifest = getattr(self._specs, "corpus_manifest", "") or ""
+        if not manifest:
+            return ""
+
+        root = getattr(self._specs, "corpus_root", "") or ""
+        if not root:
+            raise ValueError("--corpus_root is required when --corpus_manifest is set")
+
+        from igc.ds.sources import RedfishFixtureSource, TrustLevel
+        from igc.ds.sources.corpus_io import write_corpus
+        from igc.ds.sources.mixer import SourceMix
+        from igc.ds.sources.training_object import normalize
+
+        kind = getattr(self._specs, "corpus_kind", "dataset") or "dataset"
+        sources = RedfishFixtureSource.from_redfish_ctl_manifest(
+            manifest,
+            root,
+            trust_level=TrustLevel.REAL,
+            kind=kind,
+        )
+        if not sources:
+            raise ValueError(
+                f"no redfish_ctl corpus sources selected from {manifest} "
+                f"under {root} for kind={kind}"
+            )
+
+        out_dir = Path(self._dataset_dir) / "redfish_ctl_corpus" / str(kind).lower()
+        mix = SourceMix(sources)
+        train_records, _ = mix.split()
+        write_corpus(normalize(train_records), mix.manifest(), str(out_dir))
+        return str(out_dir)
 
     def train(self):
         """
@@ -156,19 +201,13 @@ class IgcMain:
 
         :return:
         """
-        self._dataset = MaskedJSONDataset(
-            self._dataset_dir,
-            default_tokenize=self._specs.model_type,
-            max_len=self._specs.seq_len,
-            recreate_dataset=self._specs.recreate_dataset,
-            do_consistency_check=self._specs.do_consistency_check
-        )
+        dataset = self.dataset
 
         # copy last checkpoint as last model with opt etc. so we can use it.
         if self._specs.copy_llm:
             model, _ = from_pretrained_default(self._specs, only_model=True)
             model.to(torch.device("cpu"))
-            safe_resize_token_embeddings(model, self._dataset.tokenizer)
+            safe_resize_token_embeddings(model, dataset.tokenizer)
             # (BetterTransformer was removed in transformers 5.x; SDPA is native.)
             model, epoch, model_path = IgcModule.copy_checkpoint(self._specs, "state_encoder", model)
             print("Saved model to checkpoint file: ", model_path)

--- a/igc/shared/shared_arg_parser.py
+++ b/igc/shared/shared_arg_parser.py
@@ -741,6 +741,25 @@ def add_dataset_dataloader(parser):
              "provenance-tagged corpus instead of building from --json_data_dir.")
 
     group.add_argument(
+        "--corpus_manifest",
+        type=str, default="",
+        help="redfish_ctl corpus manifest, such as corpora/manifest.v1.json. "
+             "Use with --corpus_root after materializing dataset artifacts.")
+
+    group.add_argument(
+        "--corpus_root",
+        type=str, default="",
+        help="Root directory created by redfish_ctl corpus materialize/extract-all. "
+             "When --corpus_manifest is set, dataset captures are discovered below this root.")
+
+    group.add_argument(
+        "--corpus_kind",
+        type=str, default="dataset",
+        choices=("dataset", "mock", "full", "sim"),
+        help="redfish_ctl artifact kind to consume. dataset is the preferred IGC input; "
+             "full is accepted as a legacy alias.")
+
+    group.add_argument(
         "--raw_data_dir",
         type=str, default="~/.json_responses",
         help="Raw captured Redfish responses the mock REST env serves; mirrors "

--- a/tests/ds/test_redfish_fixture_source.py
+++ b/tests/ds/test_redfish_fixture_source.py
@@ -7,7 +7,7 @@ it took), stamps source/trust/vendor/schema provenance, attaches allowed methods
 from a supplied ``.npy``-style map, skips unparsable and non-object JSON instead
 of crashing, and treats a missing directory as empty. Also pins the trust-tier
 ordering used to split evaluation. Pure stdlib — no torch, no network, no
-idrac_ctl fixtures on disk.
+checked-out redfish_ctl fixtures on disk.
 
 Author:
 Mus mbayramo@stanford.edu
@@ -23,7 +23,9 @@ def _write(root: Path, name: str, body) -> None:
     """Write ``body`` (dict or raw string) to ``root/name``."""
     root.mkdir(parents=True, exist_ok=True)
     text = body if isinstance(body, str) else json.dumps(body)
-    (root / name).write_text(text)
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
 
 
 def _corpus(tmp_path: Path) -> Path:
@@ -107,6 +109,91 @@ def test_glob_pattern_limits_selected_fixture_files(tmp_path: Path) -> None:
     assert [r.url for r in recs] == ["/redfish/v1/Systems/1"]
     assert src.num_emitted == 1
     assert src.num_skipped == 0
+
+
+def test_materialized_redfish_ctl_layout_is_recursive(tmp_path: Path) -> None:
+    """A materialized dataset artifact may keep JSON below nested json_responses dirs."""
+    root = tmp_path / "materialized" / "dataset" / "dell_xr8620t"
+    _write(root, "corpus.json", {"corpus_id": "dell-xr8620t"})
+    _write(root, "rest_api_map.v1.json", {
+        "url_file_mapping": {
+            "/redfish/v1/Systems/1": "json_responses/Systems/_redfish_v1_Systems_1.json"
+        },
+        "allowed_methods_mapping": {"/redfish/v1/Systems/1": ["GET", "PATCH"]},
+    })
+    _write(root, "json_responses/Systems/_redfish_v1_Systems_1.json",
+           {"@odata.id": "/redfish/v1/Systems/1",
+            "@odata.type": "#ComputerSystem.v1_20_0.ComputerSystem", "Id": "1"})
+    _write(root, "json_responses/Schemas/Manifest.v1_1_0.json",
+           {"@odata.id": "/redfish/v1/Schemas/Manifest.v1_1_0.json",
+            "@odata.type": "#JsonSchemaFile.v1_0_0.JsonSchemaFile", "Id": "Manifest"})
+
+    src = RedfishFixtureSource(str(root), "dell-xr8620t", TrustLevel.REAL, vendor="dell")
+    recs = sorted(src.iter_records(), key=lambda rec: rec.url)
+
+    assert [rec.url for rec in recs] == [
+        "/redfish/v1/Schemas/Manifest.v1_1_0.json",
+        "/redfish/v1/Systems/1",
+    ]
+    assert recs[1].provenance["file"] == "json_responses/Systems/_redfish_v1_Systems_1.json"
+    assert recs[1].provenance["corpus_id"] == "dell-xr8620t"
+    assert src.num_emitted == 2
+    assert src.num_skipped == 2
+
+
+def test_redfish_ctl_manifest_builds_vendor_sources(tmp_path: Path) -> None:
+    """Manifest rows select materialized dataset corpora without assuming host dirs."""
+    manifest = tmp_path / "manifest.v1.json"
+    materialized = tmp_path / "build" / "corpora"
+    rows = [
+        ("dell-xr8620t", "dell", "xr8620t", "2023-06-17", "corpora/dataset/dell_xr8620t.tar.gz"),
+        ("hpe-dl360", "hpe", "dl360", "2026-01-02", "corpora/dataset/hpe_dl360.tar.gz"),
+        ("supermicro-x10sdv", "supermicro", "x10sdv", "2026-01-03", "corpora/dataset/supermicro_x10sdv.tar.gz"),
+        ("supermicro-gb300", "supermicro", "gb300", "2026-01-04", "corpora/dataset/supermicro_gb300.tar.gz"),
+    ]
+    manifest.write_text(json.dumps({
+        "schema_version": 1,
+        "corpora": [
+            {
+                "id": corpus_id,
+                "kind": "dataset",
+                "vendor": vendor,
+                "model": model,
+                "capture_id": capture_id,
+                "archive": archive,
+            }
+            for corpus_id, vendor, model, capture_id, archive in rows
+        ],
+    }))
+
+    for corpus_id, _vendor, _model, _capture_id, archive in rows:
+        slug = Path(archive).name[:-7]
+        root = materialized / "dataset" / slug
+        _write(root,
+               "json_responses/_redfish_v1.json",
+               {"@odata.id": f"/redfish/v1/{corpus_id}", "Id": corpus_id})
+        _write(root,
+               "rest_api_map.v1.json",
+               {
+                   "url_file_mapping": {
+                       f"/redfish/v1/{corpus_id}": "json_responses/_redfish_v1.json",
+                   },
+                   "allowed_methods_mapping": {f"/redfish/v1/{corpus_id}": ["GET", "HEAD"]},
+               })
+
+    sources = RedfishFixtureSource.from_redfish_ctl_manifest(str(manifest), str(materialized))
+    records = [next(source.iter_records()) for source in sources]
+
+    assert [source.source for source in sources] == [row[0] for row in rows]
+    assert [source.vendor for source in sources] == [row[1] for row in rows]
+    assert [record.url for record in records] == [f"/redfish/v1/{row[0]}" for row in rows]
+    assert [record.allowed_methods for record in records] == [["GET", "HEAD"]] * len(rows)
+    assert [record.provenance["corpus_id"] for record in records] == [row[0] for row in rows]
+    assert [record.provenance["capture_id"] for record in records] == [row[3] for row in rows]
+
+    gb300_only = RedfishFixtureSource.from_redfish_ctl_manifest(
+        str(manifest), str(materialized), corpus_ids=["supermicro-gb300"])
+    assert [source.source for source in gb300_only] == ["supermicro-gb300"]
 
 
 def test_url_from_filename_helper() -> None:

--- a/tests/modules/test_igc_main_corpus_manifest.py
+++ b/tests/modules/test_igc_main_corpus_manifest.py
@@ -1,0 +1,168 @@
+"""
+Offline regression tests for IgcMain corpus selection.
+
+Pins that the redfish_ctl manifest flags feed a live dataset path and that
+``IgcMain.run`` does not overwrite an already selected corpus dataset with the
+legacy raw-capture dataset.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from igc.modules.igc_main import IgcMain
+
+
+class _FakeMetricLogger:
+    """Small stand-in for MetricLogger; no files or backends."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class _FakeCorpusDataset:
+    """Capture the corpus directory IgcMain asks the tokenizer bridge to load."""
+
+    instances = []
+
+    def __init__(self, corpus_dir, default_tokenize=None, max_len=None):
+        self.corpus_dir = Path(corpus_dir)
+        self.default_tokenize = default_tokenize
+        self.max_len = max_len
+        self.tokenizer = object()
+        _FakeCorpusDataset.instances.append(self)
+
+
+def _specs(tmp_path: Path, **overrides):
+    """Build the minimum argparse namespace IgcMain touches in these tests."""
+    values = {
+        "metric_report": "none",
+        "json_data_dir": str(tmp_path / "json"),
+        "dataset_dir": str(tmp_path / "datasets"),
+        "corpus_dir": "",
+        "corpus_manifest": "",
+        "corpus_root": "",
+        "corpus_kind": "dataset",
+        "model_type": "gpt2",
+        "seq_len": 32,
+        "recreate_dataset": False,
+        "do_consistency_check": False,
+        "copy_llm": False,
+        "test_llm": False,
+        "train": "",
+        "llm": None,
+        "rl": None,
+        "device": "cpu",
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _write_json(path: Path, body) -> None:
+    """Write a JSON body under ``path``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(body), encoding="utf-8")
+
+
+def test_redfish_ctl_manifest_materializes_live_corpus(tmp_path, monkeypatch):
+    """--corpus_manifest/--corpus_root build examples.jsonl then load it."""
+    monkeypatch.setattr("igc.modules.igc_main.MetricLogger", _FakeMetricLogger)
+    monkeypatch.setattr("igc.ds.corpus_dataset.CorpusJSONLDataset", _FakeCorpusDataset)
+    _FakeCorpusDataset.instances.clear()
+
+    manifest = tmp_path / "manifest.v1.json"
+    materialized = tmp_path / "materialized"
+    root = materialized / "dataset" / "dell_xr8620t"
+    _write_json(
+        manifest,
+        {
+            "schema_version": 1,
+            "corpora": [
+                {
+                    "id": "dell-xr8620t",
+                    "kind": "dataset",
+                    "vendor": "dell",
+                    "model": "xr8620t",
+                    "capture_id": "capture-1",
+                    "archive": "corpora/dataset/dell_xr8620t.tar.gz",
+                }
+            ],
+        },
+    )
+    _write_json(
+        root / "rest_api_map.v1.json",
+        {
+            "url_file_mapping": {
+                "/redfish/v1/Systems/1": "json_responses/_redfish_v1_Systems_1.json"
+            },
+            "allowed_methods_mapping": {"/redfish/v1/Systems/1": ["GET", "HEAD", "PATCH"]},
+        },
+    )
+    _write_json(
+        root / "json_responses" / "_redfish_v1_Systems_1.json",
+        {
+            "@odata.id": "/redfish/v1/Systems/1",
+            "@odata.type": "#ComputerSystem.v1_20_0.ComputerSystem",
+            "Id": "1",
+        },
+    )
+
+    specs = _specs(
+        tmp_path,
+        corpus_manifest=str(manifest),
+        corpus_root=str(materialized),
+        corpus_kind="dataset",
+    )
+    dataset = IgcMain(specs).dataset
+
+    assert dataset is _FakeCorpusDataset.instances[0]
+    assert dataset.default_tokenize == "gpt2"
+    assert dataset.max_len == 32
+    examples_path = dataset.corpus_dir / "examples.jsonl"
+    manifest_path = dataset.corpus_dir / "manifest.json"
+    assert examples_path.is_file()
+    assert manifest_path.is_file()
+
+    row = json.loads(examples_path.read_text(encoding="utf-8").strip())
+    assert row["request_or_action"] == {
+        "method": "GET",
+        "url": "/redfish/v1/Systems/1",
+        "body": None,
+    }
+    assert row["allowed_methods"] == ["GET", "HEAD", "PATCH"]
+    assert row["vendor"] == "dell"
+    assert row["provenance"]["corpus_id"] == "dell-xr8620t"
+
+
+def test_manifest_requires_materialized_root(tmp_path, monkeypatch):
+    """A manifest without --corpus_root fails with a clear local error."""
+    monkeypatch.setattr("igc.modules.igc_main.MetricLogger", _FakeMetricLogger)
+    specs = _specs(tmp_path, corpus_manifest=str(tmp_path / "manifest.v1.json"))
+
+    with pytest.raises(ValueError, match="--corpus_root"):
+        _ = IgcMain(specs).dataset
+
+
+def test_run_keeps_existing_dataset(tmp_path, monkeypatch):
+    """run() must not replace a selected corpus dataset with MaskedJSONDataset."""
+    monkeypatch.setattr("igc.modules.igc_main.MetricLogger", _FakeMetricLogger)
+
+    def _raise_masked(*args, **kwargs):
+        raise AssertionError("MaskedJSONDataset should not be constructed by run()")
+
+    monkeypatch.setattr("igc.modules.igc_main.MaskedJSONDataset", _raise_masked)
+    main = IgcMain(_specs(tmp_path, corpus_dir=str(tmp_path / "written-corpus")))
+    sentinel = object()
+    main._dataset = sentinel
+
+    main.run()
+
+    assert main._dataset is sentinel
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/perf/test_hot_path_budgets.py
+++ b/tests/perf/test_hot_path_budgets.py
@@ -5,7 +5,7 @@ Each budget is ~50-100x looser than the measured number on the reference corpus,
 never depends on machine speed — only an algorithmic regression (e.g. the O(V^2) neighbor
 scan this suite was born from: 0.71s measured, budget 0.5s per 1,000 nodes) trips it.
 Excluded from the default offline gate; run explicitly with `pytest -m perf` (the fixture
-corpus lives in the data-collection submodule, so a checkout without submodules skips).
+corpus is local to this checkout, so a minimal checkout without fixtures skips).
 
 Author:
 Mus mbayramo@stanford.edu
@@ -22,12 +22,12 @@ from igc.ds.sources.candidate_features import build_candidate_cache
 from igc.ds.sources.resource_graph import RedfishResourceGraph
 from igc.modules.eval.zero_shot_ranking import embed_candidates
 
-_CORPUS = "idrac_ctl/tests/supermicro_fixtures"
+_CORPUS = "tests/supermicro_fixtures"
 
 pytestmark = [
     pytest.mark.perf,
     pytest.mark.skipif(not os.path.isdir(_CORPUS),
-                       reason="fixture corpus not present (submodule not initialized)"),
+                       reason="fixture corpus not present"),
 ]
 
 

--- a/tests/shared/test_arg_parser_action_repr.py
+++ b/tests/shared/test_arg_parser_action_repr.py
@@ -47,6 +47,24 @@ def test_raw_data_dir_is_defined(monkeypatch):
     assert args.raw_data_dir == "~/.json_responses"
 
 
+def test_redfish_corpus_manifest_flags_are_defined(monkeypatch):
+    """Materialized redfish_ctl dataset inputs can be passed without path assumptions."""
+    args = _parse(
+        monkeypatch,
+        [
+            "--corpus_manifest",
+            "corpora/manifest.v1.json",
+            "--corpus_root",
+            "build/corpus",
+            "--corpus_kind",
+            "dataset",
+        ],
+    )
+    assert args.corpus_manifest == "corpora/manifest.v1.json"
+    assert args.corpus_root == "build/corpus"
+    assert args.corpus_kind == "dataset"
+
+
 def test_rl_sizes_are_ints(monkeypatch):
     """rl batch/buffer sizes parse as ints, not floats."""
     args = _parse(monkeypatch, [])

--- a/tests/test_save_spec_redaction.py
+++ b/tests/test_save_spec_redaction.py
@@ -17,7 +17,7 @@ from igc_main import _is_sensitive, save_spec
 @pytest.mark.parametrize(
     "key",
     (
-        "IDRAC_PASSWORD",
+        "REDFISH_PASSWORD",
         "HUGGINGFACE_TOKEN",
         "OPENAI_API_KEY",
         "WANDB_APIKEY",


### PR DESCRIPTION
## Summary

- Add preferred input support for materialized `redfish_ctl` corpus manifests.
- Preserve the legacy `~/.json_responses` layout and `rest_api_map.npy` fallback.
- Load portable `rest_api_map.v1.json` when present and keep method maps scoped to one capture.
- Add vendor, model, capture, and corpus identifiers to generated Redfish records.
- Update IGC docs away from sibling checkout assumptions and toward explicit corpus materialization.

## Corpus Contract

- Preferred input: materialized `redfish_ctl` dataset layout plus `manifest.v1.json`.
- Compatibility input: one isolated legacy capture under `~/.json_responses/<capture-host>/`.
- JSON discovery is recursive inside a single capture.
- URL and allowed-method mappings are scoped per capture; identical Redfish URLs from different vendors are not globally merged.
- Action-catalog generation can continue producing derived action/schema records without redefining the source corpus.

## Related Work

- Related M3 PR: https://github.com/spyroot/igc/pull/99
- Dependent `redfish_ctl` PR: https://github.com/spyroot/redfish_ctl/pull/117

## Validation

- `env KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 /Users/spyroot/miniconda3/condabin/conda run -n igc-dev python -m pytest -q`
  - `668 passed, 1 skipped, 29 deselected, 8 xfailed, 20 warnings in 36.26s`
- `env KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 /Users/spyroot/miniconda3/condabin/conda run -n igc-dev ruff check igc/ds/redfish_dataset.py igc/ds/sources/base.py igc/ds/sources/redfish_fixture_source.py igc/shared/shared_arg_parser.py tests/ds/test_redfish_fixture_source.py tests/perf/test_hot_path_budgets.py tests/shared/test_arg_parser_action_repr.py tests/test_save_spec_redaction.py`
  - `All checks passed!`
- `git diff --cached --check`
  - passed
