### PR TITLE
Document P0 phase workflow

### DIFF
--- a/docs/P0_PHASE_WORKFLOW.md
+++ b/docs/P0_PHASE_WORKFLOW.md
@@ -1,0 +1,151 @@
+# P0 Phase Workflow
+
+This is the current P0 split for Redfish language-model work. It keeps the immediate pretraining
+goal separate from later goal/argument extraction, so Phase 1 can finish without being blocked by
+Phase 2 and Phase 3 dataset generation.
+
+## Phase 1: Pretrain `model_x`
+
+Purpose: train `model_x` on Redfish JSON reconstruction using full Redfish corpora and same-run
+method maps. This creates the Redfish-aware base model used by later phases.
+
+Deliverables:
+
+- Phase 1 dataset renderer: `x = {rest_api, allowed_methods, json}` and `y_true = {json}`.
+- Causal-LM labels masked over `x` and active only on the `y_true` JSON completion.
+- GPU launch ladder: local/offline unit tests, cheap smoke, short large-model smoke, then full
+  Phase 1 run on the approved multi-node GPU training surface.
+- W&B metrics under `phase1_pretrain/*`, with train/eval/throughput/data/calibration/test
+  subgroups.
+- Checkpoint and evaluation report showing JSON parse rate, exact-match rate, and `@odata.id`
+  match rate.
+
+Acceptance gate:
+
+- Full Redfish JSON pretraining has completed over the approved full corpora, not just fixtures.
+- W&B contains readable Phase 1 plots for loss, perplexity, token accuracy, throughput, JSON
+  validity, exact reconstruction, calibration, and test-time evaluation.
+- The checkpoint and evaluation report are stored in the approved shared model store.
+- The repo receives only reviewed artifact metadata through Git LFS pointers; bulky weights are not
+  copied back into the source tree.
+
+The first serious model profile should use a 7B instruct backbone with rsLoRA unless a smoke gate
+proves that profile cannot run. GPT-2 remains a path smoke only; it is not evidence that the Redfish
+representation is useful.
+
+## Phase 2: Build And Train `D1`
+
+Purpose: after Phase 1, use `model_x` plus a review/judging pass to build `D1`, then fine-tune a
+specialized model that maps operator text and current Redfish context to an ordered `rest_api_list`.
+
+Current P0 scope: mock-dataset plumbing and offline tests only.
+
+Real dataset build waits for the Phase 1 checkpoint. The accepted row shape is:
+
+```json
+{
+  "phase": 2,
+  "dataset": "D1",
+  "task": "text_to_ordered_rest_api_list",
+  "x": {
+    "text": "check the task queue, then list the available computer systems",
+    "json": [],
+    "allowed_methods": {}
+  },
+  "y_true": {
+    "rest_api_list": [
+      "/redfish/v1/TaskService/Tasks",
+      "/redfish/v1/Systems"
+    ]
+  }
+}
+```
+
+Evaluation must report ordered exact match and set match separately.
+W&B metrics live under `phase2_goal_extract/*`, with train/eval/order/throughput/data/calibration/test
+subgroups.
+
+## Phase 3: Method And Argument Extraction
+
+Purpose: after Phase 2, fine-tune a specialized model that maps operator text plus the ordered
+`rest_api_list` to ordered calls with `rest_api`, `allowed_methods`, `method`, and `arguments`.
+
+Current P0 scope: mock-dataset plumbing and offline tests only.
+W&B metrics live under `phase3_argument_extract/*`, with train/eval/order/throughput/data/calibration/test
+subgroups.
+
+The accepted row shape is:
+
+```json
+{
+  "phase": 3,
+  "task": "text_and_rest_api_list_to_calls",
+  "x": {
+    "text": "check the task queue, then list the available computer systems",
+    "rest_api_list": [
+      "/redfish/v1/TaskService/Tasks",
+      "/redfish/v1/Systems"
+    ],
+    "json": [],
+    "allowed_methods": {}
+  },
+  "y_true": {
+    "calls": [
+      {
+        "rest_api": "/redfish/v1/TaskService/Tasks",
+        "allowed_methods": [
+          "GET",
+          "HEAD"
+        ],
+        "method": "GET",
+        "arguments": {}
+      },
+      {
+        "rest_api": "/redfish/v1/Systems",
+        "allowed_methods": [
+          "GET",
+          "HEAD"
+        ],
+        "method": "GET",
+        "arguments": {}
+      }
+    ]
+  }
+}
+```
+
+## Inference Contract
+
+After Phase 2 and Phase 3, a sentence should produce testable JSON:
+
+```json
+{
+  "text": "check the task queue, then list the available computer systems",
+  "ordered_goals": [
+    {
+      "rest_api": "/redfish/v1/TaskService/Tasks",
+      "allowed_methods": [
+        "GET",
+        "HEAD"
+      ],
+      "method": "GET",
+      "arguments": {}
+    },
+    {
+      "rest_api": "/redfish/v1/Systems",
+      "allowed_methods": [
+        "GET",
+        "HEAD"
+      ],
+      "method": "GET",
+      "arguments": {}
+    }
+  ]
+}
+```
+
+Order matters in this JSON. RL can still learn execution strategy, retries, and recovery from the
+environment, but the language pipeline should preserve operator-stated order whenever it is present.
+
+Author:
+Mus mbayramo@stanford.edu

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,11 @@ Reinforce Learner).
 - [GOAL_LATENT_DESIGN.md](GOAL_LATENT_DESIGN.md) — the GoalExtractor and GoalEncoder design:
   atomic sub-goal extraction, latent `z_sub_goal` alignment, hidden verifier payloads, and HER
   relabel boundaries.
+- [P0_PHASE_WORKFLOW.md](P0_PHASE_WORKFLOW.md) — the current Phase 1/2/3 split: Redfish JSON
+  pretraining first, mock-dataset plumbing for ordered REST goal extraction next, and method/argument
+  extraction after that.
+- [phase_1.md](phase_1.md), [phase_2.md](phase_2.md), [phase_3.md](phase_3.md) — concrete dataset
+  row shapes, rendering contracts, W&B metric namespaces, and inference JSON for each phase.
 - [TRAINING_OPTIMIZATION_PLAN.md](TRAINING_OPTIMIZATION_PLAN.md) — the large-model training,
   optimization, and GPU-efficiency roadmap for 3B/7B state-encoder work.
 

--- a/docs/phase_1.md
+++ b/docs/phase_1.md
@@ -1,0 +1,146 @@
+# Phase 1: Redfish JSON Pretraining
+
+Phase 1 trains `model_x` on Redfish JSON reconstruction. This phase does not train goal extraction,
+argument extraction, ordering, rewards, or RL behavior. It only teaches the chosen LLM the shape of
+Redfish resources, URI grammar, method context, and JSON completion.
+
+Names are fixed as follows:
+
+- `model_x`: the chosen base LLM after this Redfish JSON pretraining step.
+- `x`: the input context shown to the model.
+- `y_true`: the exact target JSON the model should emit.
+- `y_pred`: the model output during inference or evaluation.
+- `rest_api`: one concrete Redfish URI.
+- `allowed_methods`: methods from the same discovery run's `rest_api_map.npy`.
+- `json`: full Redfish JSON resource body.
+
+Training is normal causal-LM next-token learning. The rendered prompt contains `x`; labels are
+`-100` over the prompt tokens and actual token IDs over the `y_true` completion tokens. In other
+words, this phase trains:
+
+```text
+P(y_true.json | x.rest_api, x.allowed_methods, x.json)
+```
+
+## JSONL Row
+
+This is the stored shape for one Phase 1 row. The example is a small collection resource; real rows
+come from full Redfish corpora plus the same-run method map.
+
+```json
+{
+  "phase": 1,
+  "task": "redfish_json_reconstruction",
+  "x": {
+    "rest_api": "/redfish/v1/Fabrics/PCIe/Switches",
+    "allowed_methods": [
+      "GET",
+      "HEAD"
+    ],
+    "json": {
+      "@odata.context": "/redfish/v1/$metadata#SwitchCollection.SwitchCollection",
+      "@odata.id": "/redfish/v1/Fabrics/PCIe/Switches",
+      "@odata.type": "#SwitchCollection.SwitchCollection",
+      "Members": [],
+      "Members@odata.count": 0,
+      "Name": "Switch Collection"
+    }
+  },
+  "y_true": {
+    "json": {
+      "@odata.context": "/redfish/v1/$metadata#SwitchCollection.SwitchCollection",
+      "@odata.id": "/redfish/v1/Fabrics/PCIe/Switches",
+      "@odata.type": "#SwitchCollection.SwitchCollection",
+      "Members": [],
+      "Members@odata.count": 0,
+      "Name": "Switch Collection"
+    }
+  }
+}
+```
+
+## Rendered Training Text
+
+The JSONL row can be rendered for a causal LLM like this:
+
+```text
+### REST API
+/redfish/v1/Fabrics/PCIe/Switches
+
+### Allowed Methods
+GET, HEAD
+
+### Redfish JSON Input
+{
+  "@odata.context": "/redfish/v1/$metadata#SwitchCollection.SwitchCollection",
+  "@odata.id": "/redfish/v1/Fabrics/PCIe/Switches",
+  "@odata.type": "#SwitchCollection.SwitchCollection",
+  "Members": [],
+  "Members@odata.count": 0,
+  "Name": "Switch Collection"
+}
+
+### Complete Redfish JSON
+{
+  "@odata.context": "/redfish/v1/$metadata#SwitchCollection.SwitchCollection",
+  "@odata.id": "/redfish/v1/Fabrics/PCIe/Switches",
+  "@odata.type": "#SwitchCollection.SwitchCollection",
+  "Members": [],
+  "Members@odata.count": 0,
+  "Name": "Switch Collection"
+}
+```
+
+`x` is everything before `### Complete Redfish JSON`. `y_true` is the JSON after
+`### Complete Redfish JSON`. The shifted labels should mask the `x` tokens and compute
+cross-entropy only on the `y_true` JSON completion.
+
+## Phase 1 W&B Metrics
+
+Use a dedicated namespace so Phase 1 curves never mix with goal extraction or RL:
+
+- `phase1_pretrain/train/loss`
+- `phase1_pretrain/train/perplexity`
+- `phase1_pretrain/train/optimizer_step`
+- `phase1_pretrain/train/tokens_processed`
+- `phase1_pretrain/eval/loss`
+- `phase1_pretrain/eval/perplexity`
+- `phase1_pretrain/eval/token_accuracy`
+- `phase1_pretrain/eval/top_k_accuracy`
+- `phase1_pretrain/eval/json_parse_rate`
+- `phase1_pretrain/eval/json_exact_match_rate`
+- `phase1_pretrain/eval/odata_id_match_rate`
+- `phase1_pretrain/throughput/train_tokens_per_sec`
+- `phase1_pretrain/throughput/train_samples_per_sec`
+- `phase1_pretrain/throughput/eval_tokens_per_sec`
+- `phase1_pretrain/throughput/eval_samples_per_sec`
+- `phase1_pretrain/data/padding_ratio`
+- `phase1_pretrain/data/mean_sequence_length`
+- `phase1_pretrain/data/max_sequence_length`
+- `phase1_pretrain/calibration/log_prob_per_token`
+- `phase1_pretrain/calibration/ece`
+- `phase1_pretrain/test/latency_sec_p50`
+- `phase1_pretrain/test/latency_sec_p95`
+- `phase1_pretrain/test/memory_peak_mb`
+
+## Acceptance Gate
+
+Phase 1 is accepted only after:
+
+- `model_x` trains on the approved full Redfish corpora, not only fixture data.
+- W&B shows clear Phase 1 loss, perplexity, throughput, reconstruction, and test-time plots.
+- The final checkpoint and evaluation report are in the approved shared model store.
+- The repository stores only reviewed Git LFS artifact pointers or metadata for the checkpoint; raw
+  weights are not copied into the source tree.
+
+## Evaluation
+
+For Phase 1, evaluation should check:
+
+- `y_pred` parses as JSON.
+- `y_pred.json["@odata.id"]` equals `x.rest_api`.
+- `y_pred.json` exactly matches `y_true.json` for exact reconstruction runs.
+- Loss is computed only on `y_true` tokens, not on prompt/context tokens.
+
+Author:
+Mus mbayramo@stanford.edu

--- a/docs/phase_2.md
+++ b/docs/phase_2.md
@@ -25,6 +25,8 @@ separate exact-order accuracy from set-recall.
 
 To build one `D1` row, sample one, two, or three Redfish records from `D0` or the same captured
 corpus. Each sampled record must carry its `rest_api`, full `json`, and `allowed_methods`.
+The following block is an intermediate synthetic-text generation request, not the final stored row:
+`x` is the sampled Redfish context, and `y_pred.text` is the draft operator sentence.
 
 ```json
 {
@@ -201,6 +203,9 @@ Cross-entropy is computed on the target JSON tokens. Evaluation parses `y_pred`,
 - `phase2_goal_extract/test/latency_sec_p50`
 - `phase2_goal_extract/test/latency_sec_p95`
 - `phase2_goal_extract/test/memory_peak_mb`
+
+When Phase 2 moves beyond mock plumbing, its acceptance gate must mirror Phase 1: approved full
+corpora, readable W&B plots, checkpoint/report storage, and reviewed Git LFS artifact metadata.
 
 Author:
 Mus mbayramo@stanford.edu

--- a/docs/phase_2.md
+++ b/docs/phase_2.md
@@ -1,0 +1,206 @@
+# Phase 2: Ordered REST Goal Extraction
+
+Phase 2 builds and trains `D1`, the dataset for extracting Redfish REST goals from an operator
+sentence. `model_x` must already have completed Phase 1 Redfish JSON pretraining.
+
+Names are fixed as follows:
+
+- `D0`: Phase 1 JSON reconstruction data.
+- `D1`: Phase 2 text-to-ordered-REST-goal data.
+- `model_x`: the Phase 1 Redfish-tuned LLM.
+- `x`: the input context shown to the model.
+- `y_true`: the exact target label stored in the dataset.
+- `y_pred`: the model output during inference or evaluation.
+- `rest_api`: one concrete Redfish URI.
+- `rest_api_list`: ordered list of concrete Redfish URIs.
+- `allowed_methods`: methods from the same discovery run's `rest_api_map.npy`.
+- `json`: full Redfish JSON resource body.
+
+Phase 2 output is ordered. If the operator sentence says "check tasks, then check systems", the
+target order is tasks first and systems second. If the sentence has no explicit order, the dataset
+builder still stores a deterministic order and marks that order as weak evidence so evaluation can
+separate exact-order accuracy from set-recall.
+
+## D1 Build Input
+
+To build one `D1` row, sample one, two, or three Redfish records from `D0` or the same captured
+corpus. Each sampled record must carry its `rest_api`, full `json`, and `allowed_methods`.
+
+```json
+{
+  "x": {
+    "task": "produce_human_text_for_ordered_rest_api_list",
+    "json": [
+      {
+        "@odata.context": "/redfish/v1/$metadata#TaskCollection.TaskCollection",
+        "@odata.id": "/redfish/v1/TaskService/Tasks",
+        "@odata.type": "#TaskCollection.TaskCollection",
+        "Description": "Collection of Tasks",
+        "Members": [],
+        "Members@odata.count": 0,
+        "Name": "Task Collection"
+      },
+      {
+        "@odata.context": "/redfish/v1/$metadata#ComputerSystemCollection.ComputerSystemCollection",
+        "@odata.id": "/redfish/v1/Systems",
+        "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+        "Description": "Collection of Computer Systems",
+        "Members": [
+          {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1"
+          }
+        ],
+        "Members@odata.count": 1,
+        "Name": "Computer System Collection"
+      }
+    ],
+    "allowed_methods": {
+      "/redfish/v1/TaskService/Tasks": [
+        "GET",
+        "HEAD"
+      ],
+      "/redfish/v1/Systems": [
+        "GET",
+        "HEAD"
+      ]
+    },
+    "rest_api_list": [
+      "/redfish/v1/TaskService/Tasks",
+      "/redfish/v1/Systems"
+    ]
+  },
+  "y_pred": {
+    "text": "check the task queue, then list the available computer systems"
+  }
+}
+```
+
+`y_pred.text` is only a draft. If `model_x` emits junk text, that text must not enter `D1`. It must
+be cleaned or rejected.
+
+## Review Cleanup And Judge
+
+The generated text should be passed through a review/judge step with the same `json`,
+`allowed_methods`, and ordered `rest_api_list`. The reviewer has two jobs:
+
+1. rewrite the text into a natural operator sentence if needed;
+2. judge whether the sentence asks for all and only the sampled `rest_api_list`, in the intended
+   order when the sentence contains ordering language.
+
+Accepted output becomes the final `D1` row. Rejected output is not used for fine-tuning.
+
+## Final D1 Row
+
+This is the row used to fine-tune text-to-REST-goal extraction:
+
+```json
+{
+  "phase": 2,
+  "dataset": "D1",
+  "task": "text_to_ordered_rest_api_list",
+  "x": {
+    "text": "check the task queue, then list the available computer systems",
+    "json": [
+      {
+        "@odata.context": "/redfish/v1/$metadata#TaskCollection.TaskCollection",
+        "@odata.id": "/redfish/v1/TaskService/Tasks",
+        "@odata.type": "#TaskCollection.TaskCollection",
+        "Description": "Collection of Tasks",
+        "Members": [],
+        "Members@odata.count": 0,
+        "Name": "Task Collection"
+      },
+      {
+        "@odata.context": "/redfish/v1/$metadata#ComputerSystemCollection.ComputerSystemCollection",
+        "@odata.id": "/redfish/v1/Systems",
+        "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+        "Description": "Collection of Computer Systems",
+        "Members": [
+          {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1"
+          }
+        ],
+        "Members@odata.count": 1,
+        "Name": "Computer System Collection"
+      }
+    ],
+    "allowed_methods": {
+      "/redfish/v1/TaskService/Tasks": [
+        "GET",
+        "HEAD"
+      ],
+      "/redfish/v1/Systems": [
+        "GET",
+        "HEAD"
+      ]
+    }
+  },
+  "y_true": {
+    "rest_api_list": [
+      "/redfish/v1/TaskService/Tasks",
+      "/redfish/v1/Systems"
+    ],
+    "order_evidence": "explicit_then"
+  },
+  "validation": {
+    "text_source": "model_x_then_review",
+    "review_judged": true,
+    "all_rest_api_present": true,
+    "extra_rest_api_present": false,
+    "order_preserved": true
+  }
+}
+```
+
+## Fine-Tuning Target
+
+The rendered training target is canonical JSON:
+
+```json
+{
+  "rest_api_list": [
+    "/redfish/v1/TaskService/Tasks",
+    "/redfish/v1/Systems"
+  ]
+}
+```
+
+Cross-entropy is computed on the target JSON tokens. Evaluation parses `y_pred`, reads
+`y_pred.rest_api_list`, and reports both ordered exact match and set match.
+
+## Phase 2 W&B Metrics
+
+- `phase2_goal_extract/train/loss`
+- `phase2_goal_extract/train/perplexity`
+- `phase2_goal_extract/train/optimizer_step`
+- `phase2_goal_extract/eval/loss`
+- `phase2_goal_extract/eval/perplexity`
+- `phase2_goal_extract/eval/token_accuracy`
+- `phase2_goal_extract/eval/ordered_exact_match_rate`
+- `phase2_goal_extract/eval/set_match_rate`
+- `phase2_goal_extract/eval/precision`
+- `phase2_goal_extract/eval/recall`
+- `phase2_goal_extract/eval/f1`
+- `phase2_goal_extract/eval/top_k_api_accuracy`
+- `phase2_goal_extract/eval/invalid_api_rate`
+- `phase2_goal_extract/eval/missing_required_api_rate`
+- `phase2_goal_extract/eval/missing_allowed_methods_rate`
+- `phase2_goal_extract/eval/order_violation_rate`
+- `phase2_goal_extract/order/kendall_tau`
+- `phase2_goal_extract/order/edit_distance`
+- `phase2_goal_extract/throughput/train_tokens_per_sec`
+- `phase2_goal_extract/throughput/train_samples_per_sec`
+- `phase2_goal_extract/throughput/eval_tokens_per_sec`
+- `phase2_goal_extract/throughput/eval_samples_per_sec`
+- `phase2_goal_extract/data/avg_num_apis`
+- `phase2_goal_extract/data/max_num_apis`
+- `phase2_goal_extract/data/mean_sequence_length`
+- `phase2_goal_extract/data/padding_ratio`
+- `phase2_goal_extract/calibration/log_prob_per_sequence`
+- `phase2_goal_extract/calibration/ece`
+- `phase2_goal_extract/test/latency_sec_p50`
+- `phase2_goal_extract/test/latency_sec_p95`
+- `phase2_goal_extract/test/memory_peak_mb`
+
+Author:
+Mus mbayramo@stanford.edu

--- a/docs/phase_3.md
+++ b/docs/phase_3.md
@@ -1,0 +1,208 @@
+# Phase 3: Ordered Method And Argument Extraction
+
+Phase 3 fine-tunes argument extraction. It starts from accepted `D1` rows. Given operator text and
+the ordered `rest_api_list` from Phase 2, the model must produce the method and arguments for each
+`rest_api` in the same order.
+
+Names are fixed as follows:
+
+- `D1`: Phase 2 text-to-ordered-REST-goal data.
+- `model_x`: the Phase 1 Redfish-tuned LLM, cloned or continued for this fine-tune.
+- `x`: the input context shown to the model.
+- `y_true`: the exact target label stored in the dataset.
+- `y_pred`: the model output during inference or evaluation.
+- `rest_api`: one concrete Redfish URI.
+- `rest_api_list`: ordered list of concrete Redfish URIs from `D1`.
+- `method`: the selected HTTP method for a `rest_api`.
+- `allowed_methods`: methods from the same discovery run's `rest_api_map.npy`.
+- `arguments`: request body or action arguments; `{}` means no arguments.
+- `json`: full Redfish JSON resource body.
+
+Phase 3 does not choose new REST APIs. It fills `method` and `arguments` for the ordered
+`rest_api_list` already produced by Phase 2.
+
+## Phase 3 Row From D1
+
+This example continues the accepted `D1` row from Phase 2. Both resources are read-only checks with
+`GET` and `HEAD` allowed, so the correct method is `GET` and `arguments` is empty for each one.
+
+```json
+{
+  "phase": 3,
+  "task": "text_and_rest_api_list_to_calls",
+  "x": {
+    "text": "check the task queue, then list the available computer systems",
+    "rest_api_list": [
+      "/redfish/v1/TaskService/Tasks",
+      "/redfish/v1/Systems"
+    ],
+    "json": [
+      {
+        "@odata.context": "/redfish/v1/$metadata#TaskCollection.TaskCollection",
+        "@odata.id": "/redfish/v1/TaskService/Tasks",
+        "@odata.type": "#TaskCollection.TaskCollection",
+        "Description": "Collection of Tasks",
+        "Members": [],
+        "Members@odata.count": 0,
+        "Name": "Task Collection"
+      },
+      {
+        "@odata.context": "/redfish/v1/$metadata#ComputerSystemCollection.ComputerSystemCollection",
+        "@odata.id": "/redfish/v1/Systems",
+        "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+        "Description": "Collection of Computer Systems",
+        "Members": [
+          {
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1"
+          }
+        ],
+        "Members@odata.count": 1,
+        "Name": "Computer System Collection"
+      }
+    ],
+    "allowed_methods": {
+      "/redfish/v1/TaskService/Tasks": [
+        "GET",
+        "HEAD"
+      ],
+      "/redfish/v1/Systems": [
+        "GET",
+        "HEAD"
+      ]
+    }
+  },
+  "y_true": {
+    "calls": [
+      {
+        "rest_api": "/redfish/v1/TaskService/Tasks",
+        "allowed_methods": [
+          "GET",
+          "HEAD"
+        ],
+        "method": "GET",
+        "arguments": {}
+      },
+      {
+        "rest_api": "/redfish/v1/Systems",
+        "allowed_methods": [
+          "GET",
+          "HEAD"
+        ],
+        "method": "GET",
+        "arguments": {}
+      }
+    ]
+  }
+}
+```
+
+`y_true.calls` preserves the order from `x.rest_api_list`. Evaluation parses `y_pred.calls` and
+checks ordered exact match plus per-call `method` and canonical `arguments`.
+
+## Non-Empty Arguments
+
+For a write/action resource, Phase 3 uses the same shape. The only difference is that `arguments`
+contains the request body or action parameters. A non-empty argument row is accepted only when the
+sampled JSON and method evidence support it: for example an action target with
+`@Redfish.ActionInfo`, inline `@Redfish.AllowableValues`, a settings resource, or a recorded
+successful write.
+
+The target shape remains:
+
+```json
+{
+  "y_true": {
+    "calls": [
+      {
+        "rest_api": "/redfish/v1/example/action/target",
+        "allowed_methods": [
+          "POST"
+        ],
+        "method": "POST",
+        "arguments": {
+          "ExampleArgument": "ExampleAllowedValue"
+        }
+      }
+    ]
+  }
+}
+```
+
+Do not create mutation arguments from arbitrary scalar values in `json`. A value observed in a GET
+body is not proof that the resource accepts that value in a PATCH or POST body.
+
+## Phase 3 W&B Metrics
+
+- `phase3_argument_extract/train/loss`
+- `phase3_argument_extract/train/perplexity`
+- `phase3_argument_extract/train/optimizer_step`
+- `phase3_argument_extract/eval/loss`
+- `phase3_argument_extract/eval/perplexity`
+- `phase3_argument_extract/eval/token_accuracy`
+- `phase3_argument_extract/eval/call_ordered_exact_match_rate`
+- `phase3_argument_extract/eval/call_order_correct_rate`
+- `phase3_argument_extract/eval/step_exact_match_rate`
+- `phase3_argument_extract/eval/rest_api_exact_match_rate`
+- `phase3_argument_extract/eval/allowed_methods_exact_match_rate`
+- `phase3_argument_extract/eval/method_exact_match_rate`
+- `phase3_argument_extract/eval/arguments_json_parse_rate`
+- `phase3_argument_extract/eval/arguments_exact_match_rate`
+- `phase3_argument_extract/eval/invalid_method_rate`
+- `phase3_argument_extract/eval/readonly_empty_arguments_rate`
+- `phase3_argument_extract/order/kendall_tau`
+- `phase3_argument_extract/order/edit_distance`
+- `phase3_argument_extract/throughput/train_tokens_per_sec`
+- `phase3_argument_extract/throughput/train_samples_per_sec`
+- `phase3_argument_extract/throughput/eval_tokens_per_sec`
+- `phase3_argument_extract/throughput/eval_samples_per_sec`
+- `phase3_argument_extract/data/avg_num_calls`
+- `phase3_argument_extract/data/avg_arguments_length`
+- `phase3_argument_extract/data/mean_sequence_length`
+- `phase3_argument_extract/data/padding_ratio`
+- `phase3_argument_extract/calibration/log_prob_per_call`
+- `phase3_argument_extract/calibration/ece_method`
+- `phase3_argument_extract/test/latency_sec_p50`
+- `phase3_argument_extract/test/latency_sec_p95`
+- `phase3_argument_extract/test/memory_peak_mb`
+
+## Inference Handoff
+
+At normal inference time the chain is:
+
+1. Phase 2 receives operator text plus current Redfish JSON/method context and emits an ordered
+   `rest_api_list`.
+2. Phase 3 receives the same text plus ordered `rest_api_list` and emits one ordered call per
+   `rest_api`.
+3. RL receives the ordered REST goals and can still learn environment strategy, retries, recovery,
+   and consequences from state transitions.
+
+The combined inference JSON should be easy to test:
+
+```json
+{
+  "text": "check the task queue, then list the available computer systems",
+  "ordered_goals": [
+    {
+      "rest_api": "/redfish/v1/TaskService/Tasks",
+      "allowed_methods": [
+        "GET",
+        "HEAD"
+      ],
+      "method": "GET",
+      "arguments": {}
+    },
+    {
+      "rest_api": "/redfish/v1/Systems",
+      "allowed_methods": [
+        "GET",
+        "HEAD"
+      ],
+      "method": "GET",
+      "arguments": {}
+    }
+  ]
+}
+```
+
+Author:
+Mus mbayramo@stanford.edu

--- a/docs/phase_3.md
+++ b/docs/phase_3.md
@@ -165,6 +165,9 @@ body is not proof that the resource accepts that value in a PATCH or POST body.
 - `phase3_argument_extract/test/latency_sec_p95`
 - `phase3_argument_extract/test/memory_peak_mb`
 
+When Phase 3 moves beyond mock plumbing, its acceptance gate must mirror Phase 1: approved full
+corpora, readable W&B plots, checkpoint/report storage, and reviewed Git LFS artifact metadata.
+
 ## Inference Handoff
 
 At normal inference time the chain is:


### PR DESCRIPTION
## Summary
- Add a P0 workflow doc that splits Phase 1 Redfish JSON pretraining from Phase 2/3 mock-dataset plumbing.
- Add concrete Phase 1/2/3 dataset row shapes, ordered inference contracts, and W&B metric namespaces.
- Link the phase docs from docs/README.md.

## Checks
- git diff --check -- docs/P0_PHASE_WORKFLOW.md docs/phase_1.md docs/phase_2.md docs/phase_3.md docs/README.md
- grep public-safety marker scan on changed docs: no matches