### PR TITLE
Build goal dataset from full corpora

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ datasets/modules/*
 datasets/*.tar.gz
 datasets/*.tar.gz.md5
 datasets/dataset.json
+datasets/generated/
+datasets/goal*/
 datasets/tokenizer/tokenizer.json
 test_datasets/
 tests/datasets/

--- a/datasets/goal_latent_full_corpus.tar.gz
+++ b/datasets/goal_latent_full_corpus.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2dd48632191d923b53d80181bc0b02d8d804b2dd87ca6f9d3f7db1a5d5fd8e50
+size 1942506

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,8 +61,8 @@ the proposed first compact-state schema: a JSON-serializable structured payload 
 
 ```mermaid
 flowchart LR
-    Goal["Goal\nigc/core/types.py\ninstruction + spec + constraints + plan"]
-    Planner["Planner / casting layer\nplanned M3"]
+    Goal["GoalEnvelope\noperator text -> GoalRefs + explicit dependencies"]
+    Extractor["GoalExtractor / GoalEncoder\ntext -> atomic z_sub_goal(s)"]
     State["RedfishStateV0\nstructured resources, links,\nstatus, tasks, settings, telemetry"]
     Catalog["ToolCatalog.available_actions(obs)\nplanned Redfish adapter\nlegal ToolAction candidates"]
     Codec["ActionCodec\nigc/modules/policy/action_codec.py\nrender + cache candidate templates"]
@@ -74,11 +74,11 @@ flowchart LR
     Step["StepResult / Transition\nigc/core/types.py\nthin step + rich replay record"]
     Replay["Replay / HER\nterminal masks + achieved_goal"]
 
-    Goal --> Planner --> Catalog
+    Goal --> Extractor --> Pointer
     State --> Catalog --> Codec --> Pointer --> Args --> Guard --> Sim
     Sim --> State
     State --> Eval --> Step --> Replay --> Pointer
-    Goal --> Eval
+    Extractor --> Eval
 ```
 
 ### Model dependency map
@@ -93,7 +93,7 @@ flowchart TD
     M1["M1 backbone encoder\nconfig-driven causal/decoder model"]
     S0["RedfishStateV0 extractor\nstructured state contract + fixtures"]
     M2["M2 state pooler / autoencoder\npooled structured/text state"]
-    M3["M3 planner\ninstruction -> sub-goal plan"]
+    GE["GoalExtractor / GoalEncoder\ninstruction -> atomic goals + z_sub_goal"]
     M4["M4 evaluator / reward\nstructured verify + dense reward"]
     M5["M5 world model\nnext-state + status/task phase"]
     M6["M6 RL policy\ncandidate scoring + replay/HER"]
@@ -101,12 +101,12 @@ flowchart TD
 
     S0 --> M2
     M1 --> M2
-    M1 --> M3
+    M1 --> GE
     S0 --> M4
     M2 --> M5
     M4 --> M5
     M2 --> M6
-    M3 --> M6
+    GE --> M6
     M4 --> M6
     M5 --> M6
     M6 --> Gate
@@ -234,11 +234,11 @@ machine (Current→Pending→Applied, job Scheduled→Running→Done).
 
 ![Hierarchical workload plan](diagrams/04-hierarchical-workload-plan.svg)
 
-Design consequences: `Goal` carries a `plan` (sub-goal DAG); `ToolAction` carries `preconditions`
-and `effects`; the simulator models deferred/async state; reward is decomposed (terminal +
-per-sub-goal + progress shaping) with HER over reachable sub-goals; the planner ("casting" layer)
-generalizes `GoalExtractorTrainer` from one action to an ordered plan; and API/state discovery become
-explicit pipeline stages.
+Design consequences: `GoalEnvelope` carries atomic `GoalRef` targets and only the dependency hints
+explicitly stated in text; `ToolAction` carries `preconditions` and `effects`; the simulator models
+deferred/async state; reward is decomposed (terminal + per-sub-goal + progress shaping) with HER over
+reachable sub-goals; and API/state discovery become explicit pipeline stages. The RL policy learns
+the concrete action ordering; the language model does not emit a strategy.
 
 ### Meta-learning: a transferable multi-step agent
 
@@ -247,8 +247,8 @@ API (or filesystem/SQL/GitHub) and it should operate that backend with little or
 is the target hypothesis; it becomes a claim only after offline eval traces and metrics support it.
 The design makes the hypothesis concrete, layer by layer:
 
-1. **Extract the goal.** The planner (the "casting" layer) maps a high-level instruction to a `Goal`
-   and an ordered sub-goal `plan` (the hierarchical decomposition above).
+1. **Extract the goal.** `GoalExtractor` maps a high-level instruction to atomic `GoalRef` targets
+   and explicit dependency hints; `GoalEncoder` aligns the text with concrete Redfish goal surfaces.
 2. **Discover the action space.** A new backend exposes its tools/ops through `ToolCatalog` +
    `available_actions(obs)` (for Redfish, derived from the `idrac_ctl` crawl + the `.npy` map). The
    agent never needs a fixed, pre-enumerated action set — it reads what is legal *now*.
@@ -256,16 +256,16 @@ The design makes the hypothesis concrete, layer by layer:
    it has never seen is still scorable: its `tool_name/op/schema` text is embedded by the shared
    backbone, so there is no output-layer resize, no re-index, no head retrain. This is what turns "a
    new API" from a retraining event into an inference-time lookup.
-4. **Find an optimal strategy.** Goal-conditioned RL (DQN + HER) over the sub-goal plan learns the
-   ordering and the fewest-steps path; the world model supplies preconditions/dynamics so the agent
-   plans rather than flails.
+4. **Find an optimal strategy.** Goal-conditioned RL (DQN + HER) over the active `z_sub_goal` learns
+   the ordering and the fewest-steps path; the world model supplies preconditions/dynamics so the
+   agent plans rather than flails.
 5. **Adapt on the new environment.** Trained across *multiple* environments (filesystem, SQL, GitHub,
    Redfish) — the meta-training distribution — the shared backbone, pointer policy, and state encoder
    transfer; a short interaction (plus an optional LoRA / world-model update) adapts to the new
    backend's quirks. This is the meta-learning ("learn to learn") payoff: capability acquired on known
    APIs carries to unknown ones.
 
-In short: **extract → plan → discover → execute → transfer.** Every layer is built so the unit of
+In short: **extract → discover → execute → transfer.** Every layer is built so the unit of
 generalization is *the skill of operating a tool API*, not *a specific API*.
 
 ## 4. The six models and the training curriculum
@@ -280,7 +280,7 @@ de-hardcoded before the first backbone fit.
 | --- | --- | --- | --- | --- |
 | 0 | — | make it runnable + de-hardcode dims + backbone config-driven | `pytest -q` green, ruff clean | CPU |
 | 1 | M1 backbone / state encoder | causal-LM SFT over Redfish JSON → checkpoint A | held-out token acc ↑ vs measured GPT-2 baseline | 1-GPU |
-| 2 | M2 autoencoder · M3 planner · M4 reward | pool→latent 64 · NL→sub-goal DAG · decomposed reward | recon MSE · DAG topo-validity · reward AUC | 1-GPU ×3 |
+| 2 | M2 autoencoder · GoalExtractor/GoalEncoder · M4 reward | pool→latent 64 · NL→atomic goals · decomposed reward | recon MSE · extraction exact match · reward AUC | 1-GPU ×3 |
 | 3 | M5 world/transition | next-latent + status/job-phase classification | 1-step error, phase accuracy, rollout drift | 1-GPU |
 | 4 | M6 RL agent | goal-cond. DQN + HER on `ToolAction`, learned reward | success_rate per workload, episode_length | 1-GPU (longest) |
 
@@ -314,8 +314,8 @@ The target loader should use `AutoTokenizer` + a class arg, and `ValueHead` shou
 | 3 · Offline prover envs | filesystem + sqlite plugins (real args, dynamic actions, exact verify, dry-run, destructive blocked) | per-env offline tests |
 | 4 · Trajectory + github | recorder + `TrajectoryDataset`; `CassetteSimulator`; github plugin (offline replay, live-gated) | record→load round-trip; github offline via cassette |
 | 5 · Backbone + M1/M2 | backbone-agnostic refactor; `StatePooler`; train M1 + M2 on NVL72 | small-model CPU green → 1-GPU overfit-a-batch smoke |
-| 6 · Learning layer | planner (M3) + reward (M4) + world model (M5) + evaluators + preference data → RL agent (M6) | offline eval harness scores traces; GPU-marked training |
-| 7 · Guardrail + deploy | dry-run/approval/executor over `_is_live`; serve backbone+planner via vLLM (TP=1); live Redfish canary behind the gate | guardrail blocks destructive-without-approval; offline gate stays green |
+| 6 · Learning layer | GoalExtractor/GoalEncoder + reward (M4) + world model (M5) + evaluators + preference data → RL agent (M6) | offline eval harness scores traces; GPU-marked training |
+| 7 · Guardrail + deploy | dry-run/approval/executor over `_is_live`; serve backbone + goal extractor via vLLM (TP=1); live Redfish canary behind the gate | guardrail blocks destructive-without-approval; offline gate stays green |
 
 ## 7. Infra · monitoring · deploy (NVL72)
 
@@ -329,7 +329,7 @@ NVL72 through a one-GPU-first Slurm/pyxis workflow.
 - **Training-loop sanity checks:** overfit-a-batch, grad-norm clip + `isfinite` guard, LR
   warmup/cosine, deterministic seed, resume-from-checkpoint, early stop, a startup dim-contract
   assertion (`observation_space == latent_dim + goal_dim`), and a Buffer arity check.
-- **Deploy, two paths:** (A) backbone + planner served OpenAI-compatible via vLLM, **TP=1 mandatory**
+- **Deploy, two paths:** (A) backbone + GoalExtractor served OpenAI-compatible via vLLM, **TP=1 mandatory**
   (blocked until the backbone refactor lands); (B) the RL policy runs in the mock-env eval harness,
   never wired to a live BMC by default. Any real-Redfish move is read-only GET/HEAD first, paced,
   approved non-prod host, behind the guardrail.
@@ -354,7 +354,7 @@ Found in-tree during design review:
 ## 9. Open decisions
 
 1. Trainable base model id (the `--model_type` value for the flash-class backbone).
-2. Planner build — learned (`GoalExtractor`→planner), LLM-via-Flash, or both.
+2. Goal extraction build — learned `GoalExtractor`/`GoalEncoder`, teacher-generated text drafts, or both.
 3. `--raw_data_dir` — new flag or alias of the existing `--json_data_dir`.
 4. Reward decomposition — how per-sub-goal rewards sum-consistently with the terminal reward.
 
@@ -402,18 +402,21 @@ first; MoE is a later upgrade** (upcycle/distill once there are many APIs + data
 — MoE adds capacity/specialization, not the meta-learning (which lives in attention-over-history).
 
 **Backbone sizing — decoupled.** Small dense bf16 backbone for the hot-loop encoder/RL (M1/M2/M6,
-runs every step); a larger 14–32B for the goal extractor (M3, runs once per episode). Trainable =
+runs every step); a larger model may be used for the GoalExtractor if extraction metrics justify it
+(runs once per episode). Trainable =
 small/mid dense bf16 + LoRA + ZeRO-3 (`--sharding zero3`). DeepSeek-V4-Flash (284B FP8/FP4 MoE) is the
 **inference/teacher** only (deployed NVFP4), never the trainable backbone.
 
-**M3 — Design B (standalone distillation).** Own backbone + tokenizer + DeepSeek-distilled
-`(instruction → goal + params)` data, reusing the existing `GoalExtractorTrainer`; bootstrap by calling
-DeepSeek directly. Verify teacher outputs against `Goal.spec` before distilling.
+**Goal extraction — standalone distillation.** Own backbone + tokenizer + Redfish-corpus-backed
+`(operator text -> atomic GoalRef set + explicit dependency hints)` data. A teacher model may draft
+operator text, but deterministic code owns `true_y`; verify generated text against the current
+GoalExtractor before using it as supervised data.
 
 **Training curriculum.**
 1. **Represent** (supervised, separate): M1 backbone SFT + M2 autoencoder → compact states. Pretrained
    first; RL LoRA-adapts on top (do not co-train the whole backbone with RL).
-2. **Plan** (distill) + **Reward** (build, parallel): M3 from DeepSeek; M4 schema-driven verifier.
+2. **Extract** (distill) + **Reward** (build, parallel): GoalExtractor/GoalEncoder from the
+   generated goal dataset; M4 schema-driven verifier.
 3. **Meta-RL — ONE optimization path:** the in-context RL²-Transformer policy over the API-sim
    distribution, with HER, a **BC/SFT warm-start** (imitate teacher demos before RL — the main lever
    against the sparse-reward cold start), and a **narrow→broad task curriculum**. Meta is not a phase
@@ -432,8 +435,8 @@ Four views of the agreed design (§10). Maintainable mermaid; render on GitHub.
 ```mermaid
 flowchart TB
     NL["Natural-language goal<br/>(set boot=PXE, power-cycle)"]
-    NL --> M3["M3 planner / goal extractor<br/>distilled from DeepSeek<br/>-> Goal(spec, params, sub-goals)"]
-    M3 -->|goal-conditions| AGENT
+    NL --> GE["GoalExtractor / GoalEncoder<br/>-> atomic GoalRefs + z_sub_goal"]
+    GE -->|goal-conditions| AGENT
 
     subgraph AGENT["Goal-conditioned RL2 agent (one shared policy)"]
         ENC["M1/M2 encoder<br/>API response -> compact state vector"]
@@ -484,7 +487,7 @@ flowchart LR
 flowchart TB
     subgraph SEP["Separate prerequisite phases"]
         REP["Represent<br/>M1 backbone SFT + M2 autoencoder<br/>small dense, pretrained first"]
-        PLAN["Plan<br/>M3 distilled from DeepSeek"]
+        PLAN["Extract<br/>GoalExtractor / GoalEncoder"]
         REW["Reward<br/>M4 schema-driven verifier"]
     end
     REP --> META
@@ -500,14 +503,14 @@ flowchart TB
 
 ```mermaid
 flowchart LR
-    DS["DeepSeek-V4-Flash<br/>284B MoE, NVFP4<br/>DEPLOYED inference endpoint"]
-    DS -->|teacher: generate goal/param data| DISTILL["distillation set<br/>verified Goal objects"]
-    DISTILL -->|SFT| M3B["M3 goal extractor<br/>14-32B dense, OWN backbone<br/>(runs once per episode)"]
+    DS["Teacher LLM<br/>inference-only bootstrap"]
+    DS -->|draft operator text X only| DISTILL["goal text set<br/>deterministic true_y labels"]
+    DISTILL -->|SFT / contrastive| GEB["GoalExtractor / GoalEncoder<br/>(runs once per episode)"]
     SMALL["small dense bf16 backbone 1-7B<br/>+ LoRA + ZeRO-3 (hot loop)"]
     SMALL --> M1["M1 state encoder"]
     SMALL --> M2["M2 autoencoder"]
     SMALL --> M6["M6 RL policy heads"]
-    DS -.->|direct call for bootstrap| M3B
+    DS -.->|direct call for bootstrap| GEB
 ```
 
 ## 12. Tool-teaching (LLM-taught few-shot tool acquisition)
@@ -521,7 +524,7 @@ brand-new tool is *scorable* with no head resize — `Igc_PointerQNetwork`
 fan-out (§3.3, step 3). But that signal is only the tool's *declared surface*; the agent
 still learns *how to actually drive* the tool by sparse-reward trial-and-error (reward
 arrives only at goal completion — §10). **Tool-teaching adds an active loop**: the
-DeepSeek-V4-Flash teacher M3 already reuses (the deployed NVFP4 endpoint, §11.4) reads
+same gated LLM-teacher path used for goal-dataset bootstrapping reads
 the agent's own `k` real `(call → result/error)` interactions with an unknown op and
 induces a grounded, versioned **ToolCard**, which flows through the *exact existing*
 render→cache→pointer→argument pipeline to accelerate few-shot acquisition. Passive
@@ -586,11 +589,11 @@ grounding tallies so a counter tick does not churn the embedding cache), and
 `spec_fingerprint` (blake2b of `ToolSpec.arg_schema[op]` — a moved op schema
 auto-invalidates a stale card).
 
-### 12.3 Induction — ToolTeacher (reuse M3's teacher)
+### 12.3 Induction — ToolTeacher
 
 `ToolTeacher.induce()` (`igc/modules/teach/tool_teacher.py`, slice 6b) issues a
-JSON-schema'd, **evidence-bound** prompt against the *same* DeepSeek-V4-Flash endpoint
-M3 distills from (§11.4 "direct call for bootstrap") — a reuse, not a new LLM. Inputs are
+JSON-schema'd, **evidence-bound** prompt against the same gated LLM-teacher path used for
+goal-dataset bootstrapping — a reuse, not a new LLM. Inputs are
 the discovery facts (`ToolSpec`, and for Redfish the `.npy` `allowed_methods_mapping` +
 `@Redfish.ActionInfo` enums) plus the `k` observed `Transition` records
 (`.action`, `.next_observation.status/.error`, truncated `.text/.structured`,
@@ -651,7 +654,7 @@ and must not be reported as already-enforced.
 
 Tool-teaching is **not a new phase**; it rides §10's single meta-RL optimization path
 (§11.3) inside Phase 6, and depends on M1/M2 (compress so `k` interactions + card fit the
-RL² budget), M3 (the teacher), and M4 (the grounder). The interplay:
+RL² budget), the gated teacher path, and M4 (the grounder). The interplay:
 
 - **BC/SFT warm-start** (§10's main lever against the sparse-reward cold start): teacher
   demos enter BC *only after* M4 confirms they reached a sub-goal, carrying their ToolCard

--- a/docs/GOAL_LATENT_DESIGN.md
+++ b/docs/GOAL_LATENT_DESIGN.md
@@ -201,6 +201,15 @@ The generated `goal_surfaces.jsonl`, `goal_text_examples.jsonl`, and `goal_datas
 are private dataset artifacts. They are not public documentation and should not be committed to this
 repository.
 
+To inspect a built dataset locally, use the sampler without loading models or calling any endpoint:
+
+```bash
+python scripts/sample_goal_dataset.py \
+  --dataset-dir /path/to/goal_dataset \
+  --limit 5 \
+  --family power
+```
+
 ## Initial Goal Families
 
 Power goals come from `#ComputerSystem` resources:

--- a/docs/GOAL_LATENT_DESIGN.md
+++ b/docs/GOAL_LATENT_DESIGN.md
@@ -181,17 +181,32 @@ python scripts/build_goal_dataset.py \
 
 The full dataset build runs inside the NV72 Docker lab, not on a laptop. The lab wrapper
 `scripts/build_goal_dataset_lab.sh` initializes the canonical `redfish_ctl` checkout, runs
-`git lfs pull` inside that checkout so the full Redfish JSON corpus is present, verifies that the
-Dell iDRAC, Supermicro GB300/HGX, and HPE iLO discovery corpora are non-empty, and then calls
-`scripts/build_goal_dataset.py`. Capture roots are discovered from the LFS-backed vendor fixture
-directories and `~/.json_responses`, or supplied with `IGC_CAPTURE_ROOTS`. The model endpoint comes
-only from environment variables or a private env file; the script never hardcodes private hosts.
+`git lfs pull` inside that checkout so the full Redfish corpus archives are present, verifies that
+`full_corpus/dell_xr8620t_full_corpus.tar.gz`,
+`full_corpus/hpe_dl360_full_corpus.tar.gz`,
+`full_corpus/supermicro_gb300_full_corpus.tar.gz`, and
+`full_corpus/supermicro_x10_full_corpus.tar.gz` are real tarballs rather than LFS pointer stubs, and
+then extracts their host roots into a private build directory. Each extracted root must carry the
+same-run `rest_api_map.npy`; `scripts/build_goal_dataset.py` loads its `allowed_methods_mapping` so
+action/reward consumers can see the discovered methods in goal-surface provenance. Capture roots can
+also be supplied explicitly with `IGC_CAPTURE_ROOTS`. The model endpoint comes only from environment
+variables or a private env file; the script never hardcodes private hosts.
 
 For a lab-side full-corpus draft pass, generate one text batch per discovered atomic goal and write a
 manifest with the counts:
 
 ```bash
 IGC_GOAL_DATASET_OUT=/private/or/lfs/path/goal_dataset \
+IGC_GOAL_DATASET_PARAPHRASE_MODE=template \
+bash scripts/build_goal_dataset_lab.sh
+```
+
+Use `IGC_GOAL_DATASET_PARAPHRASE_MODE=template` for a deterministic, endpoint-free inspection
+dataset. Use `openai` only when the private lab endpoint variables are present:
+
+```bash
+IGC_GOAL_DATASET_OUT=/private/or/lfs/path/goal_dataset \
+IGC_GOAL_DATASET_PARAPHRASE_MODE=openai \
 GOAL_PARAPHRASE_BASE_URL=<openai-compatible-base-url> \
 GOAL_PARAPHRASE_MODEL=<model-name> \
 bash scripts/build_goal_dataset_lab.sh
@@ -206,6 +221,15 @@ To inspect a built dataset locally, use the sampler without loading models or ca
 ```bash
 python scripts/sample_goal_dataset.py \
   --dataset-dir /path/to/goal_dataset \
+  --limit 5 \
+  --family power
+```
+
+If the dataset was packaged as a tarball, sample it directly:
+
+```bash
+python scripts/sample_goal_dataset.py \
+  --dataset-tar datasets/goal_latent_full_corpus.tar.gz \
   --limit 5 \
   --family power
 ```

--- a/docs/GOAL_LATENT_DESIGN.md
+++ b/docs/GOAL_LATENT_DESIGN.md
@@ -1,0 +1,340 @@
+# Goal latent design
+
+This document defines the public, code-facing contract for natural-language goal extraction and
+latent goal alignment in `igc`. It replaces the ambiguous "planner" framing with a narrower job:
+extract what the operator wants, align that intent with concrete Redfish state surfaces, and leave
+execution strategy to the goal-conditioned RL policy.
+
+## Purpose
+
+`GoalExtractor` maps operator text to one or more atomic sub-goal references. `GoalEncoder` maps both
+operator text and concrete Redfish goal surfaces into a shared latent sub-goal space. `GoalVerifier`
+checks whether a hidden concrete sub-goal is satisfied by an observation. A compound instruction may
+carry a goal set, but the policy normally conditions on one active `z_sub_goal` at a time. The
+simulator/evaluator keeps the concrete hidden payload needed for reward and HER.
+
+The boundary is intentional:
+
+- The extractor does not choose API calls.
+- The extractor does not invent an ordered execution plan.
+- The encoder does not decide success by latent distance.
+- The verifier uses concrete state facts and action results, not model confidence.
+
+## Core Records
+
+For a chat interface, `GoalExtractor` returns an envelope with four pieces:
+
+```json
+{
+  "text": "set NTP then boot the server",
+  "atomic_goal_refs": [
+    {"goal_id": "network.manager_network_protocol.NTP.ProtocolEnabled.eq.True"},
+    {"goal_id": "power.computer_system.PowerState.eq.On"}
+  ],
+  "relations": [
+    {
+      "before_goal_id": "network.manager_network_protocol.NTP.ProtocolEnabled.eq.True",
+      "after_goal_id": "power.computer_system.PowerState.eq.On",
+      "relation": "before",
+      "evidence": "then"
+    }
+  ],
+  "evidence": {
+    "network.manager_network_protocol.NTP.ProtocolEnabled.eq.True": "set NTP",
+    "power.computer_system.PowerState.eq.On": "boot the server"
+  }
+}
+```
+
+The same sentence without an ordering word, for example "boot the server and set NTP", has the same
+two `atomic_goal_refs` but an empty `relations` list. A single-goal sentence has one
+`atomic_goal_refs` item and no relations. RL/HER uses the active atomic item as `desired_sub_goal`
+and `z_sub_goal`; the episode can carry the whole envelope for progress tracking and UI reporting.
+
+`GoalRef` is the semantic, vendor-neutral atomic sub-goal target. It is small enough to be used as a
+class/slot label and stable enough to align examples across vendors.
+
+```json
+{
+  "goal_id": "power.system.power_state:on",
+  "family": "power",
+  "resource_type": "ComputerSystem",
+  "property_path": "PowerState",
+  "operator": "eq",
+  "target_value": "On",
+  "mode": "state",
+  "constraints": {}
+}
+```
+
+`GoalSurface` is one vendor/world-specific realization of one atomic `GoalRef`. It comes from captured
+Redfish JSON and carries enough context to verify the sub-goal in that world.
+
+```json
+{
+  "goal_ref": {"goal_id": "power.system.power_state:on"},
+  "vendor": "dell",
+  "source": "real_dell",
+  "resource_uri": "/redfish/v1/Systems/1",
+  "resource_type": "#ComputerSystem.v1_20_0.ComputerSystem",
+  "fact_path": "PowerState",
+  "target_value": "On",
+  "current_value": "Off",
+  "allowed_values": ["On", "Off"],
+  "verifier": {
+    "kind": "state_eq",
+    "resource_uri": "/redfish/v1/Systems/1",
+    "property_path": "PowerState",
+    "operator": "eq",
+    "target_value": "On"
+  }
+}
+```
+
+`GoalTextExample` is the supervised extraction row. The target is a list because an operator sentence
+can mention a compound goal. Each list item is an atomic sub-goal; a downstream scheduler or
+curriculum chooses which `z_sub_goal` is active at a decision point.
+
+```json
+{
+  "text": "clear the logs and reboot the server",
+  "goal_refs": [
+    {"goal_id": "log.event_log.clear"},
+    {"goal_id": "power.system.reset:graceful_restart"}
+  ],
+  "dependencies": [],
+  "text_source": "llm_paraphrase",
+  "split": "train"
+}
+```
+
+`GoalDependency` records only dependency information explicitly stated in text. It is not a learned
+execution plan and it does not make the whole compound instruction one vector. If the text says
+"then", "after", or "before", the dataset can carry a partial order:
+
+```json
+{"before": "firmware.component.update", "after": "boot.os.ubuntu2204"}
+```
+
+RL still learns which concrete `ToolAction` candidates satisfy each atomic goal in the active
+environment.
+
+## Dataset Construction
+
+The dataset is built in two layers.
+
+1. Atomic rows are deterministic. Code scans captured `SourceRecord` streams and emits single goal
+   surfaces from observable scalar leaves, inline `@Redfish.AllowableValues` annotations, generic
+   `Actions` blocks, and richer Redfish-specific surfaces such as power states, reset transition
+   intents, boot override settings, BIOS attribute values, virtual-media states, log clear targets,
+   and task terminal states.
+2. Text rows are generated or curated from those atomic rows. A paraphrase backend may propose
+   operator sentences, but deterministic code owns the labels. During bootstrapping, generated text is
+   written as an unvalidated draft row with its JSON-derived `true_y`; after a trained extractor
+   exists, a validation pass can discard text that adds a goal, removes a goal, changes a value,
+   inserts an unsupported dependency, or changes risk.
+
+Compound text examples are assembled from atomic rows. The raw Redfish capture does not need to
+contain a human compound task; it only needs enough atomic surfaces that the builder can combine
+compatible goals into a target list.
+
+The safe bootstrap generation loop is:
+
+1. Build atomic `GoalSurface` rows from `SourceRecord` streams.
+2. Choose one or more `GoalRef` rows as `true_y`.
+3. Ask a configurable paraphrase backend for candidate `x` strings.
+4. Write `GoalTextExample` rows where `x` is model-generated text and `true_y` is the selected
+   deterministic `GoalRef` set.
+5. Train the first real `GoalExtractor`.
+6. Rerun that extractor over candidate `x` rows and keep only rows whose `atomic_goal_refs` set and
+   `relations` set exactly match `true_y`.
+
+This is how LLM-backed generation is used: it writes candidate language, not labels. A handwritten
+keyword parser is intentionally not part of the label path.
+
+The first implementation path is `scripts/build_goal_dataset.py`, which consumes one or more captured
+JSON directories through `RedfishFixtureSource` and writes `GoalSurface` rows. This is the small,
+local smoke-test path; it proves the builder on tiny fixtures and does not attempt to pull the full
+corpus:
+
+```bash
+python scripts/build_goal_dataset.py \
+  --capture-root /path/to/captured/redfish-json \
+  --vendor dell \
+  --source real_dell \
+  --surfaces-out /path/to/goal_surfaces.jsonl
+```
+
+To request text examples, provide selected `--goal-id` targets and a paraphrase mode. The public code
+uses generic OpenAI-compatible environment variables and does not hardcode private endpoints:
+
+```bash
+GOAL_PARAPHRASE_BASE_URL=<openai-compatible-base-url> \
+GOAL_PARAPHRASE_MODEL=<model-name> \
+python scripts/build_goal_dataset.py \
+  --capture-root /path/to/captured/redfish-json \
+  --surfaces-out /path/to/goal_surfaces.jsonl \
+  --text-out /path/to/goal_text_examples.jsonl \
+  --paraphrase-mode openai \
+  --goal-id power.computer_system.PowerState.eq.On
+```
+
+The full dataset build runs inside the NV72 Docker lab, not on a laptop. The lab wrapper
+`scripts/build_goal_dataset_lab.sh` initializes the `redfish_ctl`/`idrac_ctl` submodule in the Docker
+checkout, runs `git lfs pull` inside that submodule so the full Redfish JSON corpus is present, verifies
+JSON files exist, and then calls `scripts/build_goal_dataset.py`. Capture roots are discovered from
+the LFS-backed vendor fixture directories and `~/.json_responses`, or supplied with
+`IGC_CAPTURE_ROOTS`. The model endpoint comes only from environment variables or a private env file;
+the script never hardcodes private hosts.
+
+For a lab-side full-corpus draft pass, generate one text batch per discovered atomic goal and write a
+manifest with the counts:
+
+```bash
+IGC_GOAL_DATASET_OUT=/private/or/lfs/path/goal_dataset \
+GOAL_PARAPHRASE_BASE_URL=<openai-compatible-base-url> \
+GOAL_PARAPHRASE_MODEL=<model-name> \
+bash scripts/build_goal_dataset_lab.sh
+```
+
+The generated `goal_surfaces.jsonl`, `goal_text_examples.jsonl`, and `goal_dataset_manifest.json`
+are private dataset artifacts. They are not public documentation and should not be committed to this
+repository.
+
+## Initial Goal Families
+
+Power goals come from `#ComputerSystem` resources:
+
+- `PowerState == On`
+- `PowerState == Off`
+- reset transition intents from `ResetType` allowable values
+
+Boot goals come from the `Boot` object on `#ComputerSystem`:
+
+- `Boot.BootSourceOverrideTarget == <allowed value>`
+- `Boot.BootSourceOverrideEnabled == Once | Continuous | Disabled`
+- boot option references from `#BootOption` resources
+
+BIOS goals come from `#Bios`, `#Bios/Settings`, and attribute registries:
+
+- current attribute facts from `Attributes`
+- pending attribute facts from settings resources
+- allowable attribute values from `#AttributeRegistry`
+
+Virtual-media goals come from virtual-media resources:
+
+- image inserted/ejected state
+- inserted image URI when a safe approved fixture surface exists
+
+Log/task goals come from log-service and task resources:
+
+- log cleared state when the resource exposes a clear action and measurable count/state
+- task terminal state such as `Completed`, `Exception`, or `Killed`
+
+Every family must define a verifier before it can train RL rewards.
+
+## Encoders And Objectives
+
+`TextGoalEncoder(text_or_atomic_span) -> z_sub_goal` and
+`GoalSurfaceEncoder(surface) -> z_sub_goal` share the same latent space. A compound instruction can
+also have a pooled `z_goal_set` for bookkeeping, but RL rewards, HER relabels, and candidate scoring
+should be defined over atomic `z_sub_goal` items unless a later experiment proves a set encoder is
+needed. A training batch should contain multiple vendors and multiple text paraphrases per semantic
+goal. The default objective is multi-positive contrastive alignment plus fact preservation:
+
+```text
+L_goal =
+  L_supervised_contrastive(text/surface positives, hard negatives)
+  + lambda_decode * L_goal_fact_decoder
+  + lambda_collapse * L_variance_or_covariance_guard
+```
+
+The decoder head predicts family, resource type, property path, operator, target value bucket,
+current-vs-pending mode, and dependency hints. It exists to prevent collapse, not to replace the
+verifier.
+
+Hard negatives are mandatory:
+
+- same property, different value;
+- same value, different property;
+- same action family, different reset type;
+- current BIOS value versus pending BIOS setting;
+- boot override once versus continuous;
+- same text family on a different resource type.
+
+## Verifier And Reward Boundary
+
+`GoalVerifier` receives the hidden concrete goal payload, the next observation, and optional action
+result metadata. It returns whether the goal is satisfied and any dense components the reward table
+defines. A `2xx` action response is evidence that the request was accepted; it is not proof that the
+goal was reached. The verifier must re-check measurable state when the goal is a state goal.
+
+For HER, the achieved-goal projector derives future achieved atomic goals from observations:
+
+```text
+achieved_goal_refs = AchievedGoalProjector(obs_future)
+z_her_sub_goal = GoalEncoder(surface_for(achieved_goal_ref))
+reward_t_her = GoalVerifier(achieved_goal_ref, obs_{t+1})
+```
+
+The reward is recomputed against the transition's `obs_{t+1}`. A future state that satisfies a goal
+does not make every earlier transition successful.
+
+## Metrics
+
+Extraction metrics:
+
+- `goal_extractor/atomic_goal_exact_match`
+- `goal_extractor/compound_goal_set_f1`
+- `goal_extractor/dependency_edge_f1`
+- `goal_extractor/invalid_goal_ref_rate`
+- `goal_extractor/value_slot_exact_match`
+
+Latent alignment metrics:
+
+- `goal_encoder/text_to_surface_recall_at_1`
+- `goal_encoder/text_to_surface_recall_at_5`
+- `goal_encoder/surface_to_text_recall_at_1`
+- `goal_encoder/hard_negative_confusion_rate`
+- `goal_encoder/effective_rank`
+- `goal_encoder/vendor_leakage_probe_accuracy`
+
+Verifier/HER metrics:
+
+- `goal_verifier/state_eq_accuracy`
+- `goal_verifier/false_success_rate`
+- `goal_verifier/false_failure_rate`
+- `her/achieved_goal_projection_count`
+- `her/relabel_reward_recompute_error_count`
+
+RL metrics must use the active latent sub-goal seen by the policy and the hidden concrete verifier
+payload used by the environment. Mixing those two surfaces in plots hides bugs.
+
+## Implementation Names
+
+Use descriptive names in code and docs:
+
+- `igc.ds.goal_dataset` for records and JSONL IO.
+- `igc.ds.goal_dataset_builder` for deterministic Redfish-to-goal extraction and compound assembly.
+- `igc.modules.goal_extractor` for text-to-goal-ref parsing interfaces and metrics.
+- `igc.modules.goal_encoder` for text/surface latent encoders and objective helpers.
+- `igc.modules.goal_verifier` for deterministic state/reward verification.
+
+Do not name new public code after phase labels. Phase labels can remain in roadmaps, but source files
+should say what they do.
+
+## Failure Modes
+
+The design is wrong if any of these happen:
+
+- A compound sentence is collapsed into one opaque goal and loses atomic targets.
+- A sentence with no explicit ordering produces an ordered plan label.
+- A policy success check compares only latent vectors.
+- A generated paraphrase changes `Once` to `Continuous`, `GracefulRestart` to `ForceRestart`, or an
+  observation/read goal into a mutation goal.
+- Vendor-specific names are used as the semantic label instead of as goal-surface evidence.
+- HER copies the future reward backward without recomputing against each transition's next
+  observation.
+- A goal family is used for RL before its verifier exists.
+
+# Author: Mus mbayramo@stanford.edu

--- a/docs/GOAL_LATENT_DESIGN.md
+++ b/docs/GOAL_LATENT_DESIGN.md
@@ -180,12 +180,12 @@ python scripts/build_goal_dataset.py \
 ```
 
 The full dataset build runs inside the NV72 Docker lab, not on a laptop. The lab wrapper
-`scripts/build_goal_dataset_lab.sh` initializes the `redfish_ctl`/`idrac_ctl` submodule in the Docker
-checkout, runs `git lfs pull` inside that submodule so the full Redfish JSON corpus is present, verifies
-JSON files exist, and then calls `scripts/build_goal_dataset.py`. Capture roots are discovered from
-the LFS-backed vendor fixture directories and `~/.json_responses`, or supplied with
-`IGC_CAPTURE_ROOTS`. The model endpoint comes only from environment variables or a private env file;
-the script never hardcodes private hosts.
+`scripts/build_goal_dataset_lab.sh` initializes the canonical `redfish_ctl` checkout, runs
+`git lfs pull` inside that checkout so the full Redfish JSON corpus is present, verifies that the
+Dell iDRAC, Supermicro GB300/HGX, and HPE iLO discovery corpora are non-empty, and then calls
+`scripts/build_goal_dataset.py`. Capture roots are discovered from the LFS-backed vendor fixture
+directories and `~/.json_responses`, or supplied with `IGC_CAPTURE_ROOTS`. The model endpoint comes
+only from environment variables or a private env file; the script never hardcodes private hosts.
 
 For a lab-side full-corpus draft pass, generate one text batch per discovered atomic goal and write a
 manifest with the counts:

--- a/docs/MATH_CHECKS.md
+++ b/docs/MATH_CHECKS.md
@@ -126,7 +126,7 @@ flowchart LR
 | --- | --- | --- |
 | M1 backbone | language-model loss over Redfish text | tokenization mask, loss finite, small batch overfit, no hidden-size assumptions. |
 | M2 state pooler | pooled state reconstruction or auxiliary prediction | shape contract, no `seq_len * hidden_size` decoder blowup, finite gradients. |
-| M3 planner | instruction to sub-goal plan | plan validity metric, topological order, precondition satisfaction. |
+| GoalExtractor / GoalEncoder | instruction to atomic goal refs and latent sub-goals | atomic-goal exact match, dependency-edge F1, hard-negative retrieval, collapse checks. |
 | M4 evaluator/reward | structured success and dense reward | reward table for success/failure/progress/no-op; no embedding equality as final verifier. |
 | M5 world model | next state/status/task phase | one-step prediction target, terminal-state handling, rollout drift metric. |
 | M6 RL policy | candidate-action Q-learning with HER | terminal mask, legal-action mask, HER achieved-goal relabel, target sanity. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,9 @@ Reinforce Learner).
   launcher automation roadmap: image reuse, storage, checkpoints, dry-runs, sanity checks, and CI.
 - [RL_SCALING_PLAN.md](RL_SCALING_PLAN.md) — RL scaling plan: DQN/HER safety,
   rollout/learner split, freshness, batching, parity, and profiling gates.
+- [GOAL_LATENT_DESIGN.md](GOAL_LATENT_DESIGN.md) — the GoalExtractor and GoalEncoder design:
+  atomic sub-goal extraction, latent `z_sub_goal` alignment, hidden verifier payloads, and HER
+  relabel boundaries.
 - [TRAINING_OPTIMIZATION_PLAN.md](TRAINING_OPTIMIZATION_PLAN.md) — the large-model training,
   optimization, and GPU-efficiency roadmap for 3B/7B state-encoder work.
 

--- a/docs/diagrams/04-hierarchical-workload-plan.svg
+++ b/docs/diagrams/04-hierarchical-workload-plan.svg
@@ -1,6 +1,6 @@
 <svg width="100%" viewBox="0 0 680 392" role="img" xmlns="http://www.w3.org/2000/svg">
 <title>A high-level workload decomposed into ordered, dependent sub-goals with discovery</title>
-<desc>The statement "tune BIOS, then boot Ubuntu" is decomposed by a planner into five ordered sub-goals where each is a precondition for the next; reboot steps are disruptive and gated; the terminal reward is clear but sparse. The agent must additionally discover the API, discover the state machine, and learn the optimal strategy.</desc>
+<desc>The statement "tune BIOS, then boot Ubuntu" is extracted into atomic sub-goals with an explicit dependency hint; reboot steps are disruptive and gated; the terminal reward is clear but sparse. The agent must additionally discover the API, discover the state machine, and learn the optimal strategy.</desc>
 <style>
 svg{--surface-2:#ffffff;--surface-1:#f7f7f5;--surface-0:#f0efea;--text-primary:#1f1e1b;--text-secondary:#57564f;--text-muted:#8a897f;--border:#e3e2dc;--border-strong:#cbcabf}
 .t,.th,.ts{font-family:-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;fill:var(--text-primary)}
@@ -23,7 +23,7 @@ rect.c-purple{fill:#EEEDFE;stroke:#AFA9EC}.c-purple text{fill:#26215C}
 <text class="ts" x="624" y="62" text-anchor="end">reward: Ubuntu boots (clear, but sparse)</text>
 
 <rect x="250" y="92" width="180" height="24" rx="12" fill="var(--surface-1)" stroke="var(--border-strong)"/>
-<text class="ts" x="340" y="108" text-anchor="middle">planner (casting): NL → plan</text>
+<text class="ts" x="340" y="108" text-anchor="middle">GoalExtractor: NL → GoalRefs</text>
 <line x1="340" y1="86" x2="340" y2="92" stroke="var(--text-secondary)" marker-end="url(#arr3)"/>
 <line x1="340" y1="116" x2="340" y2="126" stroke="var(--text-secondary)" marker-end="url(#arr3)"/>
 

--- a/docs/diagrams/05-training-curriculum.svg
+++ b/docs/diagrams/05-training-curriculum.svg
@@ -1,6 +1,6 @@
 <svg width="100%" viewBox="0 0 680 410" role="img" xmlns="http://www.w3.org/2000/svg">
 <title>igc training curriculum: six models staged on the NVL72</title>
-<desc>Stage 0 on CPU makes the code runnable and backbone-agnostic. Stage 1 trains M1 the backbone LLM. Stage 2 trains M2 autoencoder, M3 planner, and M4 reward in parallel off M1. Stage 3 trains M5 world model. Stage 4 trains M6 the RL agent, which consumes M2, M3, M4, and M5.</desc>
+<desc>Stage 0 on CPU makes the code runnable and backbone-agnostic. Stage 1 trains M1 the backbone LLM. Stage 2 trains M2 autoencoder, GoalExtractor/GoalEncoder, and M4 reward in parallel off M1. Stage 3 trains M5 world model. Stage 4 trains M6 the RL agent, which consumes M2, goal latents, M4, and M5.</desc>
 <style>
 svg{--surface-2:#ffffff;--surface-1:#f7f7f5;--surface-0:#f0efea;--text-primary:#1f1e1b;--text-secondary:#57564f;--text-muted:#8a897f;--border:#e3e2dc;--border-strong:#cbcabf}
 .t,.th,.ts{font-family:-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;fill:var(--text-primary)}
@@ -34,8 +34,8 @@ rect.c-purple{fill:#EEEDFE;stroke:#AFA9EC}.c-purple text{fill:#26215C}
 <text class="th" x="135" y="202" text-anchor="middle">M2 · autoencoder</text>
 <text class="ts" x="135" y="218" text-anchor="middle">pool → latent 64</text>
 <rect x="245" y="182" width="190" height="48" rx="6" fill="var(--surface-1)" stroke="var(--border)"/>
-<text class="th" x="340" y="202" text-anchor="middle">M3 · planner</text>
-<text class="ts" x="340" y="218" text-anchor="middle">NL → sub-goal DAG</text>
+<text class="th" x="340" y="202" text-anchor="middle">GoalExtractor</text>
+<text class="ts" x="340" y="218" text-anchor="middle">NL → atomic goals</text>
 <rect x="450" y="182" width="190" height="48" rx="6" fill="var(--surface-1)" stroke="var(--border)"/>
 <text class="th" x="545" y="202" text-anchor="middle">M4 · reward</text>
 <text class="ts" x="545" y="218" text-anchor="middle">ValueHead · decomposed</text>
@@ -50,5 +50,5 @@ rect.c-purple{fill:#EEEDFE;stroke:#AFA9EC}.c-purple text{fill:#26215C}
 <line x1="300" y1="296" x2="240" y2="320" stroke="var(--text-secondary)" marker-end="url(#a4)"/>
 
 <g class="c-coral"><rect class="c-coral" x="170" y="324" width="340" height="46" rx="6"/><text class="th" x="340" y="344" text-anchor="middle">M6 · RL agent (Stage 4 · longest)</text><text class="ts" x="340" y="360" text-anchor="middle">goal-cond. DQN + HER on ToolAction</text></g>
-<text class="ts" x="340" y="388" text-anchor="middle">M6 consumes M2 latent · M3 plan · M4+M5 reward — and learns the optimal ordering</text>
+<text class="ts" x="340" y="388" text-anchor="middle">M6 consumes M2 latent · z_sub_goal · M4+M5 reward — and learns the optimal ordering</text>
 </svg>

--- a/docs/use_cases/why-rl-not-an-llm.md
+++ b/docs/use_cases/why-rl-not-an-llm.md
@@ -106,8 +106,9 @@ The model is doing real work — just not the deciding:
 
 - **Understanding** the observation: turning a nested, vendor-specific JSON body into a state the
   policy can use is a language/code problem the backbone is good at.
-- **Planning / decomposition**: mapping a high-level `instruction` into ordered sub-goals (the
-  planned M3 layer in `ARCHITECTURE.md`) is where the model's world knowledge helps.
+- **Goal extraction**: mapping a high-level `instruction` into atomic `GoalRef` targets and explicit
+  dependency hints is where the model's world knowledge helps; the RL policy still learns execution
+  order from reward.
 - **Argument values**: choosing enum values for an action's typed slots draws on the model's grasp of
   what the fields mean.
 

--- a/igc/core/tool_card.py
+++ b/igc/core/tool_card.py
@@ -2,10 +2,10 @@
 
 A ``ToolCard`` is what the tool-teaching layer (``docs/ARCHITECTURE.md`` §12)
 induces for a tool the agent does not yet know: from a few real ``(call ->
-result/error)`` interactions, the LLM teacher (the DeepSeek-V4-Flash endpoint M3
-reuses) distills the op's effective argument signature, the response fields to
-expect, an error taxonomy (what each status *means* — retriable / fatal /
-precondition-unmet), and preconditions. The card is a *refinement* of the
+result/error)`` interactions, the gated LLM teacher distills the op's effective
+argument signature, the response fields to expect, an error taxonomy (what each
+status *means* — retriable / fatal / precondition-unmet), and preconditions. The
+card is a *refinement* of the
 discovery-time :class:`~igc.core.types.ToolSpec`, never a replacement, and it is
 only ever advisory to scoring: per the safety invariant it may RAISE caution but
 can never lower a :class:`~igc.core.types.RiskLevel` or unlock a destructive op.

--- a/igc/core/types.py
+++ b/igc/core/types.py
@@ -104,7 +104,7 @@ class Goal:
     """A goal: a natural-language ``instruction``, a machine-checkable ``spec``
     the Evaluator reads (replacing embedding ``allclose``), optional
     ``constraints``, and an optional ordered ``plan`` (a list of
-    :class:`ToolAction` sub-goals filled by the planner / casting layer).
+    :class:`ToolAction` sub-goals filled by an upstream scheduler or UI layer).
     """
 
     instruction: str

--- a/igc/ds/goal_dataset.py
+++ b/igc/ds/goal_dataset.py
@@ -1,0 +1,259 @@
+"""GoalExtractor / GoalEncoder dataset records.
+
+The key contract is intentionally narrow: operator text maps to an unordered
+set of atomic sub-goals. Each atomic sub-goal becomes an active ``z_sub_goal``
+for policy conditioning; compound instructions may carry dependency hints, but
+they are not execution plans. Hidden vendor-specific verifier payloads stay
+with :class:`GoalSurface` for reward and HER.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class GoalRef:
+    """Vendor-neutral atomic sub-goal label.
+
+    :param goal_id: stable semantic identifier used as the class/slot label.
+    :param family: broad family such as ``power`` / ``boot`` / ``network``.
+    :param resource_type: vendor-neutral resource class.
+    :param property_path: dotted Redfish property path, or ``""`` for actions.
+    :param operator: comparison operator; initially ``"eq"``.
+    :param target_value: target value for state goals.
+    :param mode: ``"state"`` or ``"transition"``.
+    :param action_name: Redfish action name for transition goals.
+    :param arguments: action arguments for transition goals.
+    :param constraints: optional semantic constraints that are not policy-visible.
+    """
+    goal_id: str
+    family: str
+    resource_type: str
+    property_path: str = ""
+    operator: str = "eq"
+    target_value: Any = None
+    mode: str = "state"
+    action_name: str = ""
+    arguments: Mapping[str, Any] = field(default_factory=dict)
+    constraints: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        """Serialize to a JSON-compatible dict.
+
+        :return: plain dict representation.
+        """
+        data = asdict(self)
+        data["arguments"] = dict(self.arguments)
+        data["constraints"] = dict(self.constraints)
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "GoalRef":
+        """Rebuild from :meth:`to_dict` output.
+
+        :param data: serialized goal ref.
+        :return: reconstructed :class:`GoalRef`.
+        """
+        return cls(
+            goal_id=str(data["goal_id"]),
+            family=str(data["family"]),
+            resource_type=str(data["resource_type"]),
+            property_path=str(data.get("property_path", "")),
+            operator=str(data.get("operator", "eq")),
+            target_value=data.get("target_value"),
+            mode=str(data.get("mode", "state")),
+            action_name=str(data.get("action_name", "")),
+            arguments=dict(data.get("arguments") or {}),
+            constraints=dict(data.get("constraints") or {}),
+        )
+
+
+@dataclass(frozen=True)
+class GoalDependency:
+    """Explicit text-level partial order between atomic sub-goals.
+
+    This is metadata for compound instructions such as "set NTP then boot"; it
+    is not a concrete API sequence and does not turn the goal set into a plan.
+
+    :param before_goal_id: goal that text says must happen first.
+    :param after_goal_id: goal that text says comes after.
+    :param relation: relation label, currently ``"before"``.
+    :param evidence: text cue such as ``"then"`` / ``"after"``.
+    """
+    before_goal_id: str
+    after_goal_id: str
+    relation: str = "before"
+    evidence: str = ""
+
+    def to_dict(self) -> dict:
+        """Serialize to a JSON-compatible dict."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "GoalDependency":
+        """Rebuild from :meth:`to_dict` output."""
+        return cls(
+            before_goal_id=str(data["before_goal_id"]),
+            after_goal_id=str(data["after_goal_id"]),
+            relation=str(data.get("relation", "before")),
+            evidence=str(data.get("evidence", "")),
+        )
+
+
+@dataclass(frozen=True)
+class GoalSurface:
+    """Vendor/world-specific evidence for one atomic :class:`GoalRef`.
+
+    The policy should never need this full payload. The verifier and HER logic
+    use it to compare concrete observations and recompute rewards.
+    """
+    goal_ref: GoalRef
+    vendor: str
+    source: str
+    resource_uri: str
+    resource_type: str
+    fact_path: str
+    target_value: Any
+    current_value: Any = None
+    allowed_values: Sequence[Any] = field(default_factory=tuple)
+    verifier: Mapping[str, Any] = field(default_factory=dict)
+    provenance: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        """Serialize to a JSON-compatible dict."""
+        return {
+            "goal_ref": self.goal_ref.to_dict(),
+            "vendor": self.vendor,
+            "source": self.source,
+            "resource_uri": self.resource_uri,
+            "resource_type": self.resource_type,
+            "fact_path": self.fact_path,
+            "target_value": self.target_value,
+            "current_value": self.current_value,
+            "allowed_values": list(self.allowed_values),
+            "verifier": dict(self.verifier),
+            "provenance": dict(self.provenance),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "GoalSurface":
+        """Rebuild from :meth:`to_dict` output."""
+        return cls(
+            goal_ref=GoalRef.from_dict(data["goal_ref"]),
+            vendor=str(data.get("vendor", "")),
+            source=str(data.get("source", "")),
+            resource_uri=str(data["resource_uri"]),
+            resource_type=str(data.get("resource_type", "")),
+            fact_path=str(data.get("fact_path", "")),
+            target_value=data.get("target_value"),
+            current_value=data.get("current_value"),
+            allowed_values=tuple(data.get("allowed_values") or ()),
+            verifier=dict(data.get("verifier") or {}),
+            provenance=dict(data.get("provenance") or {}),
+        )
+
+
+@dataclass(frozen=True)
+class GoalTextExample:
+    """Text-to-atomic-sub-goal training row.
+
+    ``goal_refs`` is a tuple so equality is deterministic for tests and JSONL
+    round trips. Callers can treat it as an unordered set unless dependencies
+    explicitly say otherwise.
+    """
+    text: str
+    goal_refs: Sequence[GoalRef]
+    dependencies: Sequence[GoalDependency] = field(default_factory=tuple)
+    text_source: str = "template"
+    split: str = "train"
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        """Serialize to a JSON-compatible dict."""
+        return {
+            "text": self.text,
+            "goal_refs": [ref.to_dict() for ref in self.goal_refs],
+            "dependencies": [dep.to_dict() for dep in self.dependencies],
+            "text_source": self.text_source,
+            "split": self.split,
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "GoalTextExample":
+        """Rebuild from :meth:`to_dict` output."""
+        return cls(
+            text=str(data["text"]),
+            goal_refs=tuple(GoalRef.from_dict(item) for item in data.get("goal_refs", ())),
+            dependencies=tuple(
+                GoalDependency.from_dict(item) for item in data.get("dependencies", ())
+            ),
+            text_source=str(data.get("text_source", "template")),
+            split=str(data.get("split", "train")),
+            metadata=dict(data.get("metadata") or {}),
+        )
+
+    @staticmethod
+    def write_jsonl(path: Path | str, rows: Iterable["GoalTextExample"]) -> None:
+        """Write text examples as JSON Lines.
+
+        :param path: output JSONL path.
+        :param rows: examples to write.
+        """
+        target = Path(path)
+        with target.open("w", encoding="utf-8") as fh:
+            for row in rows:
+                fh.write(json.dumps(row.to_dict(), sort_keys=True) + "\n")
+
+
+def read_goal_text_examples(path: Path | str) -> tuple[GoalTextExample, ...]:
+    """Read :class:`GoalTextExample` rows from JSON Lines.
+
+    :param path: input JSONL path.
+    :return: loaded examples.
+    """
+    source = Path(path)
+    rows = []
+    with source.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            stripped = line.strip()
+            if stripped:
+                rows.append(GoalTextExample.from_dict(json.loads(stripped)))
+    return tuple(rows)
+
+
+def write_goal_surfaces(path: Path | str, rows: Iterable[GoalSurface]) -> None:
+    """Write goal surfaces as JSON Lines.
+
+    :param path: output JSONL path.
+    :param rows: surfaces to write.
+    """
+    target = Path(path)
+    with target.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row.to_dict(), sort_keys=True) + "\n")
+
+
+def read_goal_surfaces(path: Path | str) -> tuple[GoalSurface, ...]:
+    """Read :class:`GoalSurface` rows from JSON Lines.
+
+    :param path: input JSONL path.
+    :return: loaded surfaces.
+    """
+    source = Path(path)
+    rows = []
+    with source.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            stripped = line.strip()
+            if stripped:
+                rows.append(GoalSurface.from_dict(json.loads(stripped)))
+    return tuple(rows)
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/igc/ds/goal_dataset_builder.py
+++ b/igc/ds/goal_dataset_builder.py
@@ -608,10 +608,12 @@ def build_goal_surfaces(records: Iterable[SourceRecord]) -> tuple[GoalSurface, .
             surfaces.extend(_bios_surfaces(record))
 
     deduped: list[GoalSurface] = []
-    seen: set[tuple[str, str, str, str]] = set()
+    seen: set[tuple[str, str, str, str, str, str]] = set()
     for surface in surfaces:
         key = (
             surface.goal_ref.goal_id,
+            surface.vendor,
+            surface.source,
             surface.resource_uri,
             surface.fact_path,
             _id_part(surface.target_value),

--- a/igc/ds/goal_dataset_builder.py
+++ b/igc/ds/goal_dataset_builder.py
@@ -241,6 +241,9 @@ def _surface(
     if goal_ref.action_name:
         verifier["action_name"] = goal_ref.action_name
         verifier["arguments"] = dict(goal_ref.arguments)
+    provenance = dict(record.provenance)
+    if record.allowed_methods:
+        provenance["allowed_methods"] = list(record.allowed_methods)
     return GoalSurface(
         goal_ref=goal_ref,
         vendor=record.vendor or "",
@@ -252,7 +255,7 @@ def _surface(
         current_value=current_value,
         allowed_values=tuple(allowed_values),
         verifier=verifier,
-        provenance=dict(record.provenance),
+        provenance=provenance,
     )
 
 

--- a/igc/ds/goal_dataset_builder.py
+++ b/igc/ds/goal_dataset_builder.py
@@ -72,6 +72,16 @@ _SENSITIVE_NAME_SUBSTRINGS = (
     "token",
     "uuid",
 )
+_METADATA_RESOURCE_TYPES = frozenset({
+    "AttributeRegistry",
+    "JsonSchemaFile",
+    "MessageRegistry",
+    "PrivilegeRegistry",
+})
+_METADATA_URI_PARTS = (
+    "/jsonschemas/",
+    "/registries/",
+)
 
 
 def _bool_title(value: bool) -> str:
@@ -125,6 +135,27 @@ def _resource_type_id(odata_type: str) -> str:
         if tail and not tail.startswith("v"):
             return _snake(tail)
     return "resource"
+
+
+def _is_metadata_document(record: SourceRecord) -> bool:
+    """Return whether a corpus record documents schema, not mutable state."""
+    body = record.response
+    if not isinstance(body, Mapping):
+        return False
+
+    odata = str(body.get("@odata.type", record.schema_version))
+    if any(resource_type in odata for resource_type in _METADATA_RESOURCE_TYPES):
+        return True
+
+    normalized_uri = record.url.lower()
+    if any(uri_part in normalized_uri for uri_part in _METADATA_URI_PARTS):
+        return True
+
+    if "$schema" in body or "Definitions" in body or "definitions" in body:
+        return True
+    return "RegistryPrefix" in body and (
+        "Messages" in body or "RegistryEntries" in body
+    )
 
 
 def _get_path(body: Mapping[str, Any], path: str) -> Any:
@@ -563,6 +594,8 @@ def build_goal_surfaces(records: Iterable[SourceRecord]) -> tuple[GoalSurface, .
     surfaces: list[GoalSurface] = []
     for record in records:
         if not isinstance(record.response, Mapping):
+            continue
+        if _is_metadata_document(record):
             continue
         odata = str(record.response.get("@odata.type", record.schema_version))
         surfaces.extend(_generic_state_surfaces(record))

--- a/igc/ds/goal_dataset_builder.py
+++ b/igc/ds/goal_dataset_builder.py
@@ -1,0 +1,617 @@
+"""Build GoalExtractor / GoalEncoder rows from captured Redfish JSON.
+
+This module owns deterministic ``Y`` construction. A paraphrase model may later
+generate operator text ``X``, but code here decides which atomic sub-goal refs
+are true. Most Redfish captures expose one property/action surface at a time;
+compound text examples are assembled by grouping those atomic rows.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable, Mapping, Sequence
+
+from igc.ds.goal_dataset import GoalDependency, GoalRef, GoalSurface, GoalTextExample
+from igc.ds.sources import SourceRecord
+
+_ALLOWABLE_SUFFIX = "@Redfish.AllowableValues"
+_SCALAR_TYPES = (str, int, float, bool)
+_SKIP_SUBTREES = frozenset({"Actions", "Links", "Members"})
+_SKIP_LEAF_KEYS = frozenset({
+    "@odata.context",
+    "@odata.etag",
+    "@odata.id",
+    "@odata.type",
+    "Created",
+    "Description",
+    "Id",
+    "Modified",
+    "Name",
+    "Password",
+    "RoleId",
+    "Token",
+    "UserName",
+})
+_SENSITIVE_NAME_PARTS = frozenset({
+    "apikey",
+    "api_key",
+    "certificate",
+    "credential",
+    "key",
+    "macaddress",
+    "mac_address",
+    "password",
+    "privatekey",
+    "private_key",
+    "roleid",
+    "role_id",
+    "secret",
+    "serialnumber",
+    "serial_number",
+    "sshkey",
+    "ssh_key",
+    "token",
+    "username",
+    "user_name",
+})
+_SENSITIVE_NAME_SUBSTRINGS = (
+    "asset_tag",
+    "change_password",
+    "credential",
+    "host_name",
+    "hostname",
+    "key",
+    "macaddress",
+    "mac_address",
+    "password",
+    "private",
+    "secret",
+    "serial",
+    "token",
+    "uuid",
+)
+
+
+def _bool_title(value: bool) -> str:
+    """Return stable bool labels for goal IDs."""
+    return "True" if value else "False"
+
+
+def _id_part(value: Any) -> str:
+    """Normalize a value into a readable goal-id component."""
+    if isinstance(value, bool):
+        return _bool_title(value)
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", str(value)).strip("_") or "empty"
+
+
+def _goal_value_id(value: Any) -> str:
+    """Return the public-safe value component for a semantic goal id."""
+    if isinstance(value, bool):
+        return _bool_title(value)
+    if isinstance(value, (int, float)):
+        return _id_part(value)
+    if isinstance(value, str) and re.fullmatch(r"[A-Za-z0-9_ -]{1,64}", value):
+        return _id_part(value)
+    return "value"
+
+
+def _snake(value: str) -> str:
+    """Convert a Redfish class/property name into a readable id token."""
+    if not value:
+        return "resource"
+    with_separators = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", value)
+    normalized = re.sub(r"[^A-Za-z0-9]+", "_", with_separators)
+    return normalized.strip("_").lower() or "resource"
+
+
+def _resource_type_id(odata_type: str) -> str:
+    """Map a Redfish ``@odata.type`` to a stable, readable resource-type id."""
+    if "ComputerSystem" in odata_type:
+        return "computer_system"
+    if "ManagerNetworkProtocol" in odata_type:
+        return "manager_network_protocol"
+    if "Bios" in odata_type:
+        return "bios"
+    if "VirtualMedia" in odata_type:
+        return "virtual_media"
+    if "LogService" in odata_type:
+        return "log_service"
+    if "Task" in odata_type:
+        return "task"
+    if "." in odata_type:
+        tail = odata_type.rsplit(".", 1)[-1]
+        if tail and not tail.startswith("v"):
+            return _snake(tail)
+    return "resource"
+
+
+def _get_path(body: Mapping[str, Any], path: str) -> Any:
+    """Read a dotted property path from a mapping."""
+    current: Any = body
+    for part in path.split("."):
+        if not isinstance(current, Mapping) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _state_goal_ref(
+    family: str,
+    resource_type: str,
+    property_path: str,
+    target_value: Any,
+) -> GoalRef:
+    """Create a state-equality atomic sub-goal ref."""
+    goal_id = ".".join((
+        family,
+        resource_type,
+        property_path,
+        "eq",
+        _goal_value_id(target_value),
+    ))
+    return GoalRef(
+        goal_id=goal_id,
+        family=family,
+        resource_type=resource_type,
+        property_path=property_path,
+        operator="eq",
+        target_value=target_value,
+        mode="state",
+    )
+
+
+def _transition_goal_ref(
+    family: str,
+    resource_type: str,
+    action_name: str,
+    argument_name: str,
+    target_value: Any,
+) -> GoalRef:
+    """Create an action/transition atomic sub-goal ref."""
+    goal_id = ".".join((
+        family,
+        resource_type,
+        action_name,
+        argument_name,
+        "eq",
+        _goal_value_id(target_value),
+    ))
+    return GoalRef(
+        goal_id=goal_id,
+        family=family,
+        resource_type=resource_type,
+        operator="eq",
+        target_value=target_value,
+        mode="transition",
+        action_name=action_name,
+        arguments={argument_name: target_value},
+    )
+
+
+def _surface(
+    record: SourceRecord,
+    goal_ref: GoalRef,
+    fact_path: str,
+    target_value: Any,
+    current_value: Any,
+    allowed_values: Sequence[Any] = (),
+    verifier_kind: str = "state_eq",
+) -> GoalSurface:
+    """Create a vendor-specific goal surface around one atomic sub-goal."""
+    verifier = {
+        "kind": verifier_kind,
+        "resource_uri": record.url,
+        "property_path": fact_path,
+        "operator": goal_ref.operator,
+        "target_value": target_value,
+    }
+    if goal_ref.action_name:
+        verifier["action_name"] = goal_ref.action_name
+        verifier["arguments"] = dict(goal_ref.arguments)
+    return GoalSurface(
+        goal_ref=goal_ref,
+        vendor=record.vendor or "",
+        source=record.source,
+        resource_uri=record.url,
+        resource_type=str(record.response.get("@odata.type", record.schema_version)),
+        fact_path=fact_path,
+        target_value=target_value,
+        current_value=current_value,
+        allowed_values=tuple(allowed_values),
+        verifier=verifier,
+        provenance=dict(record.provenance),
+    )
+
+
+def _family_for_path(resource_type: str, path: str) -> str:
+    """Infer a coarse semantic family from a resource type and property path."""
+    lowered = f"{resource_type}.{path}".lower()
+    if "power" in lowered:
+        return "power"
+    if "boot" in lowered:
+        return "boot"
+    if "bios" in lowered or "attribute" in lowered:
+        return "bios"
+    if "ntp" in lowered or "network" in lowered or "ethernet" in lowered:
+        return "network"
+    if "thermal" in lowered or "fan" in lowered or "temperature" in lowered:
+        return "thermal"
+    if "status" in lowered or "health" in lowered:
+        return "status"
+    if "log" in lowered:
+        return "log"
+    first = path.split(".", 1)[0].replace("[]", "")
+    return _snake(first) if first else "state"
+
+
+def _family_for_action(action_name: str) -> str:
+    """Infer a coarse semantic family from a Redfish action name."""
+    lowered = action_name.lower()
+    if "reset" in lowered or "power" in lowered:
+        return "action"
+    if "log" in lowered or "clearlog" in lowered:
+        return "log"
+    if "virtualmedia" in lowered:
+        return "virtual_media"
+    if "." in action_name:
+        return _snake(action_name.split(".", 1)[0])
+    return "action"
+
+
+def _is_scalar(value: Any) -> bool:
+    """Whether a JSON value is a useful atomic state target."""
+    return isinstance(value, _SCALAR_TYPES) and value is not None
+
+
+def _is_sensitive_path(path: str) -> bool:
+    """Whether a property path could carry secret or identity material."""
+    normalized_path = _snake(path.replace("[]", " "))
+    if any(token in normalized_path for token in _SENSITIVE_NAME_SUBSTRINGS):
+        return True
+    for part in path.split("."):
+        normalized = _snake(part.replace("[]", ""))
+        if normalized in _SENSITIVE_NAME_PARTS:
+            return True
+    return False
+
+
+def _walk_scalar_leaves(
+    node: Any,
+    path: str = "",
+) -> Iterable[tuple[str, Any]]:
+    """Yield scalar leaves from a Redfish body, skipping metadata/link noise."""
+    if isinstance(node, Mapping):
+        for key, value in node.items():
+            if key.endswith(_ALLOWABLE_SUFFIX):
+                continue
+            if key in _SKIP_SUBTREES or key in _SKIP_LEAF_KEYS:
+                continue
+            child_path = f"{path}.{key}" if path else key
+            if _is_sensitive_path(child_path):
+                continue
+            if _is_scalar(value):
+                yield child_path, value
+            elif isinstance(value, (Mapping, list)):
+                yield from _walk_scalar_leaves(value, child_path)
+    elif isinstance(node, list):
+        for value in node:
+            child_path = f"{path}[]" if path else "[]"
+            if _is_scalar(value):
+                yield child_path, value
+            elif isinstance(value, (Mapping, list)):
+                yield from _walk_scalar_leaves(value, child_path)
+
+
+def _walk_allowable_values(
+    node: Any,
+    path: str = "",
+    under_actions: bool = False,
+) -> Iterable[tuple[str, tuple[Any, ...], bool]]:
+    """Yield ``(property_path, allowed_values, under_actions)`` annotations."""
+    if isinstance(node, Mapping):
+        for key, value in node.items():
+            current_under_actions = under_actions or key == "Actions"
+            if key.endswith(_ALLOWABLE_SUFFIX) and isinstance(value, list) and value:
+                prop = key[: -len(_ALLOWABLE_SUFFIX)]
+                prop_path = f"{path}.{prop}" if path else prop
+                if _is_sensitive_path(prop_path):
+                    continue
+                yield prop_path, tuple(value), under_actions
+                continue
+            child_path = f"{path}.{key}" if path else key
+            yield from _walk_allowable_values(value, child_path, current_under_actions)
+    elif isinstance(node, list):
+        for value in node:
+            child_path = f"{path}[]" if path else "[]"
+            yield from _walk_allowable_values(value, child_path, under_actions)
+
+
+def _action_name_from_path(path: str) -> str:
+    """Extract ``ComputerSystem.Reset`` from an ``Actions.#...`` path."""
+    parts = path.split(".")
+    for index, part in enumerate(parts):
+        if part == "Actions" and index + 1 < len(parts):
+            return parts[index + 1].lstrip("#")
+    return ""
+
+
+def _action_surfaces(record: SourceRecord) -> list[GoalSurface]:
+    """Extract generic transition goals from a Redfish ``Actions`` block."""
+    body = record.response
+    actions = body.get("Actions")
+    if not isinstance(actions, Mapping):
+        return []
+    resource_type = _resource_type_id(str(body.get("@odata.type", "")))
+    surfaces: list[GoalSurface] = []
+    for action_key, action_body in sorted(actions.items()):
+        if not isinstance(action_body, Mapping):
+            continue
+        action_name = str(action_key).lstrip("#")
+        if _is_sensitive_path(action_name):
+            continue
+        allowed_slots = [
+            (path.rsplit(".", 1)[-1], values)
+            for path, values, under_actions in _walk_allowable_values(
+                action_body,
+                f"Actions.{action_key}",
+                under_actions=True,
+            )
+            if under_actions
+        ]
+        if allowed_slots:
+            for argument_name, allowed_values in allowed_slots:
+                for value in allowed_values:
+                    surfaces.append(_surface(
+                        record,
+                        _transition_goal_ref(
+                            _family_for_action(action_name),
+                            resource_type,
+                            action_name,
+                            argument_name,
+                            value,
+                        ),
+                        f"Actions.{action_key}.{argument_name}",
+                        value,
+                        None,
+                        allowed_values,
+                        verifier_kind="transition",
+                    ))
+            continue
+        goal_id = ".".join((
+            _family_for_action(action_name),
+            resource_type,
+            action_name,
+            "invoke",
+        ))
+        surfaces.append(_surface(
+            record,
+            GoalRef(
+                goal_id=goal_id,
+                family=_family_for_action(action_name),
+                resource_type=resource_type,
+                mode="transition",
+                action_name=action_name,
+                arguments={},
+            ),
+            f"Actions.{action_key}",
+            None,
+            None,
+            (),
+            verifier_kind="transition",
+        ))
+    return surfaces
+
+
+def _generic_state_surfaces(record: SourceRecord) -> list[GoalSurface]:
+    """Extract state goals from arbitrary Redfish scalar leaves and enums."""
+    body = record.response
+    resource_type = _resource_type_id(str(body.get("@odata.type", "")))
+    surfaces: list[GoalSurface] = []
+    emitted: set[tuple[str, str, str]] = set()
+
+    for path, allowed_values, under_actions in _walk_allowable_values(body):
+        if under_actions:
+            continue
+        for value in allowed_values:
+            if value in (None, ""):
+                continue
+            ref = _state_goal_ref(_family_for_path(resource_type, path), resource_type, path, value)
+            key = (ref.goal_id, path, _id_part(value))
+            if key in emitted:
+                continue
+            emitted.add(key)
+            surfaces.append(_surface(
+                record,
+                ref,
+                path,
+                value,
+                _get_path(body, path),
+                allowed_values,
+            ))
+
+    for path, value in _walk_scalar_leaves(body):
+        if value in (None, ""):
+            continue
+        ref = _state_goal_ref(_family_for_path(resource_type, path), resource_type, path, value)
+        key = (ref.goal_id, path, _id_part(value))
+        if key in emitted:
+            continue
+        emitted.add(key)
+        surfaces.append(_surface(
+            record,
+            ref,
+            path,
+            value,
+            value,
+            (),
+        ))
+    return surfaces
+
+
+def _computer_system_surfaces(record: SourceRecord) -> list[GoalSurface]:
+    """Extract power, boot, and reset sub-goal surfaces from a ComputerSystem body."""
+    body = record.response
+    resource_type = _resource_type_id(str(body.get("@odata.type", "")))
+    surfaces: list[GoalSurface] = []
+
+    allowed_power = body.get(f"PowerState{_ALLOWABLE_SUFFIX}") or ["On", "Off"]
+    for value in allowed_power:
+        surfaces.append(_surface(
+            record,
+            _state_goal_ref("power", resource_type, "PowerState", value),
+            "PowerState",
+            value,
+            body.get("PowerState"),
+            allowed_power,
+        ))
+
+    boot = body.get("Boot")
+    if isinstance(boot, Mapping):
+        for prop in ("BootSourceOverrideTarget", "BootSourceOverrideEnabled"):
+            allowed = boot.get(f"{prop}{_ALLOWABLE_SUFFIX}") or ()
+            for value in allowed:
+                if value in (None, ""):
+                    continue
+                surfaces.append(_surface(
+                    record,
+                    _state_goal_ref("boot", resource_type, f"Boot.{prop}", value),
+                    f"Boot.{prop}",
+                    value,
+                    boot.get(prop),
+                    allowed,
+                ))
+
+    existing = {surface.goal_ref.goal_id for surface in surfaces}
+    for surface in _action_surfaces(record):
+        if surface.goal_ref.goal_id not in existing:
+            surfaces.append(surface)
+
+    return surfaces
+
+
+def _manager_network_protocol_surfaces(record: SourceRecord) -> list[GoalSurface]:
+    """Extract NTP-related atomic sub-goal surfaces from ManagerNetworkProtocol."""
+    body = record.response
+    resource_type = _resource_type_id(str(body.get("@odata.type", "")))
+    ntp = body.get("NTP")
+    if not isinstance(ntp, Mapping):
+        return []
+
+    surfaces = []
+    for value in (True, False):
+        surfaces.append(_surface(
+            record,
+            _state_goal_ref(
+                "network",
+                resource_type,
+                "NTP.ProtocolEnabled",
+                value,
+            ),
+            "NTP.ProtocolEnabled",
+            value,
+            ntp.get("ProtocolEnabled"),
+            (True, False),
+        ))
+    servers = ntp.get("NTPServers")
+    if isinstance(servers, list):
+        for server in servers:
+            surfaces.append(_surface(
+                record,
+                _state_goal_ref(
+                    "network",
+                    resource_type,
+                    "NTP.NTPServers",
+                    server,
+                ),
+                "NTP.NTPServers",
+                server,
+                tuple(servers),
+                tuple(servers),
+                verifier_kind="contains",
+            ))
+    return surfaces
+
+
+def _bios_surfaces(record: SourceRecord) -> list[GoalSurface]:
+    """Extract BIOS attribute facts as atomic sub-goal surfaces."""
+    body = record.response
+    resource_type = _resource_type_id(str(body.get("@odata.type", "")))
+    attrs = body.get("Attributes")
+    if not isinstance(attrs, Mapping):
+        return []
+    return [
+        _surface(
+            record,
+            _state_goal_ref("bios", resource_type, f"Attributes.{name}", value),
+            f"Attributes.{name}",
+            value,
+            value,
+            (),
+        )
+        for name, value in sorted(attrs.items())
+    ]
+
+
+def build_goal_surfaces(records: Iterable[SourceRecord]) -> tuple[GoalSurface, ...]:
+    """Build deterministic atomic goal surfaces from captured Redfish records.
+
+    :param records: already-captured Redfish JSON records.
+    :return: atomic, vendor-specific goal surfaces.
+    """
+    surfaces: list[GoalSurface] = []
+    for record in records:
+        if not isinstance(record.response, Mapping):
+            continue
+        odata = str(record.response.get("@odata.type", record.schema_version))
+        surfaces.extend(_generic_state_surfaces(record))
+        surfaces.extend(_action_surfaces(record))
+        if "ComputerSystem" in odata:
+            surfaces.extend(_computer_system_surfaces(record))
+        elif "ManagerNetworkProtocol" in odata:
+            surfaces.extend(_manager_network_protocol_surfaces(record))
+        elif "Bios" in odata:
+            surfaces.extend(_bios_surfaces(record))
+
+    deduped: list[GoalSurface] = []
+    seen: set[tuple[str, str, str, str]] = set()
+    for surface in surfaces:
+        key = (
+            surface.goal_ref.goal_id,
+            surface.resource_uri,
+            surface.fact_path,
+            _id_part(surface.target_value),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(surface)
+    return tuple(deduped)
+
+
+def make_goal_text_example(
+    text: str,
+    goal_refs: Sequence[GoalRef],
+    dependencies: Sequence[GoalDependency] = (),
+    text_source: str = "template",
+    split: str = "train",
+    metadata: Mapping[str, Any] | None = None,
+) -> GoalTextExample:
+    """Create a text example for atomic or compound sub-goal extraction.
+
+    The order of ``goal_refs`` is preserved only for stable serialization.
+    Semantics are set-like unless ``dependencies`` explicitly add a text-level
+    partial order.
+    """
+    return GoalTextExample(
+        text=text,
+        goal_refs=tuple(goal_refs),
+        dependencies=tuple(dependencies),
+        text_source=text_source,
+        split=split,
+        metadata=dict(metadata or {}),
+    )
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/igc/ds/goal_paraphrases.py
+++ b/igc/ds/goal_paraphrases.py
@@ -115,6 +115,88 @@ def _safe_prompt_payload(value: Any) -> Any:
     return _safe_prompt_value(value)
 
 
+def _words(value: str) -> str:
+    """Render ids / dotted paths as operator-readable words."""
+    text = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", value)
+    text = re.sub(r"[^A-Za-z0-9]+", " ", text)
+    return " ".join(text.lower().split()) or "resource"
+
+
+def _safe_text_value(value: Any) -> str:
+    """Render a target value for deterministic template text."""
+    safe = _safe_prompt_value(value)
+    if safe == "<redacted-string>":
+        return "the requested value"
+    if isinstance(safe, bool):
+        return "enabled" if safe else "disabled"
+    return str(safe)
+
+
+def _argument_text(arguments: Mapping[str, Any]) -> str:
+    """Render action arguments without dropping multi-argument actions."""
+    parts = [
+        f"{_words(str(name))} {_safe_text_value(value)}"
+        for name, value in arguments.items()
+    ]
+    return " and ".join(parts)
+
+
+def _atomic_template(ref: GoalRef, variant: int = 0) -> str:
+    """Render one atomic goal ref as a compact operator request."""
+    resource = _words(ref.resource_type)
+    value = _safe_text_value(ref.target_value)
+    if ref.mode == "transition":
+        action = _words(ref.action_name or "action")
+        if ref.arguments:
+            args = _argument_text(ref.arguments)
+            if variant % 2:
+                return f"invoke {action} on {resource} with {args}"
+            return f"run {action} on {resource} setting {args}"
+        return f"invoke {action} on {resource}"
+
+    prop = _words(ref.property_path or ref.goal_id)
+    if variant % 2:
+        return f"make {resource} {prop} {value}"
+    return f"set {resource} {prop} to {value}"
+
+
+def generate_template_goal_text_drafts(
+    goal_refs: Sequence[GoalRef],
+    dependencies: Sequence[GoalDependency] = (),
+    count: int = 2,
+    text_source: str = "template",
+    split: str = "train",
+) -> tuple[GoalTextExample, ...]:
+    """Generate deterministic text examples for goal dataset inspection.
+
+    This is the no-endpoint bootstrap path. It creates real ``x`` rows whose
+    labels are still the deterministic ``true_y`` goal refs.
+    """
+    if count <= 0:
+        return ()
+    rows: list[GoalTextExample] = []
+    for variant in range(count):
+        atoms = [_atomic_template(ref, variant=variant) for ref in goal_refs]
+        if len(atoms) == 1:
+            text = atoms[0]
+        elif dependencies:
+            text = " then ".join(atoms)
+        else:
+            text = " and ".join(atoms)
+        rows.append(make_goal_text_example(
+            text=text,
+            goal_refs=tuple(goal_refs),
+            dependencies=tuple(dependencies),
+            text_source=text_source,
+            split=split,
+            metadata={
+                "validation": "template_generated",
+                "requested_count": count,
+            },
+        ))
+    return tuple(rows)
+
+
 def _safe_prompt_goal_ref(ref: GoalRef) -> dict[str, Any]:
     """Return a prompt-safe view of a GoalRef without raw captured strings."""
     data = ref.to_dict()

--- a/igc/ds/goal_paraphrases.py
+++ b/igc/ds/goal_paraphrases.py
@@ -1,0 +1,294 @@
+"""Paraphrase generation helpers for GoalExtractor datasets.
+
+The generator proposes operator text ``X`` only. Deterministic code owns
+``true_y`` by attaching JSON-derived :class:`igc.ds.goal_dataset.GoalRef` labels
+before any model call. A trained or injected extractor may later validate
+candidate text, but the bootstrap path intentionally does not depend on a
+handwritten parser.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import json
+import re
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Protocol, Sequence
+
+from igc.ds.goal_dataset import GoalDependency, GoalRef, GoalTextExample
+from igc.ds.goal_dataset_builder import make_goal_text_example
+
+
+class ParaphraseProvider(Protocol):
+    """Provider interface for candidate text generation."""
+
+    def generate(self, prompt: str) -> Sequence[str]: ...
+
+
+@dataclass(frozen=True)
+class StaticParaphraseProvider:
+    """Offline provider used by tests and dry runs."""
+
+    texts: Sequence[str]
+
+    def generate(self, prompt: str) -> Sequence[str]:
+        """Return static texts, ignoring the prompt."""
+        del prompt
+        return tuple(self.texts)
+
+
+class OpenAICompatibleParaphraseProvider:
+    """Minimal stdlib client for OpenAI-compatible chat completion endpoints.
+
+    Endpoint URL, model, and API key are constructor inputs so no private URL or
+    token ever needs to be hardcoded in the repository.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        model: str,
+        api_key: str = "",
+        timeout: float = 60.0,
+        temperature: float = 0.7,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.api_key = api_key
+        self.timeout = timeout
+        self.temperature = temperature
+
+    def generate(self, prompt: str) -> Sequence[str]:
+        """Call the configured chat endpoint and split lines into candidates."""
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": self.temperature,
+        }
+        body = json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            f"{self.base_url}/chat/completions",
+            data=body,
+            headers=self._headers(),
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=self.timeout) as response:
+            data = json.loads(response.read().decode("utf-8"))
+        content = data["choices"][0]["message"]["content"]
+        return tuple(line.strip("- \t") for line in content.splitlines() if line.strip())
+
+    def _headers(self) -> dict[str, str]:
+        """Build request headers without exposing secrets in logs."""
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+
+def _safe_prompt_value(value: Any) -> Any:
+    """Return a prompt-safe representation of a label value."""
+    if not isinstance(value, str):
+        return value
+    if re.fullmatch(r"[A-Za-z0-9_ -]{1,64}", value):
+        return value
+    return "<redacted-string>"
+
+
+def _unsafe_goal_suffix(value: str) -> str:
+    """Return the old unsafe suffix shape for defensive goal-id redaction."""
+    return re.sub(r"[^A-Za-z0-9_.-]+", "_", value).strip("_") or "empty"
+
+
+def _safe_prompt_mapping(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Recursively sanitize a mapping before it enters an LLM prompt."""
+    return {key: _safe_prompt_payload(item) for key, item in value.items()}
+
+
+def _safe_prompt_payload(value: Any) -> Any:
+    """Sanitize nested prompt payload values."""
+    if isinstance(value, dict):
+        return _safe_prompt_mapping(value)
+    if isinstance(value, (list, tuple)):
+        return [_safe_prompt_payload(item) for item in value]
+    return _safe_prompt_value(value)
+
+
+def _safe_prompt_goal_ref(ref: GoalRef) -> dict[str, Any]:
+    """Return a prompt-safe view of a GoalRef without raw captured strings."""
+    data = ref.to_dict()
+    sanitized_target = _safe_prompt_value(ref.target_value)
+    data["target_value"] = sanitized_target
+    data["arguments"] = _safe_prompt_payload(dict(ref.arguments))
+    data["constraints"] = _safe_prompt_payload(dict(ref.constraints))
+    if sanitized_target != ref.target_value:
+        unsafe_suffix = _unsafe_goal_suffix(str(ref.target_value))
+        if str(ref.goal_id).endswith(f".{unsafe_suffix}"):
+            data["goal_id"] = ".".join((
+                ref.family,
+                ref.resource_type,
+                ref.property_path,
+                ref.operator,
+                "<redacted>",
+            ))
+    return data
+
+
+def build_paraphrase_prompt(
+    goal_refs: Sequence[GoalRef],
+    dependencies: Sequence[GoalDependency] = (),
+    count: int = 8,
+) -> str:
+    """Build a public-safe prompt for candidate operator text.
+
+    :param goal_refs: true atomic sub-goals.
+    :param dependencies: true text-level partial-order hints.
+    :param count: requested number of paraphrases.
+    :return: prompt string.
+    """
+    refs_json = json.dumps(
+        [_safe_prompt_goal_ref(ref) for ref in goal_refs],
+        sort_keys=True,
+        indent=2,
+    )
+    deps_json = json.dumps([dep.to_dict() for dep in dependencies], sort_keys=True, indent=2)
+    ordering_rule = (
+        "Use the ordering implied by the dependency hints."
+        if dependencies
+        else "Do not add ordering words such as then, before, after, first, or second."
+    )
+    return (
+        "Generate natural-language operator requests for a server-management agent.\n"
+        "Each request must mean exactly the atomic sub-goals below.\n"
+        f"{ordering_rule}\n"
+        "Do not add, remove, weaken, strengthen, or reorder goals beyond the dependency hints.\n"
+        "Return one request per line, no numbering, no markdown.\n\n"
+        f"Requested count: {count}\n"
+        f"Atomic sub-goals:\n{refs_json}\n\n"
+        f"Dependency hints:\n{deps_json}\n"
+    )
+
+
+def _goal_id_set(refs: Iterable[GoalRef]) -> frozenset[str]:
+    """Return stable goal-id set for semantic equality checks."""
+    return frozenset(ref.goal_id for ref in refs)
+
+
+def _relation_set(relations: Iterable[GoalDependency]) -> frozenset[tuple[str, str, str]]:
+    """Return stable dependency-relation set."""
+    return frozenset(
+        (rel.before_goal_id, rel.after_goal_id, rel.relation) for rel in relations
+    )
+
+
+def validate_paraphrase_texts(
+    texts: Sequence[str],
+    extractor: Any,
+    expected_goal_refs: Sequence[GoalRef],
+    expected_relations: Sequence[GoalDependency] = (),
+    text_source: str = "llm_paraphrase",
+    split: str = "train",
+) -> tuple[GoalTextExample, ...]:
+    """Accept only generated text that extracts to exactly the target schema.
+
+    :param texts: candidate operator requests.
+    :param extractor: deterministic or learned extractor used as validator.
+    :param expected_goal_refs: true atomic sub-goals.
+    :param expected_relations: true text-level relations.
+    :param text_source: source label for accepted rows.
+    :param split: dataset split for accepted rows.
+    :return: accepted examples.
+    """
+    expected_ids = _goal_id_set(expected_goal_refs)
+    expected_edges = _relation_set(expected_relations)
+    accepted: list[GoalTextExample] = []
+    seen: set[str] = set()
+    for text in texts:
+        normalized = " ".join(text.split())
+        if not normalized or normalized.lower() in seen:
+            continue
+        seen.add(normalized.lower())
+        extraction = extractor.extract(normalized)
+        if _goal_id_set(extraction.atomic_goal_refs) != expected_ids:
+            continue
+        if _relation_set(extraction.relations) != expected_edges:
+            continue
+        accepted.append(make_goal_text_example(
+            text=normalized,
+            goal_refs=tuple(expected_goal_refs),
+            dependencies=tuple(expected_relations),
+            text_source=text_source,
+            split=split,
+            metadata={"validated_by": extractor.__class__.__name__},
+        ))
+    return tuple(accepted)
+
+
+def generate_goal_text_drafts(
+    provider: ParaphraseProvider,
+    goal_refs: Sequence[GoalRef],
+    dependencies: Sequence[GoalDependency] = (),
+    count: int = 8,
+    text_source: str = "llm_paraphrase",
+    split: str = "train",
+) -> tuple[GoalTextExample, ...]:
+    """Generate text rows from an LLM provider without extractor validation.
+
+    This is the bootstrapping path before the trained GoalExtractor exists:
+    deterministic JSON-derived ``GoalRef`` rows remain the labels, while the LLM
+    contributes only candidate operator wording. Downstream review/training can
+    filter or score these rows, but no model output changes ``true_y``.
+
+    :param provider: paraphrase provider.
+    :param goal_refs: deterministic labels for every generated text.
+    :param dependencies: optional text-level relation labels.
+    :param count: requested number of drafts.
+    :param text_source: source label.
+    :param split: dataset split.
+    :return: generated draft examples.
+    """
+    prompt = build_paraphrase_prompt(goal_refs, dependencies=dependencies, count=count)
+    rows: list[GoalTextExample] = []
+    seen: set[str] = set()
+    for text in provider.generate(prompt):
+        normalized = " ".join(text.split())
+        if not normalized or normalized.lower() in seen:
+            continue
+        seen.add(normalized.lower())
+        rows.append(make_goal_text_example(
+            text=normalized,
+            goal_refs=tuple(goal_refs),
+            dependencies=tuple(dependencies),
+            text_source=text_source,
+            split=split,
+            metadata={
+                "validation": "llm_generated_unvalidated",
+                "requested_count": count,
+            },
+        ))
+    return tuple(rows)
+
+
+def generate_goal_text_examples(
+    provider: ParaphraseProvider,
+    extractor: Any,
+    goal_refs: Sequence[GoalRef],
+    dependencies: Sequence[GoalDependency] = (),
+    count: int = 8,
+    text_source: str = "llm_paraphrase",
+    split: str = "train",
+) -> tuple[GoalTextExample, ...]:
+    """Generate and validate text rows for one target goal set."""
+    prompt = build_paraphrase_prompt(goal_refs, dependencies=dependencies, count=count)
+    return validate_paraphrase_texts(
+        provider.generate(prompt),
+        extractor=extractor,
+        expected_goal_refs=goal_refs,
+        expected_relations=dependencies,
+        text_source=text_source,
+        split=split,
+    )
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/igc/modules/base/metric_factory.py
+++ b/igc/modules/base/metric_factory.py
@@ -144,10 +144,9 @@ class ClearMLLogger(BaseLogger):
 def _wandb_run_meta(kw: dict) -> dict:
     """Build W&B run metadata (name/group/job_type/tags/config) from the spec kwargs.
 
-    Maps the ``--train``/``--llm``/``--rl`` selection to the curriculum STAGE so a W&B
-    run reads as e.g. ``m1-state-encoder`` grouped, tagged, and configured — not a random
-    name. ``m1`` = state encoder (``--train llm --llm latent``), then m2/m3/m4/m6 as they
-    come online.
+    Maps the ``--train``/``--llm``/``--rl`` selection to a readable curriculum label so
+    a W&B run reads as e.g. ``m1-state-encoder`` grouped, tagged, and configured — not a
+    random name. The old goal/parameter selections are labelled as legacy.
 
     :param kw: the flattened spec (``vars(specs)``).
     :return: a dict of ``name``, ``group``, ``job_type``, ``tags``, ``config``.
@@ -156,8 +155,8 @@ def _wandb_run_meta(kw: dict) -> dict:
     stage_map = {
         ("llm", "latent"): "m1-state-encoder",
         ("llm", "all"): "m1m2-encoder",
-        ("llm", "goal"): "m3-goal-extractor",
-        ("llm", "parameter"): "m3p-param-extractor",
+        ("llm", "goal"): "goal-extractor-legacy",
+        ("llm", "parameter"): "param-extractor-legacy",
     }
     if train in ("agent",) or kw.get("rl"):
         stage = "m6-rl-agent"

--- a/igc/modules/goal_encoder.py
+++ b/igc/modules/goal_encoder.py
@@ -1,0 +1,80 @@
+"""GoalEncoder contracts and tiny deterministic baseline.
+
+Production training will replace the hashing baseline with learned
+``TextGoalEncoder`` and ``GoalSurfaceEncoder`` modules. The interface already
+uses the corrected semantics: encode one atomic sub-goal into ``z_sub_goal``;
+compound instructions remain a set of those vectors plus dependency metadata.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Iterable
+
+from igc.ds.goal_dataset import GoalRef, GoalSurface, GoalTextExample
+
+
+@dataclass(frozen=True)
+class GoalLatent:
+    """A deterministic stand-in for a learned ``z_sub_goal`` vector."""
+
+    goal_id: str
+    values: tuple[float, ...]
+
+
+class GoalEncoder:
+    """Tiny deterministic encoder with the learned encoder's public shape."""
+
+    def __init__(self, dim: int = 16):
+        if dim <= 0:
+            raise ValueError("dim must be positive")
+        self.dim = dim
+
+    def encode_ref(self, goal_ref: GoalRef) -> GoalLatent:
+        """Encode one atomic goal ref into a stable vector.
+
+        :param goal_ref: atomic sub-goal label.
+        :return: deterministic latent for tests and offline plumbing.
+        """
+        return GoalLatent(goal_ref.goal_id, self._hash(goal_ref.goal_id))
+
+    def encode_surface(self, surface: GoalSurface) -> GoalLatent:
+        """Encode a concrete surface by its semantic atomic goal ref."""
+        return self.encode_ref(surface.goal_ref)
+
+    def encode_text_example(self, example: GoalTextExample) -> tuple[GoalLatent, ...]:
+        """Encode every atomic sub-goal in a text example.
+
+        A compound instruction returns multiple ``z_sub_goal`` items rather
+        than one opaque plan vector.
+        """
+        return tuple(self.encode_ref(ref) for ref in example.goal_refs)
+
+    def _hash(self, key: str) -> tuple[float, ...]:
+        """Hash a key into a small deterministic float tuple."""
+        values = []
+        counter = 0
+        while len(values) < self.dim:
+            digest = hashlib.sha256(f"{key}:{counter}".encode("utf-8")).digest()
+            for byte in digest:
+                values.append((byte / 127.5) - 1.0)
+                if len(values) == self.dim:
+                    break
+            counter += 1
+        return tuple(values)
+
+
+def encode_goal_set(encoder: GoalEncoder, refs: Iterable[GoalRef]) -> tuple[GoalLatent, ...]:
+    """Encode a set/list of atomic sub-goal refs.
+
+    :param encoder: goal encoder instance.
+    :param refs: atomic sub-goals.
+    :return: one latent per sub-goal.
+    """
+    return tuple(encoder.encode_ref(ref) for ref in refs)
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/igc/modules/goal_extractor.py
+++ b/igc/modules/goal_extractor.py
@@ -1,0 +1,121 @@
+"""GoalExtractor contract for text-to-atomic-sub-goal extraction.
+
+The extractor is a learned or injected model that maps operator text into the
+same target envelope written by the dataset builder: atomic :class:`GoalRef`
+rows plus optional text-stated dependency hints. This module intentionally has
+no Redfish keyword rules or hardcoded goal IDs; deterministic labels come from
+``igc.ds.goal_dataset_builder`` and trained models consume those rows later.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Sequence
+
+from igc.ds.goal_dataset import GoalDependency, GoalRef, GoalTextExample
+
+
+@dataclass(frozen=True)
+class GoalExtraction:
+    """Structured extractor output.
+
+    :param text: original operator text.
+    :param atomic_goal_refs: unordered atomic sub-goals found in text.
+    :param relations: text-stated partial-order hints.
+    :param evidence: optional text spans or decoder evidence keyed by goal id.
+    """
+
+    text: str
+    atomic_goal_refs: Sequence[GoalRef]
+    relations: Sequence[GoalDependency]
+    evidence: Mapping[str, Any]
+
+    @property
+    def dependency_hints(self) -> Sequence[GoalDependency]:
+        """Backward-compatible alias for code that still says dependencies."""
+        return self.relations
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to the JSON target shape used by extractor training."""
+        return {
+            "text": self.text,
+            "atomic_goal_refs": [ref.to_dict() for ref in self.atomic_goal_refs],
+            "relations": [relation.to_dict() for relation in self.relations],
+            "evidence": dict(self.evidence),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "GoalExtraction":
+        """Rebuild from :meth:`to_dict` output."""
+        return cls(
+            text=str(data.get("text", "")),
+            atomic_goal_refs=tuple(
+                GoalRef.from_dict(item) for item in data.get("atomic_goal_refs", ())
+            ),
+            relations=tuple(
+                GoalDependency.from_dict(item) for item in data.get("relations", ())
+            ),
+            evidence=dict(data.get("evidence") or {}),
+        )
+
+
+def extraction_from_text_example(example: GoalTextExample) -> GoalExtraction:
+    """Convert one supervised dataset row into the extractor target envelope.
+
+    :param example: text row with deterministic JSON-derived labels.
+    :return: target envelope for model training or evaluation.
+    """
+    return GoalExtraction(
+        text=example.text,
+        atomic_goal_refs=tuple(example.goal_refs),
+        relations=tuple(example.dependencies),
+        evidence=dict(example.metadata.get("evidence") or {}),
+    )
+
+
+def parse_goal_extraction(value: GoalExtraction | Mapping[str, Any] | str) -> GoalExtraction:
+    """Parse model or adapter output into a :class:`GoalExtraction`.
+
+    :param value: already parsed extraction, mapping, or JSON string.
+    :return: structured extraction.
+    """
+    if isinstance(value, GoalExtraction):
+        return value
+    if isinstance(value, str):
+        value = json.loads(value)
+    return GoalExtraction.from_dict(value)
+
+
+class GoalExtractor:
+    """Pluggable extractor wrapper around a trained decoder or test adapter."""
+
+    def __init__(
+        self,
+        decoder: Callable[[str], GoalExtraction | Mapping[str, Any] | str] | None = None,
+    ):
+        self.decoder = decoder
+
+    def extract(self, text: str) -> GoalExtraction:
+        """Extract atomic sub-goals from text through the configured decoder.
+
+        :param text: operator instruction.
+        :return: structured extraction result.
+        :raises RuntimeError: when no trained/injected decoder is configured.
+        """
+        if self.decoder is None:
+            raise RuntimeError("GoalExtractor requires a trained or injected decoder")
+        extraction = parse_goal_extraction(self.decoder(text))
+        if not extraction.text:
+            return GoalExtraction(
+                text=text,
+                atomic_goal_refs=tuple(extraction.atomic_goal_refs),
+                relations=tuple(extraction.relations),
+                evidence=dict(extraction.evidence),
+            )
+        return extraction
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/igc/modules/goal_verifier.py
+++ b/igc/modules/goal_verifier.py
@@ -1,0 +1,117 @@
+"""Concrete verification for latent sub-goal training and HER.
+
+The policy can condition on ``z_sub_goal``; success is still measured against
+the hidden concrete :class:`igc.ds.goal_dataset.GoalSurface`. This module is the
+first deterministic verifier for state equality and membership-style goals.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from igc.ds.goal_dataset import GoalSurface
+
+
+@dataclass(frozen=True)
+class GoalVerificationResult:
+    """Result of checking one concrete sub-goal against an observation."""
+
+    satisfied: bool
+    reward: float
+    reason: str
+    observed_value: Any = None
+    target_value: Any = None
+
+
+def _get_path(body: Mapping[str, Any], path: str) -> Any:
+    """Read a dotted path from a nested mapping.
+
+    :param body: observation body.
+    :param path: dotted property path.
+    :return: observed value or ``None`` when absent.
+    """
+    current: Any = body
+    for part in path.split("."):
+        if not isinstance(current, Mapping) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+class GoalVerifier:
+    """Verify hidden concrete sub-goals against observations.
+
+    This deliberately does not inspect embeddings. A successful POST/PATCH can
+    help debug an action, but state goals require measured state in the next
+    observation.
+    """
+
+    def verify(
+        self,
+        surface: GoalSurface,
+        observation: Mapping[str, Any],
+        action_result: Mapping[str, Any] | None = None,
+    ) -> GoalVerificationResult:
+        """Verify one goal surface.
+
+        :param surface: hidden concrete verifier payload.
+        :param observation: next observation body.
+        :param action_result: optional action result metadata, currently not
+            trusted as state-goal success.
+        :return: verification result.
+        """
+        del action_result  # accepted requests are not proof of final state.
+        kind = str(surface.verifier.get("kind", "state_eq"))
+        if kind == "contains":
+            return self._verify_contains(surface, observation)
+        if kind == "transition":
+            return GoalVerificationResult(
+                satisfied=False,
+                reward=0.0,
+                reason="transition_requires_followup_observation",
+                observed_value=None,
+                target_value=surface.target_value,
+            )
+        return self._verify_state_eq(surface, observation)
+
+    def _verify_state_eq(
+        self,
+        surface: GoalSurface,
+        observation: Mapping[str, Any],
+    ) -> GoalVerificationResult:
+        """Verify a state-equality sub-goal."""
+        property_path = str(surface.verifier.get("property_path") or surface.fact_path)
+        target = surface.verifier.get("target_value", surface.target_value)
+        observed = _get_path(observation, property_path)
+        satisfied = observed == target
+        return GoalVerificationResult(
+            satisfied=satisfied,
+            reward=1.0 if satisfied else 0.0,
+            reason="state_eq",
+            observed_value=observed,
+            target_value=target,
+        )
+
+    def _verify_contains(
+        self,
+        surface: GoalSurface,
+        observation: Mapping[str, Any],
+    ) -> GoalVerificationResult:
+        """Verify a membership sub-goal for list-valued facts."""
+        property_path = str(surface.verifier.get("property_path") or surface.fact_path)
+        target = surface.verifier.get("target_value", surface.target_value)
+        observed = _get_path(observation, property_path)
+        satisfied = isinstance(observed, list) and target in observed
+        return GoalVerificationResult(
+            satisfied=satisfied,
+            reward=1.0 if satisfied else 0.0,
+            reason="contains",
+            observed_value=observed,
+            target_value=target,
+        )
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/igc/modules/legacy/__init__.py
+++ b/igc/modules/legacy/__init__.py
@@ -1,0 +1,8 @@
+"""Legacy training modules kept for historical compatibility.
+
+New work should prefer descriptive modules such as ``goal_extractor`` and
+``goal_encoder`` instead of phase-labeled or permutation-based experiments.
+
+Author:
+Mus mbayramo@stanford.edu
+"""

--- a/igc/modules/legacy/llm_train_goal_extract.py
+++ b/igc/modules/legacy/llm_train_goal_extract.py
@@ -1,18 +1,13 @@
 """
-This class is used to train a goal extractor from input query.
+Legacy permutation trainer for the old goal-extractor experiment.
 
-Given input text provided by the user, or external system.
-The goal is to extract a goal for the agent and parameters
-that agent need used.
+This module is kept only so historical ``--llm goal`` / ``--llm parameter``
+runs remain inspectable. New GoalExtractor / GoalEncoder work must use
+``igc.ds.goal_dataset*`` and ``igc.modules.goal_extractor`` instead.
 
-For example given input text: "Update raid with raid0"
-The goal here update raid configuration and the
-parameter is raid0.
-
-In downstream task the goal encoded as one hot vector.
-This what used to train RL agent.
-
-Parameters just passed to agent. i.e. we don't train on parameters.
+The legacy implementation creates synthetic word permutations from action names
+and emits one-hot-like labels. It is not the Redfish-corpus-backed latent-goal
+dataset design and should not be used for new training.
 
 Author:Mus mbayramo@stanford.edu
 """
@@ -821,4 +816,3 @@ class GoalExtractorTrainer(LlmModule):
             print(f"Input query with goal and parameters {goal_with_parameters_query}")
             goal, parameters = self.query_goal_and_parameters(goal_with_parameters_query)
             print(f"Agent goal: {goal} parameters {parameters}")
-

--- a/igc/modules/llm/igc_llm_module.py
+++ b/igc/modules/llm/igc_llm_module.py
@@ -19,7 +19,7 @@ from ...ds.redfish_masked_dataset import MaskedJSONDataset
 from ...modules.base.igc_llm_base_module import LlmModule
 from ...modules.base.igc_metric_logger import MetricLogger
 from ...modules.igc_train_auto_state_encoder import AutoencoderTrainer
-from ...modules.llm_train_goal_extract import GoalExtractorTrainer
+from ...modules.legacy.llm_train_goal_extract import GoalExtractorTrainer
 from ...modules.llm_train_state_encoder import LlmEmbeddingsTrainer
 from ...modules.shared.llm_shared import (
     from_pretrained_default,

--- a/igc/modules/teach/__init__.py
+++ b/igc/modules/teach/__init__.py
@@ -1,6 +1,6 @@
 """Tool-teaching: LLM-taught few-shot tool acquisition (``docs/ARCHITECTURE.md`` §12).
 
-The teacher (the DeepSeek-V4-Flash endpoint M3 reuses) induces a
+The teacher induces a
 :class:`~igc.core.tool_card.ToolCard` for an unknown tool from a few real
 ``(call -> result/error)`` interactions; this package grounds the card against
 real evidence (:mod:`igc.modules.teach.grounding`) and gates safe cold-start

--- a/igc/modules/teach/tool_teacher.py
+++ b/igc/modules/teach/tool_teacher.py
@@ -10,7 +10,7 @@ The teacher (``docs/ARCHITECTURE.md`` §12.3) turns the agent's own ``k`` real
   an error taxonomy, the spec -> the signature). It is the offline test double *and*
   the honest rule-based baseline the curve eval (§12.7) measures the LLM teacher
   against; it never reaches the network.
-* A live DeepSeek-V4-Flash teacher (the endpoint M3 reuses, §11.4) is the gated
+* A live LLM teacher (the gated bootstrap path from §11.4) is the
   follow-on — it shares this interface so the offline plumbing is identical.
 
 :func:`teach_tool` is the induce -> ground -> confirm -> store pipeline used by both.

--- a/scripts/build_goal_dataset.py
+++ b/scripts/build_goal_dataset.py
@@ -30,6 +30,16 @@ from igc.ds.goal_paraphrases import (
 )
 from igc.ds.sources import RedfishFixtureSource, TrustLevel
 
+_VENDOR_ROOT_MARKERS = (
+    ("idrac_fixtures", "dell"),
+    ("dell", "dell"),
+    ("hpe_fixtures", "hpe"),
+    ("ilo", "hpe"),
+    ("supermicro_gb300_corpus", "supermicro"),
+    ("supermicro_fixtures", "supermicro"),
+    ("supermicro", "supermicro"),
+)
+
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse CLI arguments."""
@@ -109,15 +119,25 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _infer_vendor_from_root(root: str) -> str:
+    """Infer vendor provenance from known redfish_ctl corpus root names."""
+    normalized = [part.lower() for part in Path(root).parts]
+    for marker, vendor in _VENDOR_ROOT_MARKERS:
+        if marker in normalized:
+            return vendor
+    return ""
+
+
 def _load_records(args: argparse.Namespace):
     """Load all capture roots into SourceRecord rows."""
     records = []
     for root in args.capture_root:
+        vendor = args.vendor or _infer_vendor_from_root(root) or None
         source = RedfishFixtureSource(
             root,
             source=args.source,
             trust_level=TrustLevel.REAL,
-            vendor=args.vendor or None,
+            vendor=vendor,
             glob_pattern=args.glob_pattern,
         )
         records.extend(source.iter_records())

--- a/scripts/build_goal_dataset.py
+++ b/scripts/build_goal_dataset.py
@@ -16,6 +16,9 @@ import json
 import os
 import sys
 from pathlib import Path
+from typing import Any
+
+import numpy as np
 
 # Running as ``python scripts/build_goal_dataset.py`` puts scripts/ on sys.path;
 # add the repo root so ``import igc`` works without installation.
@@ -26,6 +29,7 @@ from igc.ds.goal_dataset_builder import build_goal_surfaces
 from igc.ds.goal_paraphrases import (
     OpenAICompatibleParaphraseProvider,
     StaticParaphraseProvider,
+    generate_template_goal_text_drafts,
     generate_goal_text_drafts,
 )
 from igc.ds.sources import RedfishFixtureSource, TrustLevel
@@ -34,11 +38,17 @@ _VENDOR_ROOT_MARKERS = (
     ("idrac_fixtures", "dell"),
     ("dell", "dell"),
     ("hpe_fixtures", "hpe"),
+    ("hpe", "hpe"),
     ("ilo", "hpe"),
     ("supermicro_gb300_corpus", "supermicro"),
     ("supermicro_fixtures", "supermicro"),
     ("supermicro", "supermicro"),
 )
+
+
+def _path_part_matches_marker(part: str, marker: str) -> bool:
+    """Return true when a path part carries a vendor marker intentionally."""
+    return part == marker or part.startswith(f"{marker}_") or part.startswith(f"{marker}-")
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -69,7 +79,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--paraphrase-mode",
-        choices=("none", "static", "openai"),
+        choices=("none", "template", "static", "openai"),
         default="none",
         help="How to produce candidate operator text.",
     )
@@ -123,9 +133,43 @@ def _infer_vendor_from_root(root: str) -> str:
     """Infer vendor provenance from known redfish_ctl corpus root names."""
     normalized = [part.lower() for part in Path(root).parts]
     for marker, vendor in _VENDOR_ROOT_MARKERS:
-        if marker in normalized:
+        if any(_path_part_matches_marker(part, marker) for part in normalized):
             return vendor
     return ""
+
+
+def _load_allowed_methods_map(root: str) -> dict[str, list[str]]:
+    """Load the same-run ``rest_api_map.npy`` method map when present."""
+    path = Path(root) / "rest_api_map.npy"
+    if not path.is_file():
+        return {}
+    if not (Path(root) / "corpus_manifest.json").is_file():
+        return {}
+    # ``rest_api_map.npy`` is a legacy trusted-corpus contract produced by
+    # redfish_ctl discovery. Keep this load behind full-corpus validation.
+    try:
+        data: Any = np.load(path, allow_pickle=True).item()
+    except (OSError, TypeError, ValueError) as err:
+        raise SystemExit(f"rest_api_map.npy is not a dict: {path}") from err
+    if not isinstance(data, dict):
+        raise SystemExit(f"rest_api_map.npy is not a dict: {path}")
+    raw = data.get("allowed_methods_mapping") or {}
+    if not isinstance(raw, dict):
+        raise SystemExit(f"allowed_methods_mapping is not a dict: {path}")
+    allowed: dict[str, list[str]] = {}
+    for url, methods in raw.items():
+        if isinstance(url, str) and isinstance(methods, (list, tuple)):
+            allowed[url] = [str(method).upper() for method in methods]
+    return allowed
+
+
+def _capture_root_label(root: str, index: int) -> str:
+    """Return a public-safe label for a capture root."""
+    for part in reversed(Path(root).parts):
+        lowered = part.lower()
+        if lowered.endswith("_full_corpus") or lowered.endswith("_corpus"):
+            return part
+    return f"capture_root_{index}"
 
 
 def _load_records(args: argparse.Namespace):
@@ -138,6 +182,7 @@ def _load_records(args: argparse.Namespace):
             source=args.source,
             trust_level=TrustLevel.REAL,
             vendor=vendor,
+            allowed_methods_map=_load_allowed_methods_map(root),
             glob_pattern=args.glob_pattern,
         )
         records.extend(source.iter_records())
@@ -178,7 +223,6 @@ def _write_text_examples(args: argparse.Namespace, surfaces) -> int:
             "--goal-id or --generate-all-goals is required when writing text examples"
         )
 
-    provider = _provider(args)
     targets = (
         [(tuple(by_id[goal_id] for goal_id in args.goal_id))]
         if args.goal_id
@@ -186,11 +230,18 @@ def _write_text_examples(args: argparse.Namespace, surfaces) -> int:
     )
     examples = []
     for refs in targets:
-        examples.extend(generate_goal_text_drafts(
-            provider,
-            goal_refs=refs,
-            count=args.count,
-        ))
+        if args.paraphrase_mode == "template":
+            examples.extend(generate_template_goal_text_drafts(
+                goal_refs=refs,
+                count=args.count,
+            ))
+        else:
+            provider = _provider(args)
+            examples.extend(generate_goal_text_drafts(
+                provider,
+                goal_refs=refs,
+                count=args.count,
+            ))
     from igc.ds.goal_dataset import GoalTextExample
 
     GoalTextExample.write_jsonl(Path(args.text_out), examples)
@@ -210,7 +261,14 @@ def _manifest(args: argparse.Namespace, records, surfaces, num_text: int) -> dic
         )
         by_family[surface.goal_ref.family] = by_family.get(surface.goal_ref.family, 0) + 1
     return {
-        "capture_roots": list(args.capture_root),
+        "capture_roots": [
+            {
+                "index": index,
+                "label": _capture_root_label(root, index),
+                "vendor": _infer_vendor_from_root(root) or "",
+            }
+            for index, root in enumerate(args.capture_root)
+        ],
         "glob_pattern": args.glob_pattern,
         "capture_records": len(records),
         "goal_surfaces": len(surfaces),
@@ -218,8 +276,8 @@ def _manifest(args: argparse.Namespace, records, surfaces, num_text: int) -> dic
         "text_examples": num_text,
         "sources": sources,
         "vendors": vendors,
-        "surfaces_out": args.surfaces_out,
-        "text_out": args.text_out,
+        "surfaces_out": Path(args.surfaces_out).name,
+        "text_out": Path(args.text_out).name if args.text_out else "",
         "by_goal_family": dict(sorted(by_family.items())),
         "by_resource_type": dict(sorted(by_resource_type.items())),
     }

--- a/scripts/build_goal_dataset.py
+++ b/scripts/build_goal_dataset.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Build GoalExtractor / GoalEncoder datasets from captured Redfish JSON.
+
+The script is offline by default. It always writes deterministic goal surfaces
+(``true_y``). It can optionally call a configurable paraphrase provider to draft
+operator text (``x``). The model provider only writes natural language; labels
+come from captured JSON and are never copied from model output.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+# Running as ``python scripts/build_goal_dataset.py`` puts scripts/ on sys.path;
+# add the repo root so ``import igc`` works without installation.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from igc.ds.goal_dataset import write_goal_surfaces
+from igc.ds.goal_dataset_builder import build_goal_surfaces
+from igc.ds.goal_paraphrases import (
+    OpenAICompatibleParaphraseProvider,
+    StaticParaphraseProvider,
+    generate_goal_text_drafts,
+)
+from igc.ds.sources import RedfishFixtureSource, TrustLevel
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--capture-root",
+        action="append",
+        required=True,
+        help="Directory of captured Redfish JSON files; may be repeated.",
+    )
+    parser.add_argument("--vendor", default="", help="Vendor label for emitted SourceRecords.")
+    parser.add_argument("--source", default="real", help="Source label for emitted SourceRecords.")
+    parser.add_argument(
+        "--surfaces-out",
+        required=True,
+        help="Output JSONL path for deterministic GoalSurface rows.",
+    )
+    parser.add_argument(
+        "--manifest-out",
+        default="",
+        help="Optional JSON path for dataset counts and input summary.",
+    )
+    parser.add_argument(
+        "--text-out",
+        default="",
+        help="Optional output JSONL path for LLM-drafted GoalTextExample rows.",
+    )
+    parser.add_argument(
+        "--paraphrase-mode",
+        choices=("none", "static", "openai"),
+        default="none",
+        help="How to produce candidate operator text.",
+    )
+    parser.add_argument(
+        "--goal-id",
+        action="append",
+        default=[],
+        help="Goal IDs to include in one generated text target.",
+    )
+    parser.add_argument(
+        "--generate-all-goals",
+        action="store_true",
+        help="Generate text rows for every unique atomic GoalRef discovered.",
+    )
+    parser.add_argument(
+        "--static-text",
+        action="append",
+        default=[],
+        help="Candidate text for --paraphrase-mode static; may be repeated.",
+    )
+    parser.add_argument(
+        "--base-url-env",
+        default="GOAL_PARAPHRASE_BASE_URL",
+        help="Env var holding OpenAI-compatible base URL for --paraphrase-mode openai.",
+    )
+    parser.add_argument(
+        "--model-env",
+        default="GOAL_PARAPHRASE_MODEL",
+        help="Env var holding model name for --paraphrase-mode openai.",
+    )
+    parser.add_argument(
+        "--api-key-env",
+        default="GOAL_PARAPHRASE_API_KEY",
+        help="Env var holding optional API key for --paraphrase-mode openai.",
+    )
+    parser.add_argument(
+        "--count",
+        type=int,
+        default=8,
+        help="Requested paraphrase count.",
+    )
+    parser.add_argument(
+        "--glob-pattern",
+        default="*.json",
+        help="Capture filename glob passed to RedfishFixtureSource; use **/*.json for trees.",
+    )
+    return parser.parse_args(argv)
+
+
+def _load_records(args: argparse.Namespace):
+    """Load all capture roots into SourceRecord rows."""
+    records = []
+    for root in args.capture_root:
+        source = RedfishFixtureSource(
+            root,
+            source=args.source,
+            trust_level=TrustLevel.REAL,
+            vendor=args.vendor or None,
+            glob_pattern=args.glob_pattern,
+        )
+        records.extend(source.iter_records())
+    return records
+
+
+def _provider(args: argparse.Namespace):
+    """Build the requested paraphrase provider."""
+    if args.paraphrase_mode == "static":
+        return StaticParaphraseProvider(tuple(args.static_text))
+    if args.paraphrase_mode == "openai":
+        base_url = os.environ.get(args.base_url_env, "")
+        model = os.environ.get(args.model_env, "")
+        if not base_url or not model:
+            raise SystemExit(
+                f"missing {args.base_url_env} or {args.model_env} for --paraphrase-mode openai"
+            )
+        return OpenAICompatibleParaphraseProvider(
+            base_url=base_url,
+            model=model,
+            api_key=os.environ.get(args.api_key_env, ""),
+        )
+    return None
+
+
+def _write_text_examples(args: argparse.Namespace, surfaces) -> int:
+    """Generate and write draft text examples when requested."""
+    if not args.text_out or args.paraphrase_mode == "none":
+        return 0
+    by_id = {surface.goal_ref.goal_id: surface.goal_ref for surface in surfaces}
+    missing = [goal_id for goal_id in args.goal_id if goal_id not in by_id]
+    if missing:
+        raise SystemExit(f"unknown goal id(s): {', '.join(missing)}")
+    if args.goal_id and args.generate_all_goals:
+        raise SystemExit("--goal-id and --generate-all-goals are mutually exclusive")
+    if not args.goal_id and not args.generate_all_goals:
+        raise SystemExit(
+            "--goal-id or --generate-all-goals is required when writing text examples"
+        )
+
+    provider = _provider(args)
+    targets = (
+        [(tuple(by_id[goal_id] for goal_id in args.goal_id))]
+        if args.goal_id
+        else [(by_id[goal_id],) for goal_id in sorted(by_id)]
+    )
+    examples = []
+    for refs in targets:
+        examples.extend(generate_goal_text_drafts(
+            provider,
+            goal_refs=refs,
+            count=args.count,
+        ))
+    from igc.ds.goal_dataset import GoalTextExample
+
+    GoalTextExample.write_jsonl(Path(args.text_out), examples)
+    return len(examples)
+
+
+def _manifest(args: argparse.Namespace, records, surfaces, num_text: int) -> dict:
+    """Build a public-safe dataset count manifest."""
+    goal_ids = {surface.goal_ref.goal_id for surface in surfaces}
+    vendors = sorted({record.vendor for record in records if record.vendor})
+    sources = sorted({record.source for record in records if record.source})
+    by_resource_type: dict[str, int] = {}
+    by_family: dict[str, int] = {}
+    for surface in surfaces:
+        by_resource_type[surface.goal_ref.resource_type] = (
+            by_resource_type.get(surface.goal_ref.resource_type, 0) + 1
+        )
+        by_family[surface.goal_ref.family] = by_family.get(surface.goal_ref.family, 0) + 1
+    return {
+        "capture_roots": list(args.capture_root),
+        "glob_pattern": args.glob_pattern,
+        "capture_records": len(records),
+        "goal_surfaces": len(surfaces),
+        "unique_goal_ids": len(goal_ids),
+        "text_examples": num_text,
+        "sources": sources,
+        "vendors": vendors,
+        "surfaces_out": args.surfaces_out,
+        "text_out": args.text_out,
+        "by_goal_family": dict(sorted(by_family.items())),
+        "by_resource_type": dict(sorted(by_resource_type.items())),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint.
+
+    :return: process-style exit code.
+    """
+    args = parse_args(argv)
+    records = _load_records(args)
+    surfaces = build_goal_surfaces(records)
+    write_goal_surfaces(Path(args.surfaces_out), surfaces)
+    num_text = _write_text_examples(args, surfaces)
+    manifest = _manifest(args, records, surfaces, num_text)
+    if args.manifest_out:
+        Path(args.manifest_out).write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    print(
+        f"wrote capture_records={manifest['capture_records']} "
+        f"surfaces={manifest['goal_surfaces']} "
+        f"unique_goal_ids={manifest['unique_goal_ids']} "
+        f"text_examples={manifest['text_examples']} "
+        f"surfaces_out={args.surfaces_out}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/scripts/build_goal_dataset_lab.sh
+++ b/scripts/build_goal_dataset_lab.sh
@@ -11,7 +11,13 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PYTHON_BIN="${PYTHON_BIN:-python}"
-IGC_REDFISH_CTL_DIR="${IGC_REDFISH_CTL_DIR:-${REPO_ROOT}/idrac_ctl}"
+if [[ -z "${IGC_REDFISH_CTL_DIR:-}" ]]; then
+	if [[ -d "${REPO_ROOT}/redfish_ctl" ]]; then
+		IGC_REDFISH_CTL_DIR="${REPO_ROOT}/redfish_ctl"
+	else
+		IGC_REDFISH_CTL_DIR="${REPO_ROOT}/idrac_ctl"
+	fi
+fi
 IGC_GOAL_DATASET_OUT="${IGC_GOAL_DATASET_OUT:-}"
 IGC_GOAL_DATASET_ENV_FILE="${IGC_GOAL_DATASET_ENV_FILE:-${REPO_ROOT}/.internal/goal_dataset.env}"
 IGC_GOAL_DATASET_PARAPHRASE_MODE="${IGC_GOAL_DATASET_PARAPHRASE_MODE:-openai}"
@@ -19,6 +25,7 @@ IGC_GOAL_DATASET_GLOB="${IGC_GOAL_DATASET_GLOB:-**/*.json}"
 IGC_GOAL_PARAPHRASE_COUNT="${IGC_GOAL_PARAPHRASE_COUNT:-8}"
 IGC_LFS_PULL="${IGC_LFS_PULL:-1}"
 IGC_LAB_DRY_RUN="${IGC_LAB_DRY_RUN:-0}"
+IGC_REQUIRE_VENDOR_CORPUS="${IGC_REQUIRE_VENDOR_CORPUS:-1}"
 
 say() {
 	printf '%s\n' "$*"
@@ -85,6 +92,26 @@ count_json_files() {
 	find "${root}" -type f -name '*.json' 2>/dev/null | wc -l | tr -dc '0-9'
 }
 
+require_json_corpus() {
+	local label="$1"
+	shift
+
+	local total=0
+	local root
+	local count
+	for root in "$@"; do
+		if [[ -d "${root}" ]]; then
+			count="$(count_json_files "${root}")"
+			total=$((total + count))
+		fi
+	done
+
+	if ((total == 0)); then
+		blocker "missing required redfish_ctl LFS JSON corpus: ${label}; run git -C ${IGC_REDFISH_CTL_DIR} lfs pull or fix the discovery export"
+	fi
+	say "required corpus: ${label} json_files=${total}"
+}
+
 prepare_redfish_ctl() {
 	require_command git
 	if [[ ! -d "${IGC_REDFISH_CTL_DIR}/.git" && ! -f "${IGC_REDFISH_CTL_DIR}/.git" ]]; then
@@ -98,6 +125,23 @@ prepare_redfish_ctl() {
 		run_or_print git -C "${IGC_REDFISH_CTL_DIR}" lfs install --local
 		run_or_print git -C "${IGC_REDFISH_CTL_DIR}" lfs pull
 	fi
+}
+
+require_vendor_corpora() {
+	if [[ "${IGC_REQUIRE_VENDOR_CORPUS}" != "1" ]]; then
+		return
+	fi
+
+	require_json_corpus \
+		"Dell iDRAC full discovery pass" \
+		"${IGC_REDFISH_CTL_DIR}/tests/idrac_fixtures"
+	require_json_corpus \
+		"Supermicro GB300/HGX full discovery pass" \
+		"${IGC_REDFISH_CTL_DIR}/tests/supermicro_gb300_corpus" \
+		"${IGC_REDFISH_CTL_DIR}/tests/supermicro_fixtures"
+	require_json_corpus \
+		"HPE iLO full discovery pass" \
+		"${IGC_REDFISH_CTL_DIR}/tests/hpe_fixtures"
 }
 
 discover_capture_roots() {
@@ -179,6 +223,7 @@ build_dataset() {
 main() {
 	source_private_env
 	prepare_redfish_ctl
+	require_vendor_corpora
 	discover_capture_roots
 	validate_generation_env
 	build_dataset

--- a/scripts/build_goal_dataset_lab.sh
+++ b/scripts/build_goal_dataset_lab.sh
@@ -18,7 +18,9 @@ if [[ -z "${IGC_REDFISH_CTL_DIR:-}" ]]; then
 		IGC_REDFISH_CTL_DIR="${REPO_ROOT}/idrac_ctl"
 	fi
 fi
+IGC_REDFISH_FULL_CORPUS_DIR="${IGC_REDFISH_FULL_CORPUS_DIR:-${IGC_REDFISH_CTL_DIR}/full_corpus}"
 IGC_GOAL_DATASET_OUT="${IGC_GOAL_DATASET_OUT:-}"
+IGC_GOAL_DATASET_WORK_DIR="${IGC_GOAL_DATASET_WORK_DIR:-}"
 IGC_GOAL_DATASET_ENV_FILE="${IGC_GOAL_DATASET_ENV_FILE:-${REPO_ROOT}/.internal/goal_dataset.env}"
 IGC_GOAL_DATASET_PARAPHRASE_MODE="${IGC_GOAL_DATASET_PARAPHRASE_MODE:-openai}"
 IGC_GOAL_DATASET_GLOB="${IGC_GOAL_DATASET_GLOB:-**/*.json}"
@@ -26,6 +28,12 @@ IGC_GOAL_PARAPHRASE_COUNT="${IGC_GOAL_PARAPHRASE_COUNT:-8}"
 IGC_LFS_PULL="${IGC_LFS_PULL:-1}"
 IGC_LAB_DRY_RUN="${IGC_LAB_DRY_RUN:-0}"
 IGC_REQUIRE_VENDOR_CORPUS="${IGC_REQUIRE_VENDOR_CORPUS:-1}"
+REQUIRED_FULL_CORPORA=(
+	"dell_xr8620t_full_corpus.tar.gz"
+	"hpe_dl360_full_corpus.tar.gz"
+	"supermicro_gb300_full_corpus.tar.gz"
+	"supermicro_x10_full_corpus.tar.gz"
+)
 
 say() {
 	printf '%s\n' "$*"
@@ -92,24 +100,82 @@ count_json_files() {
 	find "${root}" -type f -name '*.json' 2>/dev/null | wc -l | tr -dc '0-9'
 }
 
-require_json_corpus() {
-	local label="$1"
-	shift
+is_lfs_pointer() {
+	local archive="$1"
+	LC_ALL=C head -c 96 "${archive}" 2>/dev/null |
+		grep -q 'version https://git-lfs.github.com/spec/v1'
+}
 
-	local total=0
-	local root
-	local count
-	for root in "$@"; do
-		if [[ -d "${root}" ]]; then
-			count="$(count_json_files "${root}")"
-			total=$((total + count))
-		fi
-	done
+tar_contains() {
+	local archive="$1"
+	local pattern="$2"
+	tar -tzf "${archive}" | grep -Eq "${pattern}"
+}
 
-	if ((total == 0)); then
-		blocker "missing required redfish_ctl LFS JSON corpus: ${label}; run git -C ${IGC_REDFISH_CTL_DIR} lfs pull or fix the discovery export"
+validate_tar_members() {
+	local archive="$1"
+	local member
+	while IFS= read -r member; do
+		case "${member}" in
+		"" | /* | ../* | */../* | */.. | . | ..)
+			blocker "unsafe path in redfish_ctl full corpus archive: ${archive}: ${member}"
+			;;
+		esac
+	done < <(tar -tzf "${archive}")
+
+	local listing
+	while IFS= read -r listing; do
+		case "${listing:0:1}" in
+		l | h)
+			blocker "unsafe link entry in redfish_ctl full corpus archive: ${archive}"
+			;;
+		esac
+	done < <(tar -tvzf "${archive}")
+}
+
+tar_json_count() {
+	local archive="$1"
+	tar -tzf "${archive}" |
+		awk -F/ '$NF ~ /[.]json$/ && $NF != "corpus_manifest.json" {count++} END {print count + 0}'
+}
+
+archive_host_roots() {
+	local archive="$1"
+	tar -tzf "${archive}" |
+		awk -F/ 'NF == 2 && $2 == "rest_api_map.npy" {print $1}' |
+		sort -u
+}
+
+require_archive_host_roots() {
+	local archive="$1"
+	local roots
+	roots="$(archive_host_roots "${archive}")"
+	[[ -n "${roots}" ]] ||
+		blocker "redfish_ctl full corpus archive lacks top-level host rest_api_map.npy: ${archive}"
+}
+
+require_full_corpus_archive() {
+	local archive_name="$1"
+	local archive="${IGC_REDFISH_FULL_CORPUS_DIR}/${archive_name}"
+	[[ -f "${archive}" ]] ||
+		blocker "missing required redfish_ctl full corpus archive: ${archive}"
+	if is_lfs_pointer "${archive}"; then
+		blocker "redfish_ctl full corpus archive is still an LFS pointer: ${archive}"
 	fi
-	say "required corpus: ${label} json_files=${total}"
+	tar -tzf "${archive}" >/dev/null ||
+		blocker "redfish_ctl full corpus archive is not readable tar.gz: ${archive}"
+	validate_tar_members "${archive}"
+	tar_contains "${archive}" '(^|/)rest_api_map[.]npy$' ||
+		blocker "redfish_ctl full corpus archive lacks rest_api_map.npy: ${archive}"
+	require_archive_host_roots "${archive}"
+	tar_contains "${archive}" '(^|/)corpus_manifest[.]json$' ||
+		blocker "redfish_ctl full corpus archive lacks corpus_manifest.json: ${archive}"
+
+	local count
+	count="$(tar_json_count "${archive}")"
+	((count > 0)) ||
+		blocker "redfish_ctl full corpus archive contains no resource JSON: ${archive}"
+	say "full corpus archive: ${archive_name} json_files=${count}"
 }
 
 prepare_redfish_ctl() {
@@ -132,16 +198,31 @@ require_vendor_corpora() {
 		return
 	fi
 
-	require_json_corpus \
-		"Dell iDRAC full discovery pass" \
-		"${IGC_REDFISH_CTL_DIR}/tests/idrac_fixtures"
-	require_json_corpus \
-		"Supermicro GB300/HGX full discovery pass" \
-		"${IGC_REDFISH_CTL_DIR}/tests/supermicro_gb300_corpus" \
-		"${IGC_REDFISH_CTL_DIR}/tests/supermicro_fixtures"
-	require_json_corpus \
-		"HPE iLO full discovery pass" \
-		"${IGC_REDFISH_CTL_DIR}/tests/hpe_fixtures"
+	local archive_name
+	for archive_name in "${REQUIRED_FULL_CORPORA[@]}"; do
+		require_full_corpus_archive "${archive_name}"
+	done
+}
+
+extract_full_corpora() {
+	local extract_root="${IGC_GOAL_DATASET_WORK_DIR}/full_corpus"
+	local archive_name
+	local archive
+	local dest
+	local host_root
+	mkdir -p "${extract_root}"
+
+	for archive_name in "${REQUIRED_FULL_CORPORA[@]}"; do
+		archive="${IGC_REDFISH_FULL_CORPUS_DIR}/${archive_name}"
+		dest="${extract_root}/${archive_name%.tar.gz}"
+		run_or_print mkdir -p "${dest}"
+		run_or_print tar -xzf "${archive}" -C "${dest}"
+
+		while IFS= read -r host_root; do
+			[[ -n "${host_root}" ]] || continue
+			CAPTURE_ROOTS+=("${dest}/${host_root}")
+		done < <(archive_host_roots "${archive}")
+	done
 }
 
 discover_capture_roots() {
@@ -149,12 +230,7 @@ discover_capture_roots() {
 	if [[ -n "${IGC_CAPTURE_ROOTS:-}" ]]; then
 		split_roots "${IGC_CAPTURE_ROOTS}"
 	else
-		append_root_if_present "${IGC_REDFISH_CTL_DIR}/tests/idrac_fixtures"
-		append_root_if_present "${IGC_REDFISH_CTL_DIR}/tests/supermicro_fixtures"
-		append_root_if_present "${IGC_REDFISH_CTL_DIR}/tests/hpe_fixtures"
-		append_root_if_present "${IGC_REDFISH_CTL_DIR}/tests/generic_fixtures"
-		append_root_if_present "${IGC_REDFISH_CTL_DIR}/captures"
-		append_root_if_present "${HOME}/.json_responses"
+		extract_full_corpora
 	fi
 	if [[ -n "${IGC_EXTRA_CAPTURE_ROOTS:-}" ]]; then
 		split_roots "${IGC_EXTRA_CAPTURE_ROOTS}"
@@ -166,19 +242,28 @@ discover_capture_roots() {
 	local root
 	local count
 	for root in "${CAPTURE_ROOTS[@]}"; do
+		if [[ "${IGC_LAB_DRY_RUN}" = "1" && ! -d "${root}" ]]; then
+			say "capture root: ${root} json_files=dry-run"
+			continue
+		fi
 		[[ -d "${root}" ]] || blocker "capture root does not exist: ${root}"
 		count="$(count_json_files "${root}")"
 		say "capture root: ${root} json_files=${count}"
 		total=$((total + count))
 	done
-	((total > 0)) || blocker "capture roots contain no JSON files after git lfs pull"
+	if [[ "${IGC_LAB_DRY_RUN}" != "1" ]]; then
+		((total > 0)) || blocker "capture roots contain no JSON files after git lfs pull"
+	fi
 }
 
 validate_generation_env() {
 	[[ -n "${IGC_GOAL_DATASET_OUT}" ]] || blocker "set IGC_GOAL_DATASET_OUT to a private dataset output directory"
+	if [[ -z "${IGC_GOAL_DATASET_WORK_DIR}" ]]; then
+		IGC_GOAL_DATASET_WORK_DIR="${IGC_GOAL_DATASET_OUT}/_build"
+	fi
 	case "${IGC_GOAL_DATASET_PARAPHRASE_MODE}" in
-	none | static | openai) ;;
-	*) blocker "IGC_GOAL_DATASET_PARAPHRASE_MODE must be none, static, or openai" ;;
+	none | template | static | openai) ;;
+	*) blocker "IGC_GOAL_DATASET_PARAPHRASE_MODE must be none, template, static, or openai" ;;
 	esac
 	if [[ "${IGC_GOAL_DATASET_PARAPHRASE_MODE}" = "openai" ]]; then
 		[[ -n "${GOAL_PARAPHRASE_BASE_URL:-}" ]] || blocker "GOAL_PARAPHRASE_BASE_URL is required for openai paraphrases"
@@ -224,8 +309,8 @@ main() {
 	source_private_env
 	prepare_redfish_ctl
 	require_vendor_corpora
-	discover_capture_roots
 	validate_generation_env
+	discover_capture_roots
 	build_dataset
 }
 

--- a/scripts/build_goal_dataset_lab.sh
+++ b/scripts/build_goal_dataset_lab.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Build the full GoalExtractor / GoalEncoder dataset inside the NV72 Docker lab.
+#
+# This wrapper is intentionally thin. It prepares the redfish_ctl submodule,
+# pulls its Git LFS objects, verifies JSON captures exist, and then delegates to
+# scripts/build_goal_dataset.py. The Mac/local path should use unit tests and tiny
+# fixture smoke runs only; the full X-generation pass belongs in the lab Docker
+# environment where the Redfish corpus and local model endpoint are close.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-python}"
+IGC_REDFISH_CTL_DIR="${IGC_REDFISH_CTL_DIR:-${REPO_ROOT}/idrac_ctl}"
+IGC_GOAL_DATASET_OUT="${IGC_GOAL_DATASET_OUT:-}"
+IGC_GOAL_DATASET_ENV_FILE="${IGC_GOAL_DATASET_ENV_FILE:-${REPO_ROOT}/.internal/goal_dataset.env}"
+IGC_GOAL_DATASET_PARAPHRASE_MODE="${IGC_GOAL_DATASET_PARAPHRASE_MODE:-openai}"
+IGC_GOAL_DATASET_GLOB="${IGC_GOAL_DATASET_GLOB:-**/*.json}"
+IGC_GOAL_PARAPHRASE_COUNT="${IGC_GOAL_PARAPHRASE_COUNT:-8}"
+IGC_LFS_PULL="${IGC_LFS_PULL:-1}"
+IGC_LAB_DRY_RUN="${IGC_LAB_DRY_RUN:-0}"
+
+say() {
+	printf '%s\n' "$*"
+}
+
+blocker() {
+	printf 'BLOCKER: %s\n' "$*" >&2
+	exit 1
+}
+
+quote_cmd() {
+	local quoted=()
+	local arg
+	for arg in "$@"; do
+		quoted+=("$(printf '%q' "$arg")")
+	done
+	printf '%s\n' "${quoted[*]}"
+}
+
+run_or_print() {
+	if [[ "${IGC_LAB_DRY_RUN}" = "1" ]]; then
+		quote_cmd "$@"
+	else
+		"$@"
+	fi
+}
+
+require_command() {
+	command -v "$1" >/dev/null 2>&1 || blocker "$1 not found in PATH"
+}
+
+source_private_env() {
+	if [[ -f "${IGC_GOAL_DATASET_ENV_FILE}" ]]; then
+		set -a
+		# shellcheck disable=SC1090
+		. "${IGC_GOAL_DATASET_ENV_FILE}"
+		set +a
+		say "loaded private goal-dataset env file"
+	fi
+}
+
+append_root_if_present() {
+	local root="$1"
+	if [[ -d "${root}" ]]; then
+		CAPTURE_ROOTS+=("${root}")
+	fi
+}
+
+split_roots() {
+	local roots="$1"
+	local old_ifs="${IFS}"
+	local root
+	IFS=':'
+	for root in ${roots}; do
+		if [[ -n "${root}" ]]; then
+			CAPTURE_ROOTS+=("${root}")
+		fi
+	done
+	IFS="${old_ifs}"
+}
+
+count_json_files() {
+	local root="$1"
+	find "${root}" -type f -name '*.json' 2>/dev/null | wc -l | tr -dc '0-9'
+}
+
+prepare_redfish_ctl() {
+	require_command git
+	if [[ ! -d "${IGC_REDFISH_CTL_DIR}/.git" && ! -f "${IGC_REDFISH_CTL_DIR}/.git" ]]; then
+		say "initializing redfish_ctl submodule"
+		run_or_print git -C "${REPO_ROOT}" submodule update --init --recursive idrac_ctl
+	fi
+
+	if [[ "${IGC_LFS_PULL}" = "1" ]]; then
+		git lfs version >/dev/null 2>&1 || blocker "git lfs is required inside the lab container"
+		say "pulling redfish_ctl Git LFS objects"
+		run_or_print git -C "${IGC_REDFISH_CTL_DIR}" lfs install --local
+		run_or_print git -C "${IGC_REDFISH_CTL_DIR}" lfs pull
+	fi
+}
+
+discover_capture_roots() {
+	CAPTURE_ROOTS=()
+	if [[ -n "${IGC_CAPTURE_ROOTS:-}" ]]; then
+		split_roots "${IGC_CAPTURE_ROOTS}"
+	else
+		append_root_if_present "${IGC_REDFISH_CTL_DIR}/tests/idrac_fixtures"
+		append_root_if_present "${IGC_REDFISH_CTL_DIR}/tests/supermicro_fixtures"
+		append_root_if_present "${IGC_REDFISH_CTL_DIR}/tests/hpe_fixtures"
+		append_root_if_present "${IGC_REDFISH_CTL_DIR}/tests/generic_fixtures"
+		append_root_if_present "${IGC_REDFISH_CTL_DIR}/captures"
+		append_root_if_present "${HOME}/.json_responses"
+	fi
+	if [[ -n "${IGC_EXTRA_CAPTURE_ROOTS:-}" ]]; then
+		split_roots "${IGC_EXTRA_CAPTURE_ROOTS}"
+	fi
+
+	((${#CAPTURE_ROOTS[@]} > 0)) || blocker "no capture roots found; set IGC_CAPTURE_ROOTS"
+
+	local total=0
+	local root
+	local count
+	for root in "${CAPTURE_ROOTS[@]}"; do
+		[[ -d "${root}" ]] || blocker "capture root does not exist: ${root}"
+		count="$(count_json_files "${root}")"
+		say "capture root: ${root} json_files=${count}"
+		total=$((total + count))
+	done
+	((total > 0)) || blocker "capture roots contain no JSON files after git lfs pull"
+}
+
+validate_generation_env() {
+	[[ -n "${IGC_GOAL_DATASET_OUT}" ]] || blocker "set IGC_GOAL_DATASET_OUT to a private dataset output directory"
+	case "${IGC_GOAL_DATASET_PARAPHRASE_MODE}" in
+	none | static | openai) ;;
+	*) blocker "IGC_GOAL_DATASET_PARAPHRASE_MODE must be none, static, or openai" ;;
+	esac
+	if [[ "${IGC_GOAL_DATASET_PARAPHRASE_MODE}" = "openai" ]]; then
+		[[ -n "${GOAL_PARAPHRASE_BASE_URL:-}" ]] || blocker "GOAL_PARAPHRASE_BASE_URL is required for openai paraphrases"
+		[[ -n "${GOAL_PARAPHRASE_MODEL:-}" ]] || blocker "GOAL_PARAPHRASE_MODEL is required for openai paraphrases"
+		say "paraphrase backend env is present"
+	fi
+}
+
+build_dataset() {
+	require_command "${PYTHON_BIN}"
+	mkdir -p "${IGC_GOAL_DATASET_OUT}"
+
+	local surfaces_out="${IGC_GOAL_DATASET_OUT}/goal_surfaces.jsonl"
+	local text_out="${IGC_GOAL_DATASET_OUT}/goal_text_examples.jsonl"
+	local manifest_out="${IGC_GOAL_DATASET_OUT}/goal_dataset_manifest.json"
+	local args=(
+		"${PYTHON_BIN}" "${REPO_ROOT}/scripts/build_goal_dataset.py"
+		--source full_redfish_corpus
+		--glob-pattern "${IGC_GOAL_DATASET_GLOB}"
+		--surfaces-out "${surfaces_out}"
+		--manifest-out "${manifest_out}"
+	)
+	local root
+	for root in "${CAPTURE_ROOTS[@]}"; do
+		args+=(--capture-root "${root}")
+	done
+
+	if [[ "${IGC_GOAL_DATASET_PARAPHRASE_MODE}" != "none" ]]; then
+		args+=(
+			--text-out "${text_out}"
+			--paraphrase-mode "${IGC_GOAL_DATASET_PARAPHRASE_MODE}"
+			--generate-all-goals
+			--count "${IGC_GOAL_PARAPHRASE_COUNT}"
+		)
+	fi
+
+	say "building goal dataset"
+	run_or_print "${args[@]}"
+	say "dataset outputs: ${IGC_GOAL_DATASET_OUT}"
+}
+
+main() {
+	source_private_env
+	prepare_redfish_ctl
+	discover_capture_roots
+	validate_generation_env
+	build_dataset
+}
+
+main "$@"

--- a/scripts/sample_goal_dataset.py
+++ b/scripts/sample_goal_dataset.py
@@ -16,6 +16,8 @@ import json
 import os
 import random
 import sys
+import tarfile
+import tempfile
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -33,6 +35,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--dataset-dir",
         default="",
         help="Directory containing goal_dataset_manifest.json and JSONL outputs.",
+    )
+    parser.add_argument(
+        "--dataset-tar",
+        default="",
+        help="Tar.gz artifact containing goal_dataset_manifest.json and JSONL outputs.",
     )
     parser.add_argument(
         "--surfaces",
@@ -83,6 +90,21 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Print full verifier payloads. Off by default to keep output compact.",
     )
     return parser.parse_args(argv)
+
+
+def _safe_extract_dataset_tar(path: Path, target: Path) -> None:
+    """Extract a dataset tarball without allowing path traversal."""
+    with tarfile.open(path, "r:gz") as tar:
+        for member in tar.getmembers():
+            member_path = Path(member.name)
+            if (
+                member_path.is_absolute()
+                or ".." in member_path.parts
+                or member.issym()
+                or member.islnk()
+            ):
+                raise SystemExit(f"unsafe path in dataset tar: {member.name}")
+        tar.extractall(target)
 
 
 def _dataset_path(args: argparse.Namespace, name: str, explicit: str) -> Path | None:
@@ -245,6 +267,12 @@ def main(argv: list[str] | None = None) -> int:
     :return: process-style exit code.
     """
     args = parse_args(argv)
+    temp_dir: tempfile.TemporaryDirectory[str] | None = None
+    if args.dataset_tar:
+        temp_dir = tempfile.TemporaryDirectory(prefix="igc-goal-dataset-")
+        _safe_extract_dataset_tar(Path(args.dataset_tar), Path(temp_dir.name))
+        args.dataset_dir = temp_dir.name
+
     manifest_path = _dataset_path(args, "goal_dataset_manifest.json", args.manifest)
     surfaces_path = _dataset_path(args, "goal_surfaces.jsonl", args.surfaces)
     text_path = _dataset_path(args, "goal_text_examples.jsonl", args.text)
@@ -267,6 +295,8 @@ def main(argv: list[str] | None = None) -> int:
     if args.mode in {"both", "text"}:
         print()
         _print_text(_sample(text_rows, args.limit, args.seed))
+    if temp_dir is not None:
+        temp_dir.cleanup()
     return 0
 
 

--- a/scripts/sample_goal_dataset.py
+++ b/scripts/sample_goal_dataset.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Sample and summarize a built GoalExtractor / GoalEncoder dataset.
+
+This local inspection helper reads the JSONL artifacts produced by
+``scripts/build_goal_dataset.py`` or ``scripts/build_goal_dataset_lab.sh`` and
+prints a small, human-readable view of what is inside. It does not call model
+endpoints, does not require a GPU, and hides full verifier payloads by default.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+# Running as ``python scripts/sample_goal_dataset.py`` puts scripts/ on sys.path;
+# add the repo root so ``import igc`` works without installation.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from igc.ds.goal_dataset import GoalSurface, GoalTextExample
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dataset-dir",
+        default="",
+        help="Directory containing goal_dataset_manifest.json and JSONL outputs.",
+    )
+    parser.add_argument(
+        "--surfaces",
+        default="",
+        help="Explicit goal_surfaces.jsonl path; overrides --dataset-dir default.",
+    )
+    parser.add_argument(
+        "--text",
+        default="",
+        help="Explicit goal_text_examples.jsonl path; overrides --dataset-dir default.",
+    )
+    parser.add_argument(
+        "--manifest",
+        default="",
+        help="Explicit goal_dataset_manifest.json path; overrides --dataset-dir default.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=5,
+        help="Maximum rows to print from each selected dataset file.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=7,
+        help="Deterministic sampling seed.",
+    )
+    parser.add_argument(
+        "--family",
+        default="",
+        help="Optional GoalRef family filter such as power, boot, network, bios.",
+    )
+    parser.add_argument(
+        "--vendor",
+        default="",
+        help="Optional vendor filter for surfaces such as dell, hpe, supermicro.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("both", "surfaces", "text"),
+        default="both",
+        help="Which artifact type to sample.",
+    )
+    parser.add_argument(
+        "--show-verifier",
+        action="store_true",
+        help="Print full verifier payloads. Off by default to keep output compact.",
+    )
+    return parser.parse_args(argv)
+
+
+def _dataset_path(args: argparse.Namespace, name: str, explicit: str) -> Path | None:
+    """Resolve an artifact path from either explicit args or ``--dataset-dir``."""
+    if explicit:
+        return Path(explicit)
+    if args.dataset_dir:
+        return Path(args.dataset_dir) / name
+    return None
+
+
+def _read_json(path: Path | None) -> dict[str, Any]:
+    """Read a JSON object if the path exists, otherwise return an empty dict."""
+    if path is None or not path.is_file():
+        return {}
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        raise SystemExit(f"manifest is not a JSON object: {path}")
+    return data
+
+
+def _read_jsonl(path: Path | None) -> list[dict[str, Any]]:
+    """Read a JSON Lines file into dictionaries."""
+    if path is None or not path.is_file():
+        return []
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line_no, line in enumerate(fh, 1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            data = json.loads(stripped)
+            if not isinstance(data, dict):
+                raise SystemExit(f"row {line_no} is not a JSON object: {path}")
+            rows.append(data)
+    return rows
+
+
+def _sample(rows: list[Any], limit: int, seed: int) -> list[Any]:
+    """Return a deterministic sample without changing row order when small."""
+    if limit <= 0 or not rows:
+        return []
+    if len(rows) <= limit:
+        return rows
+    rng = random.Random(seed)
+    indices = sorted(rng.sample(range(len(rows)), limit))
+    return [rows[index] for index in indices]
+
+
+def _goal_family(goal_ref: dict[str, Any]) -> str:
+    """Read a GoalRef family from serialized data."""
+    return str(goal_ref.get("family") or "")
+
+
+def _filter_surfaces(
+    rows: Iterable[GoalSurface],
+    family: str,
+    vendor: str,
+) -> list[GoalSurface]:
+    """Apply optional family/vendor filters to surface rows."""
+    filtered = []
+    for row in rows:
+        if family and row.goal_ref.family != family:
+            continue
+        if vendor and row.vendor != vendor:
+            continue
+        filtered.append(row)
+    return filtered
+
+
+def _filter_text(rows: Iterable[GoalTextExample], family: str) -> list[GoalTextExample]:
+    """Apply optional family filter to text rows."""
+    if not family:
+        return list(rows)
+    return [
+        row for row in rows
+        if any(ref.family == family for ref in row.goal_refs)
+    ]
+
+
+def _print_manifest(manifest: dict[str, Any]) -> None:
+    """Print compact manifest fields when present."""
+    if not manifest:
+        print("manifest: <missing>")
+        return
+    print("manifest:")
+    for key in (
+        "capture_records",
+        "goal_surfaces",
+        "unique_goal_ids",
+        "text_examples",
+    ):
+        if key in manifest:
+            print(f"  {key}: {manifest[key]}")
+    vendors = manifest.get("vendors") or []
+    if vendors:
+        print(f"  vendors: {', '.join(str(vendor) for vendor in vendors)}")
+
+
+def _format_value(value: Any) -> str:
+    """Render compact scalar/list values for terminal inspection."""
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, sort_keys=True)
+
+
+def _print_surfaces(rows: list[GoalSurface], show_verifier: bool) -> None:
+    """Print sampled surface rows."""
+    print(f"surface sample ({len(rows)} row(s)):")
+    if not rows:
+        print("  <none>")
+        return
+    for index, row in enumerate(rows, 1):
+        allowed = len(tuple(row.allowed_values))
+        print(f"  {index}. {row.goal_ref.goal_id}")
+        print(
+            "     "
+            f"vendor={row.vendor or 'unknown'} "
+            f"source={row.source or 'unknown'} "
+            f"resource_type={row.goal_ref.resource_type}"
+        )
+        print(
+            "     "
+            f"path={row.fact_path} "
+            f"target={_format_value(row.target_value)} "
+            f"current={_format_value(row.current_value)} "
+            f"allowed_values={allowed}"
+        )
+        print(f"     resource_uri={row.resource_uri}")
+        print(f"     verifier_kind={row.verifier.get('kind', '<missing>')}")
+        if show_verifier:
+            print(f"     verifier={json.dumps(dict(row.verifier), sort_keys=True)}")
+
+
+def _print_text(rows: list[GoalTextExample]) -> None:
+    """Print sampled text rows."""
+    print(f"text sample ({len(rows)} row(s)):")
+    if not rows:
+        print("  <none>")
+        return
+    for index, row in enumerate(rows, 1):
+        print(f"  {index}. {row.text}")
+        print(f"     source={row.text_source} split={row.split}")
+        print("     goal_ids:")
+        for ref in row.goal_refs:
+            print(f"       - {ref.goal_id}")
+        if row.dependencies:
+            print("     dependencies:")
+            for dep in row.dependencies:
+                print(
+                    "       - "
+                    f"{dep.before_goal_id} {dep.relation} {dep.after_goal_id}"
+                )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint.
+
+    :return: process-style exit code.
+    """
+    args = parse_args(argv)
+    manifest_path = _dataset_path(args, "goal_dataset_manifest.json", args.manifest)
+    surfaces_path = _dataset_path(args, "goal_surfaces.jsonl", args.surfaces)
+    text_path = _dataset_path(args, "goal_text_examples.jsonl", args.text)
+
+    manifest = _read_json(manifest_path)
+    surface_rows = [
+        GoalSurface.from_dict(row) for row in _read_jsonl(surfaces_path)
+    ]
+    text_rows = [
+        GoalTextExample.from_dict(row) for row in _read_jsonl(text_path)
+    ]
+
+    surface_rows = _filter_surfaces(surface_rows, args.family, args.vendor)
+    text_rows = _filter_text(text_rows, args.family)
+
+    _print_manifest(manifest)
+    if args.mode in {"both", "surfaces"}:
+        print()
+        _print_surfaces(_sample(surface_rows, args.limit, args.seed), args.show_verifier)
+    if args.mode in {"both", "text"}:
+        print()
+        _print_text(_sample(text_rows, args.limit, args.seed))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/scripts/submit_train.sh
+++ b/scripts/submit_train.sh
@@ -22,7 +22,7 @@ SBATCH_FILE="${HERE}/scripts/train_igc.sbatch"
 
 case "${STAGE}" in
     m1|m2|m3|m3p|m6|agent|state_encoder|autoencoder|goal|parameter|rl|all) : ;;
-    *) echo "ERROR: stage '${STAGE}' is not one of m1|m2|m3|m3p|m6|all" >&2; exit 2 ;;
+    *) echo "ERROR: stage '${STAGE}' is not one of m1|m2|legacy goal|legacy parameter|m6|all" >&2; exit 2 ;;
 esac
 
 # Fleet-health gate (TEAM_GUIDE blocker rule): never submit against an unhealthy fleet.

--- a/scripts/train_igc.sbatch
+++ b/scripts/train_igc.sbatch
@@ -6,8 +6,8 @@
 # Stages (curriculum order — each later stage loads the earlier artifacts):
 #   m1 | state_encoder   --train llm  --llm latent     state encoder (backbone SFT; --use_peft for LoRA)
 #   m2 | autoencoder     --train llm  --llm encoder     state autoencoder (compresses the state)
-#   m3 | goal            --train llm  --llm goal         goal extractor (planner)
-#   m3p| parameter       --train llm  --llm parameter    goal+parameter extractor (arg head)
+#   m3 | goal            --train llm  --llm goal         legacy permutation goal extractor
+#   m3p| parameter       --train llm  --llm parameter    legacy goal+parameter extractor
 #   m6 | agent           --train agent --rl all          RL agent (DQN+HER) — needs m1+m2 first
 #   all                  --train all  --llm all --rl all  everything in one job
 #

--- a/tests/bats/build_goal_dataset_lab.bats
+++ b/tests/bats/build_goal_dataset_lab.bats
@@ -39,6 +39,8 @@ make_redfish_ctl_corpus() {
 		>"${root}/tests/idrac_fixtures/system.json"
 	printf '{"@odata.id":"/redfish/v1/Managers/1/NetworkProtocol","@odata.type":"#ManagerNetworkProtocol.v1_10_0.ManagerNetworkProtocol","NTP":{"ProtocolEnabled":false}}\n' \
 		>"${root}/tests/supermicro_fixtures/ntp.json"
+	printf '{"@odata.id":"/redfish/v1/Systems/1/Bios","@odata.type":"#Bios.v1_2_0.Bios","Attributes":{"BootMode":"Uefi"}}\n' \
+		>"${root}/tests/hpe_fixtures/bios.json"
 }
 
 @test "lab wrapper requires a private output directory" {
@@ -76,6 +78,9 @@ make_redfish_ctl_corpus() {
 
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"pulling redfish_ctl Git LFS objects"* ]]
+	[[ "$output" == *"required corpus: Dell iDRAC full discovery pass"* ]]
+	[[ "$output" == *"required corpus: Supermicro GB300/HGX full discovery pass"* ]]
+	[[ "$output" == *"required corpus: HPE iLO full discovery pass"* ]]
 	[[ "$output" == *"--generate-all-goals"* ]]
 	[[ "$output" == *"--capture-root ${corpus}/tests/idrac_fixtures"* ]]
 	[[ "$output" == *"--capture-root ${corpus}/tests/supermicro_fixtures"* ]]
@@ -99,5 +104,5 @@ make_redfish_ctl_corpus() {
 		bash "${REPO_ROOT}/scripts/build_goal_dataset_lab.sh"
 
 	[ "$status" -eq 1 ]
-	[[ "$output" == *"no JSON files after git lfs pull"* ]]
+	[[ "$output" == *"missing required redfish_ctl LFS JSON corpus"* ]]
 }

--- a/tests/bats/build_goal_dataset_lab.bats
+++ b/tests/bats/build_goal_dataset_lab.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+
+setup() {
+	REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+	export REPO_ROOT
+
+	mkdir -p "${BATS_TEST_TMPDIR}/bin"
+	export PATH="${BATS_TEST_TMPDIR}/bin:${PATH}"
+}
+
+install_lab_fakes() {
+	cat >"${BATS_TEST_TMPDIR}/bin/git" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${FAKE_GIT_LOG}"
+if [[ "${1:-}" == "lfs" && "${2:-}" == "version" ]]; then
+    printf 'git-lfs/3.0.0\n'
+fi
+EOF
+	chmod +x "${BATS_TEST_TMPDIR}/bin/git"
+
+	cat >"${BATS_TEST_TMPDIR}/bin/python" <<'EOF'
+#!/usr/bin/env bash
+printf 'python-stub should not execute in dry-run\n' >&2
+exit 2
+EOF
+	chmod +x "${BATS_TEST_TMPDIR}/bin/python"
+}
+
+make_redfish_ctl_corpus() {
+	local root="$1"
+	mkdir -p \
+		"${root}/tests/idrac_fixtures" \
+		"${root}/tests/supermicro_fixtures" \
+		"${root}/tests/hpe_fixtures" \
+		"${root}/tests/generic_fixtures"
+	touch "${root}/.git"
+	printf '{"@odata.id":"/redfish/v1/Systems/1","@odata.type":"#ComputerSystem.v1_20_0.ComputerSystem","PowerState":"Off"}\n' \
+		>"${root}/tests/idrac_fixtures/system.json"
+	printf '{"@odata.id":"/redfish/v1/Managers/1/NetworkProtocol","@odata.type":"#ManagerNetworkProtocol.v1_10_0.ManagerNetworkProtocol","NTP":{"ProtocolEnabled":false}}\n' \
+		>"${root}/tests/supermicro_fixtures/ntp.json"
+}
+
+@test "lab wrapper requires a private output directory" {
+	install_lab_fakes
+	corpus="${BATS_TEST_TMPDIR}/redfish_ctl"
+	make_redfish_ctl_corpus "${corpus}"
+
+	run env \
+		FAKE_GIT_LOG="${BATS_TEST_TMPDIR}/git.log" \
+		HOME="${BATS_TEST_TMPDIR}/home" \
+		IGC_LAB_DRY_RUN=1 \
+		IGC_REDFISH_CTL_DIR="${corpus}" \
+		GOAL_PARAPHRASE_BASE_URL=http://example.invalid \
+		GOAL_PARAPHRASE_MODEL=local-pro \
+		bash "${REPO_ROOT}/scripts/build_goal_dataset_lab.sh"
+
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"IGC_GOAL_DATASET_OUT"* ]]
+}
+
+@test "lab wrapper pulls LFS and renders full-corpus generation command" {
+	install_lab_fakes
+	corpus="${BATS_TEST_TMPDIR}/redfish_ctl"
+	make_redfish_ctl_corpus "${corpus}"
+
+	run env \
+		FAKE_GIT_LOG="${BATS_TEST_TMPDIR}/git.log" \
+		HOME="${BATS_TEST_TMPDIR}/home" \
+		IGC_LAB_DRY_RUN=1 \
+		IGC_REDFISH_CTL_DIR="${corpus}" \
+		IGC_GOAL_DATASET_OUT="${BATS_TEST_TMPDIR}/out" \
+		GOAL_PARAPHRASE_BASE_URL=http://example.invalid \
+		GOAL_PARAPHRASE_MODEL=local-pro \
+		bash "${REPO_ROOT}/scripts/build_goal_dataset_lab.sh"
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"pulling redfish_ctl Git LFS objects"* ]]
+	[[ "$output" == *"--generate-all-goals"* ]]
+	[[ "$output" == *"--capture-root ${corpus}/tests/idrac_fixtures"* ]]
+	[[ "$output" == *"--capture-root ${corpus}/tests/supermicro_fixtures"* ]]
+	[[ "$output" == *"git -C ${corpus} lfs pull"* ]]
+}
+
+@test "lab wrapper blocks when LFS leaves no JSON captures" {
+	install_lab_fakes
+	corpus="${BATS_TEST_TMPDIR}/redfish_ctl"
+	mkdir -p "${corpus}/tests/idrac_fixtures"
+	touch "${corpus}/.git"
+
+	run env \
+		FAKE_GIT_LOG="${BATS_TEST_TMPDIR}/git.log" \
+		HOME="${BATS_TEST_TMPDIR}/home" \
+		IGC_LAB_DRY_RUN=1 \
+		IGC_REDFISH_CTL_DIR="${corpus}" \
+		IGC_GOAL_DATASET_OUT="${BATS_TEST_TMPDIR}/out" \
+		GOAL_PARAPHRASE_BASE_URL=http://example.invalid \
+		GOAL_PARAPHRASE_MODEL=local-pro \
+		bash "${REPO_ROOT}/scripts/build_goal_dataset_lab.sh"
+
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"no JSON files after git lfs pull"* ]]
+}

--- a/tests/bats/build_goal_dataset_lab.bats
+++ b/tests/bats/build_goal_dataset_lab.bats
@@ -29,18 +29,60 @@ EOF
 
 make_redfish_ctl_corpus() {
 	local root="$1"
-	mkdir -p \
-		"${root}/tests/idrac_fixtures" \
-		"${root}/tests/supermicro_fixtures" \
-		"${root}/tests/hpe_fixtures" \
-		"${root}/tests/generic_fixtures"
+	mkdir -p "${root}/full_corpus"
 	touch "${root}/.git"
-	printf '{"@odata.id":"/redfish/v1/Systems/1","@odata.type":"#ComputerSystem.v1_20_0.ComputerSystem","PowerState":"Off"}\n' \
-		>"${root}/tests/idrac_fixtures/system.json"
-	printf '{"@odata.id":"/redfish/v1/Managers/1/NetworkProtocol","@odata.type":"#ManagerNetworkProtocol.v1_10_0.ManagerNetworkProtocol","NTP":{"ProtocolEnabled":false}}\n' \
-		>"${root}/tests/supermicro_fixtures/ntp.json"
-	printf '{"@odata.id":"/redfish/v1/Systems/1/Bios","@odata.type":"#Bios.v1_2_0.Bios","Attributes":{"BootMode":"Uefi"}}\n' \
-		>"${root}/tests/hpe_fixtures/bios.json"
+	make_full_corpus_archive "${root}" "dell_xr8620t_full_corpus.tar.gz" "10.0.0.1" \
+		'{"@odata.id":"/redfish/v1/Systems/1","@odata.type":"#ComputerSystem.v1_20_0.ComputerSystem","PowerState":"Off"}'
+	make_full_corpus_archive "${root}" "supermicro_gb300_full_corpus.tar.gz" "10.0.0.2" \
+		'{"@odata.id":"/redfish/v1/Managers/1/NetworkProtocol","@odata.type":"#ManagerNetworkProtocol.v1_10_0.ManagerNetworkProtocol","NTP":{"ProtocolEnabled":false}}'
+	make_full_corpus_archive "${root}" "hpe_dl360_full_corpus.tar.gz" "10.0.0.3" \
+		'{"@odata.id":"/redfish/v1/Systems/1/Bios","@odata.type":"#Bios.v1_2_0.Bios","Attributes":{"BootMode":"Uefi"}}'
+	make_full_corpus_archive "${root}" "supermicro_x10_full_corpus.tar.gz" "10.0.0.4" \
+		'{"@odata.id":"/redfish/v1/Chassis/1","@odata.type":"#Chassis.v1_0_0.Chassis","PowerState":"On"}'
+}
+
+make_full_corpus_archive() {
+	local root="$1"
+	local archive="$2"
+	local host="$3"
+	local body="$4"
+	local build="${BATS_TEST_TMPDIR}/${archive%.tar.gz}"
+	rm -rf "${build}"
+	mkdir -p "${build}/${host}"
+	printf '%s\n' "${body}" >"${build}/${host}/resource.json"
+	printf '{"schema_version":"1","artifact_type":"full_training","json_file_count":1}\n' \
+		>"${build}/${host}/corpus_manifest.json"
+	printf 'npy-stub\n' >"${build}/${host}/rest_api_map.npy"
+	tar -czf "${root}/full_corpus/${archive}" -C "${build}" "${host}"
+}
+
+make_unsafe_link_archive() {
+	local root="$1"
+	local archive="$2"
+	local build="${BATS_TEST_TMPDIR}/unsafe-${archive%.tar.gz}"
+	rm -rf "${build}"
+	mkdir -p "${build}/10.0.0.9"
+	printf '{"@odata.id":"/redfish/v1/Systems/1"}\n' \
+		>"${build}/10.0.0.9/resource.json"
+	printf '{"schema_version":"1","artifact_type":"full_training","json_file_count":1}\n' \
+		>"${build}/10.0.0.9/corpus_manifest.json"
+	printf 'npy-stub\n' >"${build}/10.0.0.9/rest_api_map.npy"
+	ln -s /tmp "${build}/10.0.0.9/unsafe-link"
+	tar -czf "${root}/full_corpus/${archive}" -C "${build}" "10.0.0.9"
+}
+
+make_nested_map_archive() {
+	local root="$1"
+	local archive="$2"
+	local build="${BATS_TEST_TMPDIR}/nested-${archive%.tar.gz}"
+	rm -rf "${build}"
+	mkdir -p "${build}/nested/10.0.0.9"
+	printf '{"@odata.id":"/redfish/v1/Systems/1"}\n' \
+		>"${build}/nested/10.0.0.9/resource.json"
+	printf '{"schema_version":"1","artifact_type":"full_training","json_file_count":1}\n' \
+		>"${build}/nested/10.0.0.9/corpus_manifest.json"
+	printf 'npy-stub\n' >"${build}/nested/10.0.0.9/rest_api_map.npy"
+	tar -czf "${root}/full_corpus/${archive}" -C "${build}" "nested"
 }
 
 @test "lab wrapper requires a private output directory" {
@@ -78,19 +120,20 @@ make_redfish_ctl_corpus() {
 
 	[ "$status" -eq 0 ]
 	[[ "$output" == *"pulling redfish_ctl Git LFS objects"* ]]
-	[[ "$output" == *"required corpus: Dell iDRAC full discovery pass"* ]]
-	[[ "$output" == *"required corpus: Supermicro GB300/HGX full discovery pass"* ]]
-	[[ "$output" == *"required corpus: HPE iLO full discovery pass"* ]]
+	[[ "$output" == *"full corpus archive: dell_xr8620t_full_corpus.tar.gz"* ]]
+	[[ "$output" == *"full corpus archive: supermicro_gb300_full_corpus.tar.gz"* ]]
+	[[ "$output" == *"full corpus archive: hpe_dl360_full_corpus.tar.gz"* ]]
+	[[ "$output" == *"full corpus archive: supermicro_x10_full_corpus.tar.gz"* ]]
 	[[ "$output" == *"--generate-all-goals"* ]]
-	[[ "$output" == *"--capture-root ${corpus}/tests/idrac_fixtures"* ]]
-	[[ "$output" == *"--capture-root ${corpus}/tests/supermicro_fixtures"* ]]
+	[[ "$output" == *"--capture-root ${BATS_TEST_TMPDIR}/out/_build/full_corpus/dell_xr8620t_full_corpus/10.0.0.1"* ]]
+	[[ "$output" == *"--capture-root ${BATS_TEST_TMPDIR}/out/_build/full_corpus/supermicro_gb300_full_corpus/10.0.0.2"* ]]
 	[[ "$output" == *"git -C ${corpus} lfs pull"* ]]
 }
 
-@test "lab wrapper blocks when LFS leaves no JSON captures" {
+@test "lab wrapper blocks when a required full corpus archive is missing" {
 	install_lab_fakes
 	corpus="${BATS_TEST_TMPDIR}/redfish_ctl"
-	mkdir -p "${corpus}/tests/idrac_fixtures"
+	mkdir -p "${corpus}/full_corpus"
 	touch "${corpus}/.git"
 
 	run env \
@@ -104,5 +147,45 @@ make_redfish_ctl_corpus() {
 		bash "${REPO_ROOT}/scripts/build_goal_dataset_lab.sh"
 
 	[ "$status" -eq 1 ]
-	[[ "$output" == *"missing required redfish_ctl LFS JSON corpus"* ]]
+	[[ "$output" == *"missing required redfish_ctl full corpus archive"* ]]
+}
+
+@test "lab wrapper rejects unsafe link entries before extracting full corpora" {
+	install_lab_fakes
+	corpus="${BATS_TEST_TMPDIR}/redfish_ctl"
+	make_redfish_ctl_corpus "${corpus}"
+	make_unsafe_link_archive "${corpus}" "dell_xr8620t_full_corpus.tar.gz"
+
+	run env \
+		FAKE_GIT_LOG="${BATS_TEST_TMPDIR}/git.log" \
+		HOME="${BATS_TEST_TMPDIR}/home" \
+		IGC_LAB_DRY_RUN=1 \
+		IGC_REDFISH_CTL_DIR="${corpus}" \
+		IGC_GOAL_DATASET_OUT="${BATS_TEST_TMPDIR}/out" \
+		GOAL_PARAPHRASE_BASE_URL=http://example.invalid \
+		GOAL_PARAPHRASE_MODEL=local-pro \
+		bash "${REPO_ROOT}/scripts/build_goal_dataset_lab.sh"
+
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"unsafe link entry in redfish_ctl full corpus archive"* ]]
+}
+
+@test "lab wrapper rejects full corpora without top-level host map" {
+	install_lab_fakes
+	corpus="${BATS_TEST_TMPDIR}/redfish_ctl"
+	make_redfish_ctl_corpus "${corpus}"
+	make_nested_map_archive "${corpus}" "dell_xr8620t_full_corpus.tar.gz"
+
+	run env \
+		FAKE_GIT_LOG="${BATS_TEST_TMPDIR}/git.log" \
+		HOME="${BATS_TEST_TMPDIR}/home" \
+		IGC_LAB_DRY_RUN=1 \
+		IGC_REDFISH_CTL_DIR="${corpus}" \
+		IGC_GOAL_DATASET_OUT="${BATS_TEST_TMPDIR}/out" \
+		GOAL_PARAPHRASE_BASE_URL=http://example.invalid \
+		GOAL_PARAPHRASE_MODEL=local-pro \
+		bash "${REPO_ROOT}/scripts/build_goal_dataset_lab.sh"
+
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"lacks top-level host rest_api_map.npy"* ]]
 }

--- a/tests/ds/test_goal_dataset_builder.py
+++ b/tests/ds/test_goal_dataset_builder.py
@@ -265,6 +265,38 @@ def test_sensitive_identity_leaves_do_not_become_prompt_labels() -> None:
     assert all(surface.goal_ref.action_name != "Bios.ChangePassword" for surface in surfaces)
 
 
+def test_schema_and_registry_documents_do_not_become_goal_surfaces() -> None:
+    """Schema/registry corpus JSON is metadata, not an RL goal surface."""
+    schema_body = {
+        "@odata.id": "/redfish/v1/JsonSchemas/ComputerSystem",
+        "@odata.type": "#JsonSchemaFile.v1_0_0.JsonSchemaFile",
+        "Definitions": {
+            "PowerState": {
+                "enum": ["On", "Off"],
+                "description": "Power state documentation",
+            }
+        },
+    }
+    registry_body = {
+        "@odata.id": "/redfish/v1/Registries/Base",
+        "@odata.type": "#MessageRegistry.v1_6_0.MessageRegistry",
+        "RegistryPrefix": "Base",
+        "Messages": {
+            "Success": {
+                "Description": "Operation succeeded",
+                "Severity": "OK",
+            }
+        },
+    }
+
+    surfaces = build_goal_surfaces([
+        _record("/redfish/v1/JsonSchemas/ComputerSystem", schema_body),
+        _record("/redfish/v1/Registries/Base", registry_body),
+    ])
+
+    assert surfaces == ()
+
+
 def test_boot_server_and_set_ntp_text_has_two_unordered_sub_goals() -> None:
     """The example x maps to true_y as a set of atomic z_sub_goal targets."""
     surfaces = build_goal_surfaces([

--- a/tests/ds/test_goal_dataset_builder.py
+++ b/tests/ds/test_goal_dataset_builder.py
@@ -1,0 +1,356 @@
+"""Offline tests for the latent sub-goal dataset builder.
+
+These tests pin the corrected GoalExtractor target: operator text maps to an
+unordered set of atomic ``GoalRef`` sub-goals, while concrete Redfish JSON
+surfaces remain hidden verifier/reward evidence. No network, GPU, or live
+Redfish host is required.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+from pathlib import Path
+
+from igc.ds.goal_dataset import GoalDependency, GoalTextExample, read_goal_text_examples
+from igc.ds.goal_dataset_builder import build_goal_surfaces, make_goal_text_example
+from igc.ds.sources import SourceRecord, TrustLevel
+
+
+def _record(url: str, body: dict, vendor: str = "dell") -> SourceRecord:
+    """Build a REAL-tier SourceRecord with vendor provenance."""
+    return SourceRecord(
+        url=url,
+        response=body,
+        source=f"real_{vendor}",
+        trust_level=TrustLevel.REAL,
+        vendor=vendor,
+        schema_version=str(body.get("@odata.type", "")),
+    )
+
+
+def _system_body() -> dict:
+    """Tiny ComputerSystem body with power, boot, and reset surfaces."""
+    return {
+        "@odata.id": "/redfish/v1/Systems/1",
+        "@odata.type": "#ComputerSystem.v1_20_0.ComputerSystem",
+        "PowerState": "Off",
+        "PowerState@Redfish.AllowableValues": ["On", "Off"],
+        "Boot": {
+            "BootSourceOverrideTarget": "None",
+            "BootSourceOverrideTarget@Redfish.AllowableValues": ["None", "Pxe", "Hdd"],
+            "BootSourceOverrideEnabled": "Disabled",
+            "BootSourceOverrideEnabled@Redfish.AllowableValues": [
+                "Disabled",
+                "Once",
+                "Continuous",
+            ],
+        },
+        "Actions": {
+            "#ComputerSystem.Reset": {
+                "target": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+                "ResetType@Redfish.AllowableValues": [
+                    "On",
+                    "GracefulRestart",
+                    "ForceRestart",
+                ],
+            }
+        },
+    }
+
+
+def _network_protocol_body() -> dict:
+    """Tiny ManagerNetworkProtocol body with NTP state."""
+    return {
+        "@odata.id": "/redfish/v1/Managers/1/NetworkProtocol",
+        "@odata.type": "#ManagerNetworkProtocol.v1_10_0.ManagerNetworkProtocol",
+        "NTP": {
+            "ProtocolEnabled": False,
+            "NTPServers": ["time-a.example.test", "time-b.example.test"],
+        },
+    }
+
+
+def _chassis_body() -> dict:
+    """Generic non-ComputerSystem body with nested state and actions."""
+    return {
+        "@odata.id": "/redfish/v1/Chassis/1",
+        "@odata.type": "#Chassis.v1_25_0.Chassis",
+        "Name": "Main Chassis",
+        "PowerState": "On",
+        "Thermal": {
+            "Fans": [
+                {"Name": "Fan 1", "Reading": 42, "Status": {"State": "Enabled"}},
+            ],
+        },
+        "Actions": {
+            "#Chassis.Reset": {
+                "target": "/redfish/v1/Chassis/1/Actions/Chassis.Reset",
+                "ResetType@Redfish.AllowableValues": ["ForceRestart"],
+            },
+            "#LogService.ClearLog": {
+                "target": "/redfish/v1/Chassis/1/LogServices/EventLog/Actions/LogService.ClearLog",
+            },
+        },
+    }
+
+
+def test_computer_system_record_yields_atomic_power_boot_and_reset_surfaces() -> None:
+    """One JSON resource yields many atomic sub-goal surfaces, never a plan."""
+    surfaces = build_goal_surfaces([
+        _record("/redfish/v1/Systems/1", _system_body()),
+    ])
+
+    by_id = {surface.goal_ref.goal_id: surface for surface in surfaces}
+
+    power = by_id["power.computer_system.PowerState.eq.On"]
+    assert power.goal_ref.family == "power"
+    assert power.goal_ref.target_value == "On"
+    assert power.current_value == "Off"
+    assert power.verifier["kind"] == "state_eq"
+    assert power.verifier["property_path"] == "PowerState"
+
+    boot_target = by_id["boot.computer_system.Boot.BootSourceOverrideTarget.eq.Pxe"]
+    assert boot_target.goal_ref.family == "boot"
+    assert boot_target.allowed_values == ("None", "Pxe", "Hdd")
+    assert boot_target.goal_ref.target_value == "Pxe"
+
+    reset = by_id["action.computer_system.ComputerSystem.Reset.ResetType.eq.GracefulRestart"]
+    assert reset.goal_ref.family == "action"
+    assert reset.goal_ref.mode == "transition"
+    assert reset.goal_ref.action_name == "ComputerSystem.Reset"
+    assert reset.goal_ref.arguments == {"ResetType": "GracefulRestart"}
+
+
+def test_generic_redfish_record_yields_nested_state_and_action_surfaces() -> None:
+    """Unknown Redfish resource types still produce state and transition labels."""
+    surfaces = build_goal_surfaces([
+        _record("/redfish/v1/Chassis/1", _chassis_body(), vendor="supermicro"),
+    ])
+
+    power = next(
+        surface for surface in surfaces
+        if surface.goal_ref.resource_type == "chassis"
+        and surface.goal_ref.property_path == "PowerState"
+        and surface.goal_ref.target_value == "On"
+    )
+    assert power.goal_ref.family == "power"
+    assert power.current_value == "On"
+    assert power.verifier["kind"] == "state_eq"
+
+    fan = next(
+        surface for surface in surfaces
+        if surface.goal_ref.property_path == "Thermal.Fans[].Reading"
+    )
+    assert fan.goal_ref.family == "thermal"
+    assert fan.goal_ref.target_value == 42
+    assert fan.verifier["property_path"] == "Thermal.Fans[].Reading"
+
+    reset = next(
+        surface for surface in surfaces
+        if surface.goal_ref.action_name == "Chassis.Reset"
+        and surface.goal_ref.arguments == {"ResetType": "ForceRestart"}
+    )
+    assert reset.goal_ref.mode == "transition"
+    assert reset.verifier["kind"] == "transition"
+
+    clear_log = next(
+        surface for surface in surfaces
+        if surface.goal_ref.action_name == "LogService.ClearLog"
+    )
+    assert clear_log.goal_ref.arguments == {}
+    assert clear_log.goal_ref.goal_id.endswith(".invoke")
+
+
+def test_inline_allowable_values_on_any_resource_yield_state_targets() -> None:
+    """Allowable values outside Actions become atomic target values."""
+    body = {
+        "@odata.id": "/redfish/v1/Managers/1",
+        "@odata.type": "#Manager.v1_16_0.Manager",
+        "CommandShell": {
+            "ConnectTypesSupported": "SSH",
+            "ConnectTypesSupported@Redfish.AllowableValues": ["SSH", "IPMI", "Oem"],
+        },
+    }
+
+    surfaces = build_goal_surfaces([
+        _record("/redfish/v1/Managers/1", body, vendor="hpe"),
+    ])
+
+    targets = {
+        surface.goal_ref.target_value
+        for surface in surfaces
+        if surface.goal_ref.property_path == "CommandShell.ConnectTypesSupported"
+    }
+    assert targets == {"SSH", "IPMI", "Oem"}
+
+
+def test_free_form_string_targets_do_not_enter_goal_ids() -> None:
+    """Private instance strings stay verifier payloads, not semantic ids."""
+    surfaces = build_goal_surfaces([
+        _record("/redfish/v1/Managers/1/NetworkProtocol", _network_protocol_body()),
+    ])
+
+    ntp_servers = [
+        surface for surface in surfaces
+        if surface.goal_ref.property_path == "NTP.NTPServers"
+    ]
+    assert {surface.target_value for surface in ntp_servers} == {
+        "time-a.example.test",
+        "time-b.example.test",
+    }
+    assert {surface.goal_ref.goal_id for surface in ntp_servers} == {
+        "network.manager_network_protocol.NTP.NTPServers.eq.value",
+    }
+    assert all("time-" not in surface.goal_ref.goal_id for surface in ntp_servers)
+    assert {
+        surface.verifier["target_value"] for surface in ntp_servers
+    } == {"time-a.example.test", "time-b.example.test"}
+
+
+def test_metadata_and_link_leaves_do_not_become_goal_labels() -> None:
+    """Dataset rows avoid identity/link noise while covering real state leaves."""
+    body = {
+        "@odata.id": "/redfish/v1/Managers/1",
+        "@odata.type": "#Manager.v1_16_0.Manager",
+        "Id": "1",
+        "Name": "Manager",
+        "Links": {"ManagerForServers": [{"@odata.id": "/redfish/v1/Systems/1"}]},
+        "Status": {"State": "Enabled", "Health": "OK"},
+    }
+
+    surfaces = build_goal_surfaces([
+        _record("/redfish/v1/Managers/1", body),
+    ])
+
+    paths = {surface.goal_ref.property_path for surface in surfaces}
+    assert "Status.State" in paths
+    assert "Status.Health" in paths
+    assert "@odata.id" not in paths
+    assert "Links.ManagerForServers[].@odata.id" not in paths
+
+
+def test_sensitive_identity_leaves_do_not_become_prompt_labels() -> None:
+    """Secrets and account identity fields are not allowed into LLM prompts."""
+    body = {
+        "@odata.id": "/redfish/v1/AccountService/Accounts/1",
+        "@odata.type": "#ManagerAccount.v1_12_0.ManagerAccount",
+        "UserName": "admin",
+        "Password": "plain-text",
+        "SSHKey": "ssh-rsa AAAA...",
+        "Token": "secret-token",
+        "RoleId": "Administrator",
+        "PermanentMACAddress": "12:34:56:78:90:ab",
+        "HostName": "private-host",
+        "Enabled": True,
+        "Actions": {
+            "#Bios.ChangePassword": {
+                "target": "/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword",
+            }
+        },
+    }
+
+    surfaces = build_goal_surfaces([
+        _record("/redfish/v1/AccountService/Accounts/1", body),
+    ])
+
+    paths = {surface.goal_ref.property_path for surface in surfaces}
+    assert "Enabled" in paths
+    assert "UserName" not in paths
+    assert "Password" not in paths
+    assert "SSHKey" not in paths
+    assert "Token" not in paths
+    assert "RoleId" not in paths
+    assert "PermanentMACAddress" not in paths
+    assert "HostName" not in paths
+    assert all(surface.goal_ref.action_name != "Bios.ChangePassword" for surface in surfaces)
+
+
+def test_boot_server_and_set_ntp_text_has_two_unordered_sub_goals() -> None:
+    """The example x maps to true_y as a set of atomic z_sub_goal targets."""
+    surfaces = build_goal_surfaces([
+        _record("/redfish/v1/Systems/1", _system_body(), vendor="dell"),
+        _record(
+            "/redfish/v1/Managers/1/NetworkProtocol",
+            _network_protocol_body(),
+            vendor="dell",
+        ),
+    ])
+    by_id = {surface.goal_ref.goal_id: surface for surface in surfaces}
+    example = make_goal_text_example(
+        text="boot server and set ntp",
+        goal_refs=[
+            by_id["power.computer_system.PowerState.eq.On"].goal_ref,
+            by_id["network.manager_network_protocol.NTP.ProtocolEnabled.eq.True"].goal_ref,
+        ],
+        text_source="human",
+    )
+
+    assert isinstance(example, GoalTextExample)
+    assert example.text == "boot server and set ntp"
+    assert [ref.goal_id for ref in example.goal_refs] == [
+        "power.computer_system.PowerState.eq.On",
+        "network.manager_network_protocol.NTP.ProtocolEnabled.eq.True",
+    ]
+    assert example.dependencies == ()
+
+
+def test_explicit_then_adds_dependency_hint_without_becoming_a_plan() -> None:
+    """Ordering words create dependency edges, not a concrete action sequence."""
+    surfaces = build_goal_surfaces([
+        _record("/redfish/v1/Systems/1", _system_body()),
+        _record("/redfish/v1/Managers/1/NetworkProtocol", _network_protocol_body()),
+    ])
+    by_id = {surface.goal_ref.goal_id: surface for surface in surfaces}
+    example = make_goal_text_example(
+        text="set ntp then boot server",
+        goal_refs=[
+            by_id["network.manager_network_protocol.NTP.ProtocolEnabled.eq.True"].goal_ref,
+            by_id["power.computer_system.PowerState.eq.On"].goal_ref,
+        ],
+        dependencies=[
+            GoalDependency(
+                before_goal_id="network.manager_network_protocol.NTP.ProtocolEnabled.eq.True",
+                after_goal_id="power.computer_system.PowerState.eq.On",
+                relation="before",
+                evidence="then",
+            )
+        ],
+    )
+
+    assert [ref.goal_id for ref in example.goal_refs] == [
+        "network.manager_network_protocol.NTP.ProtocolEnabled.eq.True",
+        "power.computer_system.PowerState.eq.On",
+    ]
+    assert example.dependencies[0].before_goal_id.startswith("network.")
+    assert example.dependencies[0].after_goal_id.startswith("power.")
+
+
+def test_goal_text_examples_jsonl_round_trip(tmp_path: Path) -> None:
+    """Dataset rows serialize without losing sub-goal IDs or dependency hints."""
+    surfaces = build_goal_surfaces([
+        _record("/redfish/v1/Systems/1", _system_body()),
+        _record("/redfish/v1/Managers/1/NetworkProtocol", _network_protocol_body()),
+    ])
+    by_id = {surface.goal_ref.goal_id: surface for surface in surfaces}
+    example = make_goal_text_example(
+        text="set ntp then boot server",
+        goal_refs=[
+            by_id["network.manager_network_protocol.NTP.ProtocolEnabled.eq.True"].goal_ref,
+            by_id["power.computer_system.PowerState.eq.On"].goal_ref,
+        ],
+        dependencies=[
+            GoalDependency(
+                before_goal_id="network.manager_network_protocol.NTP.ProtocolEnabled.eq.True",
+                after_goal_id="power.computer_system.PowerState.eq.On",
+                relation="before",
+                evidence="then",
+            )
+        ],
+        split="train",
+    )
+
+    path = tmp_path / "goal_text_examples.jsonl"
+    example.write_jsonl(path, [example])
+    (loaded,) = read_goal_text_examples(path)
+
+    assert loaded == example

--- a/tests/ds/test_goal_dataset_builder.py
+++ b/tests/ds/test_goal_dataset_builder.py
@@ -121,6 +121,21 @@ def test_computer_system_record_yields_atomic_power_boot_and_reset_surfaces() ->
     assert reset.goal_ref.arguments == {"ResetType": "GracefulRestart"}
 
 
+def test_same_semantic_goal_keeps_vendor_specific_surfaces() -> None:
+    """Cross-vendor positives must not collapse during surface dedupe."""
+    surfaces = build_goal_surfaces([
+        _record("/redfish/v1/Systems/1", _system_body(), vendor="dell"),
+        _record("/redfish/v1/Systems/1", _system_body(), vendor="hpe"),
+    ])
+
+    power_on_surfaces = [
+        surface for surface in surfaces
+        if surface.goal_ref.goal_id == "power.computer_system.PowerState.eq.On"
+    ]
+
+    assert {surface.vendor for surface in power_on_surfaces} == {"dell", "hpe"}
+
+
 def test_generic_redfish_record_yields_nested_state_and_action_surfaces() -> None:
     """Unknown Redfish resource types still produce state and transition labels."""
     surfaces = build_goal_surfaces([

--- a/tests/ds/test_goal_paraphrases.py
+++ b/tests/ds/test_goal_paraphrases.py
@@ -1,0 +1,177 @@
+"""Offline tests for LLM-generated goal text drafts.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+from igc.ds.goal_dataset import GoalDependency, GoalRef
+from igc.ds.goal_dataset_builder import build_goal_surfaces
+from igc.ds.goal_paraphrases import (
+    StaticParaphraseProvider,
+    build_paraphrase_prompt,
+    generate_goal_text_drafts,
+    generate_goal_text_examples,
+    validate_paraphrase_texts,
+)
+from igc.ds.sources import SourceRecord, TrustLevel
+
+
+def _record(url: str, body: dict) -> SourceRecord:
+    """Build a tiny REAL-tier SourceRecord."""
+    return SourceRecord(url=url, response=body, source="real_test", trust_level=TrustLevel.REAL)
+
+
+def _refs():
+    """Goal refs for power-on and NTP-enable."""
+    surfaces = build_goal_surfaces([
+        _record("/redfish/v1/Systems/1", {
+            "@odata.type": "#ComputerSystem.v1_20_0.ComputerSystem",
+            "PowerState": "Off",
+            "PowerState@Redfish.AllowableValues": ["On", "Off"],
+        }),
+        _record("/redfish/v1/Managers/1/NetworkProtocol", {
+            "@odata.type": "#ManagerNetworkProtocol.v1_10_0.ManagerNetworkProtocol",
+            "NTP": {"ProtocolEnabled": False},
+        }),
+    ])
+    by_id = {surface.goal_ref.goal_id: surface.goal_ref for surface in surfaces}
+    return (
+        by_id["power.computer_system.PowerState.eq.On"],
+        by_id["network.manager_network_protocol.NTP.ProtocolEnabled.eq.True"],
+    )
+
+
+def test_paraphrase_prompt_names_atomic_targets_and_ordering_rule() -> None:
+    """The prompt asks for X only; deterministic code owns Y."""
+    prompt = build_paraphrase_prompt(_refs(), dependencies=())
+
+    assert "atomic sub-goals" in prompt
+    assert "Do not add ordering words" in prompt
+    assert "power.computer_system.PowerState.eq.On" in prompt
+    assert "network.manager_network_protocol.NTP.ProtocolEnabled.eq.True" in prompt
+
+
+def test_paraphrase_prompt_redacts_captured_string_values() -> None:
+    """Raw host/IP/string facts are not sent to the LLM provider."""
+    ref = GoalRef(
+        goal_id="network.manager_network_protocol.NTP.NTPServers.eq.value",
+        family="network",
+        resource_type="manager_network_protocol",
+        property_path="NTP.NTPServers",
+        target_value="time-a.example.test",
+    )
+
+    prompt = build_paraphrase_prompt((ref,), dependencies=())
+
+    assert "time-a.example.test" not in prompt
+    assert "<redacted-string>" in prompt
+    assert "network.manager_network_protocol.NTP.NTPServers.eq.value" in prompt
+
+
+def test_generate_goal_text_drafts_attaches_deterministic_labels_without_validation() -> None:
+    """The bootstrapping path lets the LLM write X but not alter true_y."""
+    refs = _refs()
+    provider = StaticParaphraseProvider([
+        "boot server and set ntp",
+        "boot server and set ntp",
+        "set ntp then boot server",
+    ])
+
+    examples = generate_goal_text_drafts(
+        provider,
+        goal_refs=refs,
+        count=3,
+        text_source="llm_paraphrase",
+    )
+
+    assert [example.text for example in examples] == [
+        "boot server and set ntp",
+        "set ntp then boot server",
+    ]
+    assert examples[0].text == "boot server and set ntp"
+    assert examples[0].text_source == "llm_paraphrase"
+    assert [ref.goal_id for ref in examples[0].goal_refs] == [
+        "power.computer_system.PowerState.eq.On",
+        "network.manager_network_protocol.NTP.ProtocolEnabled.eq.True",
+    ]
+    assert examples[0].dependencies == ()
+    assert examples[0].metadata["validation"] == "llm_generated_unvalidated"
+
+
+def test_generate_goal_text_drafts_preserves_dependency_labels() -> None:
+    """Dependency labels come from deterministic construction, not model text."""
+    refs = _refs()
+    relation = GoalDependency(
+        before_goal_id="network.manager_network_protocol.NTP.ProtocolEnabled.eq.True",
+        after_goal_id="power.computer_system.PowerState.eq.On",
+        relation="before",
+        evidence="then",
+    )
+    provider = StaticParaphraseProvider(["set ntp then boot server"])
+
+    examples = generate_goal_text_drafts(
+        provider,
+        goal_refs=refs,
+        dependencies=(relation,),
+    )
+
+    assert [example.text for example in examples] == ["set ntp then boot server"]
+    assert examples[0].dependencies == (relation,)
+
+
+class _FakeExtraction:
+    """Extractor output shape used by validator tests."""
+
+    def __init__(self, goal_refs, relations):
+        self.atomic_goal_refs = tuple(goal_refs)
+        self.relations = tuple(relations)
+
+
+class _FakeExtractor:
+    """No hardcoded Redfish semantics; tests validation glue only."""
+
+    def __init__(self, goal_refs, relations=()):
+        self.goal_refs = tuple(goal_refs)
+        self.relations = tuple(relations)
+
+    def extract(self, text: str):
+        """Return the configured extraction unless text asks for a mismatch."""
+        if "wrong" in text:
+            return _FakeExtraction(self.goal_refs[:1], ())
+        return _FakeExtraction(self.goal_refs, self.relations)
+
+
+def test_validate_paraphrases_is_optional_and_uses_injected_extractor() -> None:
+    """Later trainer/eval code can validate drafts with a supplied extractor."""
+    refs = _refs()
+    relation = GoalDependency(
+        before_goal_id=refs[0].goal_id,
+        after_goal_id=refs[1].goal_id,
+        relation="before",
+        evidence="then",
+    )
+    extractor = _FakeExtractor(refs, relations=(relation,))
+
+    examples = validate_paraphrase_texts(
+        ["valid text", "wrong text"],
+        extractor=extractor,
+        expected_goal_refs=refs,
+        expected_relations=(relation,),
+    )
+
+    assert [example.text for example in examples] == ["valid text"]
+
+
+def test_generate_goal_text_examples_still_validates_when_extractor_is_supplied() -> None:
+    """The validated path remains available after a trained extractor exists."""
+    refs = _refs()
+    provider = StaticParaphraseProvider(["valid text", "wrong text"])
+    extractor = _FakeExtractor(refs)
+
+    examples = generate_goal_text_examples(
+        provider,
+        extractor=extractor,
+        goal_refs=refs,
+    )
+
+    assert [example.text for example in examples] == ["valid text"]

--- a/tests/ds/test_goal_paraphrases.py
+++ b/tests/ds/test_goal_paraphrases.py
@@ -9,6 +9,7 @@ from igc.ds.goal_dataset_builder import build_goal_surfaces
 from igc.ds.goal_paraphrases import (
     StaticParaphraseProvider,
     build_paraphrase_prompt,
+    generate_template_goal_text_drafts,
     generate_goal_text_drafts,
     generate_goal_text_examples,
     validate_paraphrase_texts,
@@ -96,6 +97,40 @@ def test_generate_goal_text_drafts_attaches_deterministic_labels_without_validat
     ]
     assert examples[0].dependencies == ()
     assert examples[0].metadata["validation"] == "llm_generated_unvalidated"
+
+
+def test_generate_template_goal_text_drafts_creates_endpoint_free_x_rows() -> None:
+    """The inspection dataset can contain X rows without calling a model."""
+    refs = _refs()
+
+    examples = generate_template_goal_text_drafts(refs[:1], count=2)
+
+    assert [example.text for example in examples] == [
+        "set computer system power state to On",
+        "make computer system power state On",
+    ]
+    assert examples[0].goal_refs == refs[:1]
+    assert examples[0].text_source == "template"
+    assert examples[0].metadata["validation"] == "template_generated"
+
+
+def test_generate_template_goal_text_drafts_keeps_multi_argument_actions() -> None:
+    """Action text should not silently drop arguments from true_y labels."""
+    ref = GoalRef(
+        goal_id="action.computer_system.Reset",
+        family="action",
+        resource_type="computer_system",
+        mode="transition",
+        action_name="Reset",
+        arguments={"ResetType": "ForceRestart", "BootSourceOverrideTarget": "Pxe"},
+    )
+
+    examples = generate_template_goal_text_drafts((ref,), count=1)
+
+    assert examples[0].text == (
+        "run reset on computer system setting "
+        "reset type ForceRestart and boot source override target Pxe"
+    )
 
 
 def test_generate_goal_text_drafts_preserves_dependency_labels() -> None:

--- a/tests/modules/test_goal_extractor_encoder.py
+++ b/tests/modules/test_goal_extractor_encoder.py
@@ -1,0 +1,127 @@
+"""Offline tests for GoalExtractor and GoalEncoder public contracts.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import pytest
+
+from igc.ds.goal_dataset import GoalDependency
+from igc.ds.goal_dataset_builder import build_goal_surfaces, make_goal_text_example
+from igc.ds.sources import SourceRecord, TrustLevel
+from igc.modules.goal_encoder import GoalEncoder
+from igc.modules.goal_extractor import (
+    GoalExtraction,
+    GoalExtractor,
+    extraction_from_text_example,
+    parse_goal_extraction,
+)
+
+
+def _record(url: str, body: dict) -> SourceRecord:
+    """Build a tiny REAL-tier SourceRecord."""
+    return SourceRecord(url=url, response=body, source="real_test", trust_level=TrustLevel.REAL)
+
+
+def _refs():
+    """Goal refs for power-on and NTP-enable."""
+    surfaces = build_goal_surfaces([
+        _record("/redfish/v1/Systems/1", {
+            "@odata.type": "#ComputerSystem.v1_20_0.ComputerSystem",
+            "PowerState": "Off",
+            "PowerState@Redfish.AllowableValues": ["On", "Off"],
+        }),
+        _record("/redfish/v1/Managers/1/NetworkProtocol", {
+            "@odata.type": "#ManagerNetworkProtocol.v1_10_0.ManagerNetworkProtocol",
+            "NTP": {"ProtocolEnabled": False},
+        }),
+    ])
+    by_id = {surface.goal_ref.goal_id: surface.goal_ref for surface in surfaces}
+    return (
+        by_id["power.computer_system.PowerState.eq.On"],
+        by_id["network.manager_network_protocol.NTP.ProtocolEnabled.eq.True"],
+    )
+
+
+def test_extraction_from_text_example_preserves_unordered_goal_set() -> None:
+    """Dataset rows become extractor targets without adding an API plan."""
+    refs = _refs()
+    relation = GoalDependency(
+        before_goal_id=refs[1].goal_id,
+        after_goal_id=refs[0].goal_id,
+        relation="before",
+        evidence="then",
+    )
+    example = make_goal_text_example(
+        text="set ntp then boot server",
+        goal_refs=refs,
+        dependencies=(relation,),
+        metadata={"evidence": {"cue": "then"}},
+    )
+
+    extraction = extraction_from_text_example(example)
+
+    assert extraction.text == "set ntp then boot server"
+    assert extraction.atomic_goal_refs == refs
+    assert extraction.relations == (relation,)
+    assert extraction.evidence == {"cue": "then"}
+
+
+def test_goal_extraction_round_trips_json_target_shape() -> None:
+    """The target envelope is JSON-serializable for SFT labels."""
+    refs = _refs()
+    extraction = GoalExtraction(
+        text="boot server and set ntp",
+        atomic_goal_refs=refs,
+        relations=(),
+        evidence={},
+    )
+
+    loaded = parse_goal_extraction(extraction.to_dict())
+
+    assert loaded == extraction
+    assert parse_goal_extraction(extraction.to_dict()).to_dict() == extraction.to_dict()
+
+
+def test_goal_extractor_requires_injected_or_trained_decoder() -> None:
+    """No production fallback parser invents Redfish semantics."""
+    extractor = GoalExtractor()
+
+    with pytest.raises(RuntimeError, match="trained or injected decoder"):
+        extractor.extract("boot server")
+
+
+def test_goal_extractor_uses_injected_decoder_output() -> None:
+    """The wrapper parses trained/injected decoder JSON output."""
+    refs = _refs()
+
+    def decoder(text: str) -> dict:
+        return {
+            "text": text,
+            "atomic_goal_refs": [refs[0].to_dict()],
+            "relations": [],
+            "evidence": {"source": "test"},
+        }
+
+    extraction = GoalExtractor(decoder).extract("turn the server on")
+
+    assert [ref.goal_id for ref in extraction.atomic_goal_refs] == [
+        "power.computer_system.PowerState.eq.On",
+    ]
+    assert extraction.evidence == {"source": "test"}
+
+
+def test_goal_encoder_returns_one_latent_per_atomic_sub_goal() -> None:
+    """Compound examples encode as multiple z_sub_goal values."""
+    refs = _refs()
+    example = make_goal_text_example("boot server and set ntp", goal_refs=refs)
+    encoder = GoalEncoder(dim=4)
+
+    latents = encoder.encode_text_example(example)
+
+    assert [latent.goal_id for latent in latents] == [
+        "power.computer_system.PowerState.eq.On",
+        "network.manager_network_protocol.NTP.ProtocolEnabled.eq.True",
+    ]
+    assert all(len(latent.values) == 4 for latent in latents)
+    assert latents[0].values != latents[1].values

--- a/tests/modules/test_goal_verifier.py
+++ b/tests/modules/test_goal_verifier.py
@@ -1,0 +1,90 @@
+"""Offline tests for concrete goal verification.
+
+The policy can use a latent ``z_sub_goal``, but success is checked against a
+hidden concrete verifier payload and the next observation. These tests keep that
+boundary explicit.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+from igc.ds.goal_dataset import GoalRef, GoalSurface
+from igc.modules.goal_verifier import GoalVerificationResult, GoalVerifier
+
+
+def _surface(goal_id: str, property_path: str, target_value) -> GoalSurface:
+    """Build a tiny state-equality surface."""
+    return GoalSurface(
+        goal_ref=GoalRef(
+            goal_id=goal_id,
+            family="power",
+            resource_type="ComputerSystem",
+            property_path=property_path,
+            operator="eq",
+            target_value=target_value,
+        ),
+        vendor="dell",
+        source="real_dell",
+        resource_uri="/redfish/v1/Systems/1",
+        resource_type="#ComputerSystem.v1_20_0.ComputerSystem",
+        fact_path=property_path,
+        target_value=target_value,
+        current_value="Off",
+        allowed_values=("On", "Off"),
+        verifier={
+            "kind": "state_eq",
+            "resource_uri": "/redfish/v1/Systems/1",
+            "property_path": property_path,
+            "operator": "eq",
+            "target_value": target_value,
+        },
+    )
+
+
+def test_state_eq_verifier_checks_observation_field() -> None:
+    """A matching concrete observation satisfies the hidden goal payload."""
+    verifier = GoalVerifier()
+    surface = _surface("power.computer_system.PowerState.eq.On", "PowerState", "On")
+    observation = {"@odata.id": "/redfish/v1/Systems/1", "PowerState": "On"}
+
+    result = verifier.verify(surface, observation)
+
+    assert result == GoalVerificationResult(
+        satisfied=True,
+        reward=1.0,
+        reason="state_eq",
+        observed_value="On",
+        target_value="On",
+    )
+
+
+def test_state_eq_verifier_rejects_wrong_value() -> None:
+    """HTTP success or latent similarity cannot substitute for measured state."""
+    verifier = GoalVerifier()
+    surface = _surface("power.computer_system.PowerState.eq.On", "PowerState", "On")
+    observation = {"@odata.id": "/redfish/v1/Systems/1", "PowerState": "Off"}
+
+    result = verifier.verify(surface, observation, action_result={"status": 204})
+
+    assert result.satisfied is False
+    assert result.reward == 0.0
+    assert result.observed_value == "Off"
+
+
+def test_state_eq_verifier_reads_nested_paths() -> None:
+    """Nested Redfish paths such as Boot.BootSourceOverrideTarget are supported."""
+    verifier = GoalVerifier()
+    surface = _surface(
+        "boot.computer_system.Boot.BootSourceOverrideTarget.eq.Pxe",
+        "Boot.BootSourceOverrideTarget",
+        "Pxe",
+    )
+    observation = {
+        "@odata.id": "/redfish/v1/Systems/1",
+        "Boot": {"BootSourceOverrideTarget": "Pxe"},
+    }
+
+    result = verifier.verify(surface, observation)
+
+    assert result.satisfied is True
+    assert result.observed_value == "Pxe"

--- a/tests/modules/test_wandb_run_meta.py
+++ b/tests/modules/test_wandb_run_meta.py
@@ -1,8 +1,8 @@
 """Offline tests for _wandb_run_meta (W&B run labelling by curriculum stage).
 
-Pins that a run's spec maps to a legible STAGE (m1 state encoder, m3 goal extractor,
-m6 RL agent) with a readable name, filterable tags, and a config snapshot — so W&B
-shows what stage/model/epochs a run is instead of a random name. Pure logic — no wandb.
+Pins that a run's spec maps to a legible label (m1 state encoder, legacy goal extractor,
+m6 RL agent) with a readable name, filterable tags, and a config snapshot — so W&B shows
+what stage/model/epochs a run is instead of a random name. Pure logic — no wandb.
 
 Author:
 Mus mbayramo@stanford.edu
@@ -25,8 +25,8 @@ def test_m1_state_encoder_labels():
 
 
 def test_goal_extractor_and_rl_stages():
-    """Other selections map to their stages (m3 goal extractor, m6 RL agent)."""
-    assert _wandb_run_meta({"train": "llm", "llm": "goal"})["group"] == "m3-goal-extractor"
+    """Other selections map to their stages (legacy goal extractor, m6 RL agent)."""
+    assert _wandb_run_meta({"train": "llm", "llm": "goal"})["group"] == "goal-extractor-legacy"
     assert _wandb_run_meta({"train": "agent", "rl": "dqn"})["group"] == "m6-rl-agent"
 
 

--- a/tests/scripts/test_build_goal_dataset.py
+++ b/tests/scripts/test_build_goal_dataset.py
@@ -1,0 +1,112 @@
+"""Offline tests for ``scripts/build_goal_dataset.py``.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+from igc.ds.goal_dataset import read_goal_surfaces, read_goal_text_examples
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "build_goal_dataset.py"
+
+
+def _load_script():
+    """Import the script as a module without requiring PYTHONPATH setup."""
+    spec = importlib.util.spec_from_file_location("build_goal_dataset", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_capture(root: Path) -> None:
+    """Write tiny ComputerSystem and ManagerNetworkProtocol captures."""
+    root.mkdir()
+    (root / "_redfish_v1_Systems_1.json").write_text(json.dumps({
+        "@odata.id": "/redfish/v1/Systems/1",
+        "@odata.type": "#ComputerSystem.v1_20_0.ComputerSystem",
+        "PowerState": "Off",
+        "PowerState@Redfish.AllowableValues": ["On", "Off"],
+    }))
+    (root / "_redfish_v1_Managers_1_NetworkProtocol.json").write_text(json.dumps({
+        "@odata.id": "/redfish/v1/Managers/1/NetworkProtocol",
+        "@odata.type": "#ManagerNetworkProtocol.v1_10_0.ManagerNetworkProtocol",
+        "NTP": {"ProtocolEnabled": False},
+    }))
+
+
+def test_build_goal_dataset_writes_surfaces_and_text_drafts(tmp_path: Path) -> None:
+    """CLI builds deterministic Y rows and attaches supplied/generated X rows."""
+    script = _load_script()
+    capture = tmp_path / "capture"
+    _write_capture(capture)
+    surfaces_out = tmp_path / "goal_surfaces.jsonl"
+    text_out = tmp_path / "goal_text_examples.jsonl"
+
+    code = script.main([
+        "--capture-root", str(capture),
+        "--vendor", "dell",
+        "--source", "real_dell",
+        "--surfaces-out", str(surfaces_out),
+        "--text-out", str(text_out),
+        "--paraphrase-mode", "static",
+        "--goal-id", "power.computer_system.PowerState.eq.On",
+        "--goal-id", "network.manager_network_protocol.NTP.ProtocolEnabled.eq.True",
+        "--static-text", "boot server and set ntp",
+        "--static-text", "set ntp then boot server",
+    ])
+
+    assert code == 0
+    surfaces = read_goal_surfaces(surfaces_out)
+    assert {surface.goal_ref.goal_id for surface in surfaces} >= {
+        "power.computer_system.PowerState.eq.On",
+        "network.manager_network_protocol.NTP.ProtocolEnabled.eq.True",
+    }
+    examples = read_goal_text_examples(text_out)
+    assert [example.text for example in examples] == [
+        "boot server and set ntp",
+        "set ntp then boot server",
+    ]
+    example = examples[0]
+    assert [ref.goal_id for ref in example.goal_refs] == [
+        "power.computer_system.PowerState.eq.On",
+        "network.manager_network_protocol.NTP.ProtocolEnabled.eq.True",
+    ]
+    assert example.metadata["validation"] == "llm_generated_unvalidated"
+
+
+def test_build_goal_dataset_can_generate_text_for_every_atomic_goal(
+    tmp_path: Path,
+) -> None:
+    """Lab jobs can ask for X drafts over every discovered atomic GoalRef."""
+    script = _load_script()
+    capture = tmp_path / "capture"
+    _write_capture(capture)
+    surfaces_out = tmp_path / "goal_surfaces.jsonl"
+    text_out = tmp_path / "goal_text_examples.jsonl"
+    manifest_out = tmp_path / "manifest.json"
+
+    code = script.main([
+        "--capture-root", str(capture),
+        "--surfaces-out", str(surfaces_out),
+        "--text-out", str(text_out),
+        "--manifest-out", str(manifest_out),
+        "--paraphrase-mode", "static",
+        "--generate-all-goals",
+        "--count", "1",
+        "--static-text", "generic operator request",
+    ])
+
+    assert code == 0
+    surfaces = read_goal_surfaces(surfaces_out)
+    examples = read_goal_text_examples(text_out)
+    unique_goal_ids = {surface.goal_ref.goal_id for surface in surfaces}
+    assert len(examples) == len(unique_goal_ids)
+    assert {example.goal_refs[0].goal_id for example in examples} == unique_goal_ids
+    manifest = json.loads(manifest_out.read_text())
+    assert manifest["capture_records"] == 2
+    assert manifest["unique_goal_ids"] == len(unique_goal_ids)
+    assert manifest["text_examples"] == len(unique_goal_ids)

--- a/tests/scripts/test_build_goal_dataset.py
+++ b/tests/scripts/test_build_goal_dataset.py
@@ -24,7 +24,7 @@ def _load_script():
 
 def _write_capture(root: Path) -> None:
     """Write tiny ComputerSystem and ManagerNetworkProtocol captures."""
-    root.mkdir()
+    root.mkdir(parents=True)
     (root / "_redfish_v1_Systems_1.json").write_text(json.dumps({
         "@odata.id": "/redfish/v1/Systems/1",
         "@odata.type": "#ComputerSystem.v1_20_0.ComputerSystem",
@@ -110,3 +110,38 @@ def test_build_goal_dataset_can_generate_text_for_every_atomic_goal(
     assert manifest["capture_records"] == 2
     assert manifest["unique_goal_ids"] == len(unique_goal_ids)
     assert manifest["text_examples"] == len(unique_goal_ids)
+
+
+def test_build_goal_dataset_infers_vendor_from_known_redfish_ctl_roots(
+    tmp_path: Path,
+) -> None:
+    """Multi-root lab builds keep vendor provenance for held-out splits."""
+    script = _load_script()
+    redfish_ctl = tmp_path / "redfish_ctl" / "tests"
+    dell = redfish_ctl / "idrac_fixtures"
+    supermicro = redfish_ctl / "supermicro_fixtures"
+    hpe = redfish_ctl / "hpe_fixtures"
+    for root in (dell, supermicro, hpe):
+        _write_capture(root)
+
+    surfaces_out = tmp_path / "goal_surfaces.jsonl"
+    manifest_out = tmp_path / "manifest.json"
+
+    code = script.main([
+        "--capture-root", str(dell),
+        "--capture-root", str(supermicro),
+        "--capture-root", str(hpe),
+        "--source", "full_redfish_corpus",
+        "--surfaces-out", str(surfaces_out),
+        "--manifest-out", str(manifest_out),
+    ])
+
+    assert code == 0
+    manifest = json.loads(manifest_out.read_text())
+    assert manifest["vendors"] == ["dell", "hpe", "supermicro"]
+    surfaces = read_goal_surfaces(surfaces_out)
+    assert {surface.vendor for surface in surfaces} == {
+        "dell",
+        "hpe",
+        "supermicro",
+    }

--- a/tests/scripts/test_build_goal_dataset.py
+++ b/tests/scripts/test_build_goal_dataset.py
@@ -8,6 +8,9 @@ import importlib.util
 import json
 from pathlib import Path
 
+import numpy as np
+import pytest
+
 from igc.ds.goal_dataset import read_goal_surfaces, read_goal_text_examples
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -145,3 +148,105 @@ def test_build_goal_dataset_infers_vendor_from_known_redfish_ctl_roots(
         "hpe",
         "supermicro",
     }
+
+
+def test_build_goal_dataset_vendor_inference_avoids_substring_false_positive() -> None:
+    """A misleading directory name should not silently relabel a capture."""
+    script = _load_script()
+
+    assert script._infer_vendor_from_root("/tmp/not_dell_capture/10.0.0.1") == ""
+    assert script._infer_vendor_from_root("/tmp/hpe_dl360_full_corpus/10.0.0.2") == "hpe"
+
+
+def test_build_goal_dataset_loads_allowed_methods_from_rest_api_map(
+    tmp_path: Path,
+) -> None:
+    """Full corpora keep same-run method maps for action/reward consumers."""
+    script = _load_script()
+    capture = tmp_path / "dell_xr8620t_full_corpus" / "10.0.0.1"
+    _write_capture(capture)
+    (capture / "corpus_manifest.json").write_text(json.dumps({
+        "artifact_type": "full_training",
+        "json_file_count": 2,
+    }))
+    np.save(
+        capture / "rest_api_map.npy",
+        {
+            "url_file_mapping": {
+                "/redfish/v1/Systems/1": "_redfish_v1_Systems_1.json",
+                "/redfish/v1/Managers/1/NetworkProtocol": (
+                    "_redfish_v1_Managers_1_NetworkProtocol.json"
+                ),
+            },
+            "allowed_methods_mapping": {
+                "/redfish/v1/Systems/1": ["GET", "HEAD", "PATCH"],
+                "/redfish/v1/Managers/1/NetworkProtocol": ["GET", "HEAD", "PATCH"],
+            },
+        },
+    )
+    surfaces_out = tmp_path / "goal_surfaces.jsonl"
+
+    code = script.main([
+        "--capture-root", str(capture),
+        "--source", "full_redfish_corpus",
+        "--surfaces-out", str(surfaces_out),
+    ])
+
+    assert code == 0
+    power_surface = next(
+        surface
+        for surface in read_goal_surfaces(surfaces_out)
+        if surface.goal_ref.goal_id == "power.computer_system.PowerState.eq.On"
+    )
+    assert power_surface.vendor == "dell"
+    assert power_surface.provenance["allowed_methods"] == ["GET", "HEAD", "PATCH"]
+
+
+def test_build_goal_dataset_ignores_method_map_without_manifest(tmp_path: Path) -> None:
+    """Do not pickle-load loose rest_api_map.npy files outside full-corpus roots."""
+    script = _load_script()
+    capture = tmp_path / "dell_xr8620t_full_corpus" / "10.0.0.1"
+    _write_capture(capture)
+    np.save(
+        capture / "rest_api_map.npy",
+        {
+            "allowed_methods_mapping": {
+                "/redfish/v1/Systems/1": ["GET", "HEAD", "PATCH"],
+            },
+        },
+    )
+    surfaces_out = tmp_path / "goal_surfaces.jsonl"
+
+    code = script.main([
+        "--capture-root", str(capture),
+        "--source", "full_redfish_corpus",
+        "--surfaces-out", str(surfaces_out),
+    ])
+
+    assert code == 0
+    power_surface = next(
+        surface
+        for surface in read_goal_surfaces(surfaces_out)
+        if surface.goal_ref.goal_id == "power.computer_system.PowerState.eq.On"
+    )
+    assert "allowed_methods" not in power_surface.provenance
+
+
+def test_build_goal_dataset_rejects_non_dict_rest_api_map(tmp_path: Path) -> None:
+    """Malformed full-corpus map payloads fail before writing a dataset."""
+    script = _load_script()
+    capture = tmp_path / "dell_xr8620t_full_corpus" / "10.0.0.1"
+    _write_capture(capture)
+    (capture / "corpus_manifest.json").write_text(json.dumps({
+        "artifact_type": "full_training",
+        "json_file_count": 2,
+    }))
+    np.save(capture / "rest_api_map.npy", ["not", "a", "mapping"])
+    surfaces_out = tmp_path / "goal_surfaces.jsonl"
+
+    with pytest.raises(SystemExit, match="rest_api_map.npy is not a dict"):
+        script.main([
+            "--capture-root", str(capture),
+            "--source", "full_redfish_corpus",
+            "--surfaces-out", str(surfaces_out),
+        ])

--- a/tests/scripts/test_sample_goal_dataset.py
+++ b/tests/scripts/test_sample_goal_dataset.py
@@ -6,7 +6,10 @@ Mus mbayramo@stanford.edu
 
 import importlib.util
 import json
+import tarfile
 from pathlib import Path
+
+import pytest
 
 from igc.ds.goal_dataset import GoalRef, GoalSurface, GoalTextExample
 
@@ -132,3 +135,64 @@ def test_sample_goal_dataset_filters_surface_family(tmp_path: Path, capsys) -> N
     output = capsys.readouterr().out
     assert "network.manager_network_protocol.NTP.ProtocolEnabled.eq.True" in output
     assert "power.computer_system.PowerState.eq.On" not in output
+
+
+def test_sample_goal_dataset_reads_tar_artifact(tmp_path: Path, capsys) -> None:
+    """Committed LFS tarballs can be sampled without manual extraction."""
+    script = _load_script()
+    dataset = tmp_path / "goal_dataset"
+    dataset.mkdir()
+    goal_ref = GoalRef(
+        goal_id="power.computer_system.PowerState.eq.On",
+        family="power",
+        resource_type="computer_system",
+        property_path="PowerState",
+        target_value="On",
+    )
+    surface = GoalSurface(
+        goal_ref=goal_ref,
+        vendor="dell",
+        source="full_redfish_corpus",
+        resource_uri="/redfish/v1/Systems/1",
+        resource_type="#ComputerSystem.v1_20_0.ComputerSystem",
+        fact_path="PowerState",
+        target_value="On",
+    )
+    (dataset / "goal_dataset_manifest.json").write_text(json.dumps({
+        "capture_records": 1,
+        "goal_surfaces": 1,
+        "text_examples": 0,
+        "unique_goal_ids": 1,
+        "vendors": ["dell"],
+    }))
+    _write_jsonl(dataset / "goal_surfaces.jsonl", [surface.to_dict()])
+    _write_jsonl(dataset / "goal_text_examples.jsonl", [])
+    artifact = tmp_path / "goal_dataset.tar.gz"
+    with tarfile.open(artifact, "w:gz") as tar:
+        for name in (
+            "goal_dataset_manifest.json",
+            "goal_surfaces.jsonl",
+            "goal_text_examples.jsonl",
+        ):
+            tar.add(dataset / name, arcname=name)
+
+    code = script.main(["--dataset-tar", str(artifact), "--limit", "1"])
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "vendors: dell" in output
+    assert "power.computer_system.PowerState.eq.On" in output
+
+
+def test_sample_goal_dataset_rejects_tar_link_entries(tmp_path: Path) -> None:
+    """Dataset tar extraction rejects links before writing any files."""
+    script = _load_script()
+    artifact = tmp_path / "unsafe_goal_dataset.tar.gz"
+    with tarfile.open(artifact, "w:gz") as tar:
+        info = tarfile.TarInfo("unsafe-link")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "/tmp"
+        tar.addfile(info)
+
+    with pytest.raises(SystemExit, match="unsafe path in dataset tar"):
+        script.main(["--dataset-tar", str(artifact)])

--- a/tests/scripts/test_sample_goal_dataset.py
+++ b/tests/scripts/test_sample_goal_dataset.py
@@ -1,0 +1,134 @@
+"""Offline tests for ``scripts/sample_goal_dataset.py``.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+from igc.ds.goal_dataset import GoalRef, GoalSurface, GoalTextExample
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "sample_goal_dataset.py"
+
+
+def _load_script():
+    """Import the script as a module without requiring PYTHONPATH setup."""
+    spec = importlib.util.spec_from_file_location("sample_goal_dataset", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    """Write JSON Lines test data."""
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows))
+
+
+def test_sample_goal_dataset_prints_manifest_surfaces_and_text_examples(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """Sampler summarizes a built dataset without printing full verifier payloads."""
+    script = _load_script()
+    goal_ref = GoalRef(
+        goal_id="power.computer_system.PowerState.eq.On",
+        family="power",
+        resource_type="computer_system",
+        property_path="PowerState",
+        target_value="On",
+    )
+    surface = GoalSurface(
+        goal_ref=goal_ref,
+        vendor="dell",
+        source="real_dell",
+        resource_uri="/redfish/v1/Systems/1",
+        resource_type="#ComputerSystem.v1_20_0.ComputerSystem",
+        fact_path="PowerState",
+        target_value="On",
+        current_value="Off",
+        verifier={
+            "kind": "state_eq",
+            "resource_uri": "/redfish/v1/Systems/1",
+            "property_path": "PowerState",
+        },
+    )
+    text = GoalTextExample(
+        text="turn the server on",
+        goal_refs=(goal_ref,),
+        text_source="llm_paraphrase",
+    )
+    dataset = tmp_path / "goal_dataset"
+    dataset.mkdir()
+    (dataset / "goal_dataset_manifest.json").write_text(json.dumps({
+        "capture_records": 1,
+        "goal_surfaces": 1,
+        "text_examples": 1,
+        "unique_goal_ids": 1,
+        "vendors": ["dell"],
+    }))
+    _write_jsonl(dataset / "goal_surfaces.jsonl", [surface.to_dict()])
+    _write_jsonl(dataset / "goal_text_examples.jsonl", [text.to_dict()])
+
+    code = script.main(["--dataset-dir", str(dataset), "--limit", "1"])
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "capture_records: 1" in output
+    assert "goal_surfaces: 1" in output
+    assert "vendors: dell" in output
+    assert "power.computer_system.PowerState.eq.On" in output
+    assert "turn the server on" in output
+    assert "verifier:" not in output
+
+
+def test_sample_goal_dataset_filters_surface_family(tmp_path: Path, capsys) -> None:
+    """Family filters keep local inspection focused."""
+    script = _load_script()
+    dataset = tmp_path / "goal_dataset"
+    dataset.mkdir()
+    refs = [
+        GoalRef(
+            goal_id="power.computer_system.PowerState.eq.On",
+            family="power",
+            resource_type="computer_system",
+            property_path="PowerState",
+            target_value="On",
+        ),
+        GoalRef(
+            goal_id="network.manager_network_protocol.NTP.ProtocolEnabled.eq.True",
+            family="network",
+            resource_type="manager_network_protocol",
+            property_path="NTP.ProtocolEnabled",
+            target_value=True,
+        ),
+    ]
+    rows = [
+        GoalSurface(
+            goal_ref=ref,
+            vendor="hpe",
+            source="real_hpe",
+            resource_uri="/redfish/v1/R",
+            resource_type="#R.v1_0_0.R",
+            fact_path=ref.property_path,
+            target_value=ref.target_value,
+        ).to_dict()
+        for ref in refs
+    ]
+    _write_jsonl(dataset / "goal_surfaces.jsonl", rows)
+
+    code = script.main([
+        "--dataset-dir",
+        str(dataset),
+        "--family",
+        "network",
+        "--limit",
+        "5",
+    ])
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "network.manager_network_protocol.NTP.ProtocolEnabled.eq.True" in output
+    assert "power.computer_system.PowerState.eq.On" not in output


### PR DESCRIPTION
## Summary

- Build the GoalExtractor/GoalEncoder inspection dataset from redfish_ctl full-corpus archives.
- Add the packaged LFS dataset artifact at `datasets/goal_latent_full_corpus.tar.gz`.
- Add sampler support for tar artifacts and harden corpus/dataset tar extraction checks.

## Dataset

- Capture records: 5,451
- Goal surfaces: 47,775
- Unique goal IDs: 11,502
- Text examples: 23,004
- Vendors: Dell, HPE, Supermicro

## Validation

- `pytest -q tests/scripts/test_build_goal_dataset.py tests/ds/test_goal_paraphrases.py tests/scripts/test_sample_goal_dataset.py`
- `ruff check igc/ds/goal_dataset_builder.py igc/ds/goal_paraphrases.py scripts/build_goal_dataset.py scripts/sample_goal_dataset.py tests/scripts/test_build_goal_dataset.py tests/ds/test_goal_paraphrases.py tests/scripts/test_sample_goal_dataset.py`
- `bats tests/bats/build_goal_dataset_lab.bats`
- `shellcheck scripts/build_goal_dataset_lab.sh tests/bats/build_goal_dataset_lab.bats`
- `shfmt -d scripts/build_goal_dataset_lab.sh tests/bats/build_goal_dataset_lab.bats`
- `git diff --cached --check`
