### PR TITLE
Add Phase 1 corpus pretraining objective

### DIFF
--- a/igc/ds/corpus_dataset.py
+++ b/igc/ds/corpus_dataset.py
@@ -268,6 +268,9 @@ class CorpusJSONLDataset(Dataset):
     def mask_arrays(self, *args, **kwargs) -> None:
         """No-op masking hook (see :meth:`enable_masking`)."""
 
+    def mask_api_prefix(self, *args, **kwargs) -> None:
+        """No-op masking hook (see :meth:`enable_masking`)."""
+
     # --- torch Dataset -------------------------------------------------------------
 
     def __len__(self) -> int:

--- a/igc/ds/corpus_dataset.py
+++ b/igc/ds/corpus_dataset.py
@@ -24,13 +24,19 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional, Sequence
 
 import torch
 from torch.utils.data import Dataset
 
 from igc.ds.sources.corpus_io import iter_examples, read_manifest
 from igc.ds.sources.mixer import DataManifest
+from igc.modules.base.metric_keys import PHASE1_PRETRAIN
+
+
+LEGACY_OBJECTIVE = "legacy"
+PHASE1_PRETRAIN_OBJECTIVE = PHASE1_PRETRAIN
+CORPUS_OBJECTIVES = (LEGACY_OBJECTIVE, PHASE1_PRETRAIN_OBJECTIVE)
 
 
 class CorpusJSONLDataset(Dataset):
@@ -48,11 +54,17 @@ class CorpusJSONLDataset(Dataset):
                  corpus_dir: str,
                  default_tokenize: Optional[str] = "gpt2",
                  max_len: Optional[int] = 1024,
-                 tokenizer: Optional[Any] = None):
+                 tokenizer: Optional[Any] = None,
+                 objective: str = LEGACY_OBJECTIVE):
         self._corpus_dir = os.path.abspath(os.path.expanduser(corpus_dir))
         self._default_tokenize = default_tokenize
         self._max_len = max_len
         self._tokenizer = tokenizer
+        self.objective = objective
+        if objective not in CORPUS_OBJECTIVES:
+            raise ValueError(
+                f"unknown corpus objective {objective!r}; choose from {CORPUS_OBJECTIVES}")
+        self.metric_namespace = PHASE1_PRETRAIN if objective == PHASE1_PRETRAIN_OBJECTIVE else ""
 
         examples_path = os.path.join(self._corpus_dir, "examples.jsonl")
         if not os.path.isfile(examples_path):
@@ -65,15 +77,10 @@ class CorpusJSONLDataset(Dataset):
         self._data: List[Dict[str, torch.Tensor]] = []
         tok = self.tokenizer
         for example in iter_examples(examples_path):
-            action = example.get("request_or_action", {}) or {}
-            text = (f"{action.get('method', 'GET')} {action.get('url', '')}\n"
-                    f"{json.dumps(example.get('response', {}), sort_keys=True)}")
-            out = tok(text, padding="max_length", max_length=self._max_len,
-                      truncation=True, return_tensors="pt")
-            self._data.append({
-                "input_ids": out["input_ids"].squeeze(0),
-                "attention_mask": out["attention_mask"].squeeze(0),
-            })
+            if objective == PHASE1_PRETRAIN_OBJECTIVE:
+                self._data.append(self._phase1_item(tok, example))
+            else:
+                self._data.append(self._legacy_item(tok, example))
 
     # --- tokenizer surface (mirrors JSONDataset) ---------------------------------
 
@@ -91,6 +98,128 @@ class CorpusJSONLDataset(Dataset):
             self._tokenizer = AutoTokenizer.from_pretrained(self._default_tokenize)
         if self._tokenizer.pad_token is None:
             self._tokenizer.pad_token = self._tokenizer.eos_token
+
+    # --- render/tokenize objectives ------------------------------------------------
+
+    def _legacy_item(self, tok: Any, example: Mapping[str, Any]) -> Dict[str, torch.Tensor]:
+        """Render the historical whole-text objective for backward compatibility."""
+        action = example.get("request_or_action", {}) or {}
+        text = (f"{action.get('method', 'GET')} {action.get('url', '')}\n"
+                f"{json.dumps(example.get('response', {}), sort_keys=True)}")
+        out = tok(text, padding="max_length", max_length=self._max_len,
+                  truncation=True, return_tensors="pt")
+        return {
+            "input_ids": out["input_ids"].squeeze(0).long(),
+            "attention_mask": out["attention_mask"].squeeze(0).long(),
+        }
+
+    def _phase1_item(self, tok: Any, example: Mapping[str, Any]) -> Dict[str, torch.Tensor]:
+        """Render Phase 1 as prompt context plus JSON completion labels."""
+        rest_api, allowed_methods, input_json, target_json = self._phase1_fields(example)
+        allowed = ", ".join(allowed_methods) if allowed_methods else "UNKNOWN"
+        prompt = (
+            "### REST API\n"
+            f"{rest_api}\n\n"
+            "### Allowed Methods\n"
+            f"{allowed}\n\n"
+            "### Redfish JSON Input\n"
+            f"{self._json_dumps(input_json)}\n\n"
+            "### Complete Redfish JSON\n"
+        )
+        completion = f"{self._json_dumps(target_json)}\n"
+        return self._tokenize_prompt_completion(tok, prompt, completion)
+
+    def _tokenize_prompt_completion(
+            self, tok: Any, prompt: str, completion: str) -> Dict[str, torch.Tensor]:
+        """Tokenize prompt/completion and mask loss over prompt + padding."""
+        prompt_ids = self._token_ids(tok, prompt)
+        completion_ids = self._token_ids(tok, completion)
+        max_len = int(self._max_len or (prompt_ids.numel() + completion_ids.numel()))
+
+        if max_len < 2:
+            raise ValueError("phase1_pretrain requires max_len >= 2")
+
+        # Keep at least one prompt token when there is prompt context, and at least
+        # one completion token. All-ignored rows can produce NaN CausalLM loss, and
+        # prompt-free truncation would turn the objective into unconditional JSON LM.
+        max_completion = max_len - 1 if prompt_ids.numel() > 0 else max_len
+        completion_budget = min(max(1, completion_ids.numel()), max_completion)
+        prompt_budget = max_len - completion_budget
+        # Preserve the prompt tail because it carries the "complete JSON" marker
+        # immediately before the completion. Keeping the head would leave the model
+        # with context but no clear generation boundary on long Redfish resources.
+        prompt_ids = prompt_ids[-prompt_budget:] if prompt_budget else prompt_ids[:0]
+        completion_ids = completion_ids[:completion_budget]
+
+        input_ids = torch.cat((prompt_ids, completion_ids)).long()
+        attention_mask = torch.ones_like(input_ids, dtype=torch.long)
+        labels = torch.full_like(input_ids, -100)
+        # Labels stay unshifted: Hugging Face CausalLM shifts logits/labels
+        # internally, so completion-token positions carry their own ids here.
+        labels[prompt_ids.numel():] = completion_ids
+
+        if input_ids.numel() < max_len:
+            pad_id = int(getattr(tok, "pad_token_id", 0) or 0)
+            pad_len = max_len - input_ids.numel()
+            input_ids = torch.cat((input_ids, torch.full((pad_len,), pad_id, dtype=torch.long)))
+            attention_mask = torch.cat((attention_mask, torch.zeros(pad_len, dtype=torch.long)))
+            labels = torch.cat((labels, torch.full((pad_len,), -100, dtype=torch.long)))
+
+        return {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "labels": labels,
+        }
+
+    @staticmethod
+    def _token_ids(tok: Any, text: str) -> torch.Tensor:
+        """Return unpadded token ids for ``text``."""
+        try:
+            out = tok(text, padding=False, truncation=False, return_tensors="pt",
+                      add_special_tokens=False)
+        except TypeError:
+            out = tok(text, padding=False, truncation=False, return_tensors="pt")
+        return out["input_ids"].squeeze(0).long()
+
+    @staticmethod
+    def _phase1_fields(
+            example: Mapping[str, Any]) -> tuple[str, List[str], Dict[str, Any], Dict[str, Any]]:
+        """Extract Phase 1 ``x``/``y_true`` from explicit or normalized corpus rows."""
+        x = example.get("x")
+        y_true = example.get("y_true")
+        if isinstance(x, Mapping) and isinstance(y_true, Mapping):
+            input_json = x.get("json", {})
+            target_json = y_true.get("json", input_json)
+            rest_api = str(x.get("rest_api") or CorpusJSONLDataset._odata_id(input_json))
+            methods = CorpusJSONLDataset._methods(x.get("allowed_methods", []))
+            return rest_api, methods, dict(input_json), dict(target_json)
+
+        action = example.get("request_or_action", {}) or {}
+        response = example.get("response", {}) or {}
+        rest_api = str(action.get("url") or CorpusJSONLDataset._odata_id(response))
+        methods = CorpusJSONLDataset._methods(example.get("allowed_methods", []))
+        return rest_api, methods, dict(response), dict(response)
+
+    @staticmethod
+    def _methods(value: Any) -> List[str]:
+        """Normalize an allowed-method field to uppercase strings."""
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        if not isinstance(value, Sequence):
+            return []
+        return [str(method).upper() for method in value]
+
+    @staticmethod
+    def _odata_id(body: Any) -> str:
+        """Best-effort ``@odata.id`` extraction from a JSON body."""
+        return str(body.get("@odata.id", "")) if isinstance(body, Mapping) else ""
+
+    @staticmethod
+    def _json_dumps(value: Any) -> str:
+        """Stable pretty JSON rendering used by Phase 1/2/3 renderers."""
+        return json.dumps(value or {}, indent=2, sort_keys=True)
 
     # --- provenance for run reports -----------------------------------------------
 

--- a/igc/ds/corpus_dataset.py
+++ b/igc/ds/corpus_dataset.py
@@ -134,6 +134,8 @@ class CorpusJSONLDataset(Dataset):
         """Tokenize prompt/completion and mask loss over prompt + padding."""
         prompt_ids = self._token_ids(tok, prompt)
         completion_ids = self._token_ids(tok, completion)
+        if completion_ids.numel() == 0:
+            raise ValueError("phase1_pretrain completion tokenized to zero tokens")
         max_len = int(self._max_len or (prompt_ids.numel() + completion_ids.numel()))
 
         if max_len < 2:
@@ -178,6 +180,11 @@ class CorpusJSONLDataset(Dataset):
             out = tok(text, padding=False, truncation=False, return_tensors="pt",
                       add_special_tokens=False)
         except TypeError:
+            encode = getattr(tok, "encode", None)
+            if callable(encode):
+                ids = encode(text, add_special_tokens=False)
+                ids_tensor = torch.as_tensor(ids, dtype=torch.long)
+                return ids_tensor.squeeze(0) if ids_tensor.dim() > 1 else ids_tensor
             out = tok(text, padding=False, truncation=False, return_tensors="pt")
         return out["input_ids"].squeeze(0).long()
 

--- a/igc/modules/base/metric_keys.py
+++ b/igc/modules/base/metric_keys.py
@@ -1,0 +1,78 @@
+"""Shared metric-key registry for staged IGC training.
+
+Used by offline tests, launch code, and phase docs to keep Phase 1, Phase 2, and
+Phase 3 metric names aligned with the existing ``MetricLogger`` / ``metric_factory``
+path. This module defines strings only; it does not import W&B or open a live run.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+PHASE1_PRETRAIN = "phase1_pretrain"
+PHASE2_GOAL_EXTRACT = "phase2_goal_extract"
+PHASE3_ARGUMENT_EXTRACT = "phase3_argument_extract"
+
+
+def phase_metric(namespace: str, group: str, name: str) -> str:
+    """Return a stable ``<namespace>/<group>/<name>`` metric key.
+
+    :param namespace: Phase namespace, for example :data:`PHASE1_PRETRAIN`.
+    :param group: Metric group such as ``train`` or ``eval``.
+    :param name: Metric name inside the group.
+    :return: Slash-separated W&B/TensorBoard metric key.
+    :raises ValueError: if any component is empty.
+    """
+    if not namespace or not group or not name:
+        raise ValueError("metric namespace, group, and name must be non-empty")
+    return f"{namespace}/{group}/{name}"
+
+
+PHASE1_WANDB_METRIC_KEYS = (
+    phase_metric(PHASE1_PRETRAIN, "train", "loss"),
+    phase_metric(PHASE1_PRETRAIN, "train", "epoch_loss"),
+    phase_metric(PHASE1_PRETRAIN, "train", "perplexity"),
+    phase_metric(PHASE1_PRETRAIN, "train", "epoch_perplexity"),
+    phase_metric(PHASE1_PRETRAIN, "train", "optimizer_step"),
+    phase_metric(PHASE1_PRETRAIN, "train", "tokens_processed"),
+    phase_metric(PHASE1_PRETRAIN, "eval", "loss"),
+    phase_metric(PHASE1_PRETRAIN, "eval", "perplexity"),
+    phase_metric(PHASE1_PRETRAIN, "eval", "token_accuracy"),
+    phase_metric(PHASE1_PRETRAIN, "eval", "json_parse_rate"),
+    phase_metric(PHASE1_PRETRAIN, "eval", "json_exact_match_rate"),
+    phase_metric(PHASE1_PRETRAIN, "eval", "odata_id_match_rate"),
+    phase_metric(PHASE1_PRETRAIN, "throughput", "train_tokens_per_sec"),
+    phase_metric(PHASE1_PRETRAIN, "throughput", "train_samples_per_sec"),
+    phase_metric(PHASE1_PRETRAIN, "data", "padding_ratio"),
+)
+
+PHASE2_WANDB_METRIC_KEYS = (
+    phase_metric(PHASE2_GOAL_EXTRACT, "train", "loss"),
+    phase_metric(PHASE2_GOAL_EXTRACT, "train", "perplexity"),
+    phase_metric(PHASE2_GOAL_EXTRACT, "train", "optimizer_step"),
+    phase_metric(PHASE2_GOAL_EXTRACT, "eval", "ordered_exact_match_rate"),
+    phase_metric(PHASE2_GOAL_EXTRACT, "eval", "set_match_rate"),
+    phase_metric(PHASE2_GOAL_EXTRACT, "eval", "precision"),
+    phase_metric(PHASE2_GOAL_EXTRACT, "eval", "recall"),
+    phase_metric(PHASE2_GOAL_EXTRACT, "eval", "f1"),
+    phase_metric(PHASE2_GOAL_EXTRACT, "eval", "missing_allowed_methods_rate"),
+    phase_metric(PHASE2_GOAL_EXTRACT, "order", "kendall_tau"),
+    phase_metric(PHASE2_GOAL_EXTRACT, "order", "edit_distance"),
+)
+
+PHASE3_WANDB_METRIC_KEYS = (
+    phase_metric(PHASE3_ARGUMENT_EXTRACT, "train", "loss"),
+    phase_metric(PHASE3_ARGUMENT_EXTRACT, "train", "perplexity"),
+    phase_metric(PHASE3_ARGUMENT_EXTRACT, "train", "optimizer_step"),
+    phase_metric(PHASE3_ARGUMENT_EXTRACT, "eval", "call_ordered_exact_match_rate"),
+    phase_metric(PHASE3_ARGUMENT_EXTRACT, "eval", "method_exact_match_rate"),
+    phase_metric(PHASE3_ARGUMENT_EXTRACT, "eval", "arguments_exact_match_rate"),
+    phase_metric(PHASE3_ARGUMENT_EXTRACT, "eval", "readonly_empty_arguments_rate"),
+    phase_metric(PHASE3_ARGUMENT_EXTRACT, "order", "kendall_tau"),
+    phase_metric(PHASE3_ARGUMENT_EXTRACT, "order", "edit_distance"),
+)
+
+PHASE23_WANDB_METRIC_KEYS = PHASE2_WANDB_METRIC_KEYS + PHASE3_WANDB_METRIC_KEYS
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/igc/modules/igc_main.py
+++ b/igc/modules/igc_main.py
@@ -157,13 +157,10 @@ class IgcMain:
 
         :return:
         """
-        self._dataset = MaskedJSONDataset(
-            self._dataset_dir,
-            default_tokenize=self._specs.model_type,
-            max_len=self._specs.seq_len,
-            recreate_dataset=self._specs.recreate_dataset,
-            do_consistency_check=self._specs.do_consistency_check
-        )
+        # Initialize the selected dataset once through the property so --corpus_dir
+        # can choose the written corpus path instead of eagerly rebuilding the
+        # legacy MaskedJSONDataset before train()/test/copy paths run.
+        _ = self.dataset
 
         # copy last checkpoint as last model with opt etc. so we can use it.
         if self._specs.copy_llm:

--- a/igc/modules/igc_main.py
+++ b/igc/modules/igc_main.py
@@ -91,6 +91,7 @@ class IgcMain:
                     corpus_dir,
                     default_tokenize=self._specs.model_type,
                     max_len=self._specs.seq_len,
+                    objective=getattr(self._specs, "corpus_objective", "legacy"),
                 )
             else:
                 self._dataset = MaskedJSONDataset(

--- a/igc/modules/llm_train_state_encoder.py
+++ b/igc/modules/llm_train_state_encoder.py
@@ -293,7 +293,10 @@ class LlmEmbeddingsTrainer(LlmModule):
     def _has_prompt_masked_labels(sample) -> bool:
         """Whether a sample carries Phase 1 prompt-masked CausalLM labels."""
         labels = sample.get("labels")
-        return torch.is_tensor(labels) and labels.eq(-100).any().item()
+        if not torch.is_tensor(labels):
+            return False
+        active_positions = labels.reshape(-1).ne(-100).nonzero(as_tuple=False).flatten()
+        return active_positions.numel() > 0 and active_positions[0].item() > 0
 
     @staticmethod
     def generate_square_subsequent_mask(sz: int) -> Tensor:

--- a/igc/modules/llm_train_state_encoder.py
+++ b/igc/modules/llm_train_state_encoder.py
@@ -23,6 +23,7 @@ from transformers import PreTrainedModel, PreTrainedTokenizer
 from igc.modules.base.igc_llm_base_module import LlmModule
 from igc.modules.base.igc_metric_logger import MetricLogger
 from igc.modules.shared.llm_shared import safe_resize_token_embeddings
+from igc.modules.base.metric_keys import phase_metric
 from igc.shared.shared_accelerator import broadcast_flag
 from igc.shared.shared_torch_builder import TorchBuilder
 
@@ -54,6 +55,24 @@ def build_causal_lm_labels(input_ids, attention_mask, pad_token_id=None):
     if pad_token_id is not None:
         labels = labels.masked_fill(input_ids == pad_token_id, -100)
     return labels
+
+
+def causal_lm_labels_from_batch(batch, input_ids, attention_mask, pad_token_id=None):
+    """Return dataset-provided labels or build whole-sequence causal-LM labels.
+
+    Phase 1 corpus rows provide prompt-masked ``labels``. Legacy datasets do not, so
+    the trainer falls back to full-sequence next-token labels.
+
+    :param batch: Collated batch dictionary.
+    :param input_ids: Device-local input ids.
+    :param attention_mask: Device-local attention mask.
+    :param pad_token_id: Tokenizer pad id for the legacy fallback.
+    :return: Labels on the same device as ``input_ids``.
+    """
+    labels = batch.get("labels")
+    if labels is not None:
+        return labels.to(input_ids.device, non_blocking=False)
+    return build_causal_lm_labels(input_ids, attention_mask, pad_token_id)
 
 
 def optimizer_steps_per_epoch(num_micro_batches: int, accum_steps: int) -> int:
@@ -209,6 +228,7 @@ class LlmEmbeddingsTrainer(LlmModule):
         self._mask_probability = 1.0
         self._best_validation_metric = float('-inf')
         self.dataset = dataset
+        self._metric_namespace = getattr(dataset, "metric_namespace", "")
 
         self.logger.info(
             f"Rank {self.rank} creating llm trainer, num epochs {self.num_epochs} "
@@ -258,13 +278,22 @@ class LlmEmbeddingsTrainer(LlmModule):
     def custom_collate_fn(samples):
         """Stack tokenized samples into a model batch.
 
-        :param samples: Dataset rows containing ``input_ids`` and ``attention_mask``.
+        :param samples: Dataset rows containing ``input_ids`` and ``attention_mask``;
+            Phase 1 rows also carry prompt-masked ``labels``.
         :return: Batch dictionary with tensor values stacked on the leading axis.
         """
         included_keys = ['input_ids', 'attention_mask']
+        if all(LlmEmbeddingsTrainer._has_prompt_masked_labels(sample) for sample in samples):
+            included_keys.append("labels")
         batch = {key: torch.stack([s[key] for s in samples]) for key in included_keys}
 
         return batch
+
+    @staticmethod
+    def _has_prompt_masked_labels(sample) -> bool:
+        """Whether a sample carries Phase 1 prompt-masked CausalLM labels."""
+        labels = sample.get("labels")
+        return torch.is_tensor(labels) and labels.eq(-100).any().item()
 
     @staticmethod
     def generate_square_subsequent_mask(sz: int) -> Tensor:
@@ -324,29 +353,19 @@ class LlmEmbeddingsTrainer(LlmModule):
 
         with torch.no_grad():
             for i, batch in enumerate(validation_dataset):
-                batch_size = batch['input_ids'].size(0)
-                target_ids = batch["input_ids"][:, 1:].clone().detach()
-                mask = (batch["input_ids"] == self.tokenizer.pad_token_id)
-                mask = mask.to(self.device)
-                target_ids = target_ids.to(self.device)
+                input_ids = batch['input_ids'].to(self.device)
+                attention_mask = batch['attention_mask'].to(self.device)
+                labels = causal_lm_labels_from_batch(
+                    batch, input_ids, attention_mask, self.tokenizer.pad_token_id)
 
-                target_ids = target_ids.masked_fill(mask[:, 1:], -100)
-                original_mask = batch['attention_mask']
-                shifted_input = batch['input_ids'][:, :-1].to(self.device)
-                shifter_mask = batch['attention_mask'][:, :-1].to(self.device)
-                target_ids = target_ids.to(self.device)
-
-                batch_inputs = {
-                    'input_ids': shifted_input,
-                    'attention_mask': shifter_mask,
-                }
+                batch_inputs = {'input_ids': input_ids, 'attention_mask': attention_mask}
 
                 outputs = self.model(**batch_inputs)
-                compute_accuracy = self.compute_accuracy(
-                    outputs.logits, target_ids, original_mask
-                )
-                correct_predictions += compute_accuracy * batch_size
-                total_predictions += batch_size
+                predictions = torch.argmax(outputs.logits[:, :-1, :], dim=-1)
+                targets = labels[:, 1:]
+                valid = targets.ne(-100)
+                correct_predictions += ((predictions == targets) & valid).sum().item()
+                total_predictions += valid.sum().item()
 
         # Global metric: each rank validates only its own eval shard, so a rank-LOCAL accuracy makes
         # ranks disagree on "best" and enter the epoch-boundary save collective asymmetrically — the
@@ -621,6 +640,8 @@ class LlmEmbeddingsTrainer(LlmModule):
         run_started_clock = time.time()
         final_epoch_loss = None
         epochs_done = last_epoch
+        tokens_processed = 0
+        samples_processed = 0
 
         if total_batches == calculated_total_batches:
             print(f"Rank {self.rank}, Staring training, "
@@ -653,8 +674,11 @@ class LlmEmbeddingsTrainer(LlmModule):
                 # (the old target_ids = input_ids[:, 1:] + truncated input) double-shifts
                 # and trains the model to predict two tokens ahead. build_causal_lm_labels
                 # keeps the sequence full-length and only sets -100 on ignored positions.
-                labels = build_causal_lm_labels(
-                    input_ids, attention_mask, self.tokenizer.pad_token_id)
+                labels = causal_lm_labels_from_batch(
+                    batch, input_ids, attention_mask, self.tokenizer.pad_token_id)
+                active_tokens = int(labels.ne(-100).sum().item())
+                tokens_processed += active_tokens
+                samples_processed += input_ids.size(0)
 
                 batch_inputs = {
                     'input_ids': input_ids,
@@ -699,6 +723,26 @@ class LlmEmbeddingsTrainer(LlmModule):
                     self.metric_logger.log_metric("train/loss", loss.item(), step)
                     self.metric_logger.log_metric("train/lr", current_lr, step)
                     self.metric_logger.log_metric("train/grad_norm", last_grad_norm, step)
+                    if self._metric_namespace:
+                        elapsed = max(time.time() - run_started_clock, 1e-9)
+                        self.metric_logger.log_metric(
+                            phase_metric(self._metric_namespace, "train", "loss"),
+                            loss.item(), step)
+                        self.metric_logger.log_metric(
+                            phase_metric(self._metric_namespace, "train", "perplexity"),
+                            float(np.exp(min(loss.item(), 20.0))), step)
+                        self.metric_logger.log_metric(
+                            phase_metric(self._metric_namespace, "train", "optimizer_step"),
+                            global_opt_steps + 1, step)
+                        self.metric_logger.log_metric(
+                            phase_metric(self._metric_namespace, "train", "tokens_processed"),
+                            tokens_processed, step)
+                        self.metric_logger.log_metric(
+                            phase_metric(self._metric_namespace, "throughput", "train_tokens_per_sec"),
+                            tokens_processed / elapsed, step)
+                        self.metric_logger.log_metric(
+                            phase_metric(self._metric_namespace, "throughput", "train_samples_per_sec"),
+                            samples_processed / elapsed, step)
 
                 if is_step:
                     global_opt_steps += 1
@@ -733,6 +777,11 @@ class LlmEmbeddingsTrainer(LlmModule):
                 validation_accuracy = self.validate(eval_dataloader)
                 if self.is_rank_zero():
                     self.metric_logger.log_metric("eval/accuracy", validation_accuracy, epoch_step)
+                    if self._metric_namespace:
+                        self.metric_logger.log_metric(
+                            phase_metric(self._metric_namespace, "eval", "token_accuracy"),
+                            validation_accuracy / 100.0,
+                            epoch_step)
 
                 print(f"Rank {self.rank} Epoch {epoch + 1} - Validation Accuracy: "
                       f"{validation_accuracy} Best: {self._best_validation_metric}")
@@ -742,6 +791,15 @@ class LlmEmbeddingsTrainer(LlmModule):
                 final_epoch_loss = average_loss
                 if self.is_rank_zero():
                     self.metric_logger.log_metric("train/epoch_loss", average_loss, epoch_step)
+                    if self._metric_namespace:
+                        self.metric_logger.log_metric(
+                            phase_metric(self._metric_namespace, "train", "epoch_loss"),
+                            average_loss,
+                            epoch_step)
+                        self.metric_logger.log_metric(
+                            phase_metric(self._metric_namespace, "train", "epoch_perplexity"),
+                            float(np.exp(min(average_loss, 20.0))),
+                            epoch_step)
                 print(f"Rank {self.rank} Epoch {epoch + 1}/{self.num_epochs} - Average Loss: {average_loss}")
             epochs_done = epoch + 1
 
@@ -933,8 +991,8 @@ class LlmEmbeddingsTrainer(LlmModule):
                 # Pre-shifting here as well (the old target_ids = input_ids[:, 1:] +
                 # truncated input) double-shifts and trains for two-tokens-ahead — the
                 # same correction applied in _train via build_causal_lm_labels.
-                labels = build_causal_lm_labels(
-                    input_ids, attention_mask, self.tokenizer.pad_token_id)
+                labels = causal_lm_labels_from_batch(
+                    batch, input_ids, attention_mask, self.tokenizer.pad_token_id)
 
                 batch_inputs = {
                     'input_ids': input_ids,

--- a/igc/shared/shared_arg_parser.py
+++ b/igc/shared/shared_arg_parser.py
@@ -741,6 +741,14 @@ def add_dataset_dataloader(parser):
              "provenance-tagged corpus instead of building from --json_data_dir.")
 
     group.add_argument(
+        "--corpus_objective",
+        type=str, default="legacy",
+        choices=["legacy", "phase1_pretrain"],
+        help="Objective for --corpus_dir. 'legacy' preserves the historical whole-text "
+             "causal-LM bridge; 'phase1_pretrain' renders x={rest_api, allowed_methods, "
+             "json} and masks labels so loss applies only to the y_true JSON completion.")
+
+    group.add_argument(
         "--raw_data_dir",
         type=str, default="~/.json_responses",
         help="Raw captured Redfish responses the mock REST env serves; mirrors "

--- a/scripts/run_profile.sh
+++ b/scripts/run_profile.sh
@@ -20,6 +20,8 @@ set -euo pipefail
 
 PROFILE="${IGC_PROFILE:?set IGC_PROFILE (e.g. m1_7b_rslora_r32)}"
 DATA_DIR="${IGC_DATA_DIR:-$HOME/.json_responses}"
+CORPUS_DIR="${IGC_CORPUS_DIR:-}"
+CORPUS_OBJECTIVE="${IGC_CORPUS_OBJECTIVE:-legacy}"
 OUT_DIR="${IGC_OUTPUT_DIR:-experiments/${PROFILE}}"
 METRIC_REPORT="${IGC_METRIC_REPORT:-wandb}"
 
@@ -39,6 +41,10 @@ fi
 # Optional per-run overrides: IGC_SET="batch_size=16 lr=2e-4"
 SET_ARGS=()
 for kv in ${IGC_SET:-}; do SET_ARGS+=(--set "$kv"); done
+CORPUS_ARGS=()
+if [ -n "$CORPUS_DIR" ]; then
+    CORPUS_ARGS+=(--corpus_dir "$CORPUS_DIR" --corpus_objective "$CORPUS_OBJECTIVE")
+fi
 
 echo "== resolved profile: ${PROFILE} =="
 python -m igc.modules.train.launch --profile "$PROFILE" "${SET_ARGS[@]}"
@@ -51,6 +57,7 @@ echo "== launching igc_main.py (data=${DATA_DIR}, out=${OUT_DIR}) =="
 # shellcheck disable=SC2086  # ARGV is a shell-form argv emitted by the launcher.
 exec python igc_main.py $ARGV \
   --json_data_dir "$DATA_DIR" \
+  "${CORPUS_ARGS[@]}" \
   --output_dir "$OUT_DIR" \
   --metric_report "$METRIC_REPORT" \
   "$@"

--- a/tests/bats/run_profile.bats
+++ b/tests/bats/run_profile.bats
@@ -42,12 +42,14 @@ EOF
     [[ "$output" == *"set IGC_PROFILE"* ]]
 }
 
-@test "run_profile resolves profile argv and launches igc_main with paths and extras" {
+@test "run_profile resolves profile argv and launches igc_main with paths, corpus, and extras" {
     install_python_stub
 
     run env \
         IGC_PROFILE=m1_gpt2_smoke \
         IGC_DATA_DIR="${BATS_TEST_TMPDIR}/data" \
+        IGC_CORPUS_DIR="${BATS_TEST_TMPDIR}/corpus" \
+        IGC_CORPUS_OBJECTIVE=phase1_pretrain \
         IGC_OUTPUT_DIR="${BATS_TEST_TMPDIR}/out" \
         IGC_METRIC_REPORT=tensorboard \
         IGC_SET="batch_size=2 lr=1e-4" \
@@ -67,6 +69,8 @@ EOF
     final_args="$(cat "${BATS_TEST_TMPDIR}/final-args.txt")"
     [[ "$final_args" == *"igc_main.py --train llm --batch_size 2"* ]]
     [[ "$final_args" == *"--json_data_dir ${BATS_TEST_TMPDIR}/data"* ]]
+    [[ "$final_args" == *"--corpus_dir ${BATS_TEST_TMPDIR}/corpus"* ]]
+    [[ "$final_args" == *"--corpus_objective phase1_pretrain"* ]]
     [[ "$final_args" == *"--output_dir ${BATS_TEST_TMPDIR}/out"* ]]
     [[ "$final_args" == *"--metric_report tensorboard -- --recreate_dataset"* ]]
 }

--- a/tests/ds/test_corpus_dataset.py
+++ b/tests/ds/test_corpus_dataset.py
@@ -46,6 +46,45 @@ class _FakeTokenizer:
         return {"input_ids": torch.tensor([ids]), "attention_mask": torch.tensor([mask])}
 
 
+class _EmptyCompletionTokenizer(_FakeTokenizer):
+    """Tokenizer stub that exposes a degenerate zero-token completion."""
+
+    def __call__(self, text, padding=None, max_length=None, truncation=None,
+                 return_tensors=None, add_special_tokens=None):
+        if text == '{\n  "empty": true\n}\n':
+            empty = torch.empty((1, 0), dtype=torch.long)
+            return {"input_ids": empty, "attention_mask": empty}
+        return super().__call__(
+            text,
+            padding=padding,
+            max_length=max_length,
+            truncation=truncation,
+            return_tensors=return_tensors,
+            add_special_tokens=add_special_tokens,
+        )
+
+
+class _NoAddSpecialCallTokenizer(_FakeTokenizer):
+    """Tokenizer where only encode() can suppress special tokens."""
+
+    def __init__(self) -> None:
+        self.encode_add_special_tokens = None
+
+    def __call__(self, text, padding=None, max_length=None, truncation=None,
+                 return_tensors=None, add_special_tokens=None):
+        if add_special_tokens is not None:
+            raise TypeError("legacy tokenizer does not accept add_special_tokens")
+        ids = [777] + [ord(c) % 1000 + 1 for c in text] + [778]
+        return {"input_ids": torch.tensor([ids]), "attention_mask": torch.ones(1, len(ids))}
+
+    def encode(self, text, add_special_tokens=True):
+        self.encode_add_special_tokens = add_special_tokens
+        ids = [ord(c) % 1000 + 1 for c in text]
+        if add_special_tokens:
+            ids = [777] + ids + [778]
+        return ids
+
+
 class _FakeSource:
     """Fixed-record source for building a small corpus."""
 
@@ -145,6 +184,21 @@ def test_phase1_rejects_max_len_too_small(tmp_path: Path):
         )
 
 
+def test_phase1_rejects_empty_completion_tokens(tmp_path: Path):
+    """A tokenizer bug or odd target must not produce an all-ignored training row."""
+    with pytest.raises(ValueError, match="completion tokenized to zero tokens"):
+        CorpusJSONLDataset(
+            _explicit_phase1_corpus_dir(
+                tmp_path,
+                {"@odata.id": "/redfish/v1/Systems/1"},
+                target={"empty": True},
+            ),
+            max_len=32,
+            tokenizer=_EmptyCompletionTokenizer(),
+            objective="phase1_pretrain",
+        )
+
+
 def test_phase1_long_prompt_keeps_completion_marker(tmp_path: Path):
     """Long resources are left-truncated so the prompt tail still names the task."""
     tok = _FakeTokenizer()
@@ -177,6 +231,7 @@ def test_items_stack_like_the_trainer_collate(tmp_path: Path):
     batch = {k: torch.stack([ds[i][k] for i in range(len(ds))]) for k in ("input_ids", "attention_mask")}
     assert batch["input_ids"].shape == (len(ds), 32)
     assert batch["attention_mask"].dtype == torch.int64
+    assert batch["input_ids"].dtype == torch.int64
 
 
 def test_trainer_duck_type_surface(tmp_path: Path):
@@ -209,6 +264,16 @@ def test_unknown_objective_rejected(tmp_path: Path):
     """The corpus objective is explicit; typos fail before tokenization."""
     with pytest.raises(ValueError, match="unknown corpus objective"):
         CorpusJSONLDataset(_corpus_dir(tmp_path), tokenizer=_FakeTokenizer(), objective="phase9")
+
+
+def test_token_ids_fallback_keeps_special_tokens_disabled():
+    """Legacy tokenizer fallback must preserve the prompt/completion boundary."""
+    tok = _NoAddSpecialCallTokenizer()
+
+    ids = CorpusJSONLDataset._token_ids(tok, "abc")
+
+    assert ids.tolist() == [98, 99, 100]
+    assert tok.encode_add_special_tokens is False
 
 
 def _contains_subsequence(values: list[int], needle: list[int]) -> bool:

--- a/tests/ds/test_corpus_dataset.py
+++ b/tests/ds/test_corpus_dataset.py
@@ -11,6 +11,7 @@ Author:
 Mus mbayramo@stanford.edu
 """
 
+import json
 from pathlib import Path
 
 import pytest
@@ -28,14 +29,20 @@ class _FakeTokenizer:
 
     pad_token = "<pad>"
     eos_token = "<eos>"
+    pad_token_id = 0
 
     def __call__(self, text, padding=None, max_length=None, truncation=None,
-                 return_tensors=None):
-        ids = [ord(c) % 1000 + 1 for c in text][:max_length]
+                 return_tensors=None, add_special_tokens=None):
+        ids = [ord(c) % 1000 + 1 for c in text]
+        if add_special_tokens:
+            ids = [999] + ids + [998]
+        if max_length is not None and truncation:
+            ids = ids[:max_length]
         mask = [1] * len(ids)
-        while len(ids) < max_length:
-            ids.append(0)
-            mask.append(0)
+        if padding == "max_length":
+            while len(ids) < max_length:
+                ids.append(0)
+                mask.append(0)
         return {"input_ids": torch.tensor([ids]), "attention_mask": torch.tensor([mask])}
 
 
@@ -64,6 +71,22 @@ def _corpus_dir(tmp_path: Path, n=4) -> str:
     return str(out)
 
 
+def _explicit_phase1_corpus_dir(tmp_path: Path, body: dict, target: dict | None = None) -> str:
+    """Write an explicit x/y_true Phase 1 row without invoking the corpus mixer."""
+    out = tmp_path / "explicit_corpus"
+    out.mkdir()
+    row = {
+        "x": {
+            "rest_api": "/redfish/v1/Systems/1",
+            "allowed_methods": ["GET", "PATCH"],
+            "json": body,
+        },
+        "y_true": {"json": target or body},
+    }
+    (out / "examples.jsonl").write_text(json.dumps(row) + "\n")
+    return str(out)
+
+
 def test_items_are_fixed_length_tensor_dicts(tmp_path: Path):
     """Every item is a {input_ids, attention_mask} pair of length max_len."""
     ds = CorpusJSONLDataset(_corpus_dir(tmp_path), max_len=64, tokenizer=_FakeTokenizer())
@@ -71,6 +94,81 @@ def test_items_are_fixed_length_tensor_dicts(tmp_path: Path):
     item = ds[0]
     assert set(item) == {"input_ids", "attention_mask"}
     assert item["input_ids"].shape == (64,) and item["attention_mask"].shape == (64,)
+
+
+def test_phase1_items_mask_prompt_and_padding_labels(tmp_path: Path):
+    """Phase 1 rows train only on the completion JSON, never prompt or padding tokens."""
+    ds = CorpusJSONLDataset(
+        _corpus_dir(tmp_path),
+        max_len=256,
+        tokenizer=_FakeTokenizer(),
+        objective="phase1_pretrain",
+    )
+
+    item = ds[0]
+
+    assert set(item) == {"input_ids", "attention_mask", "labels"}
+    assert item["input_ids"].shape == (256,)
+    assert item["labels"].shape == (256,)
+    active = item["labels"].ne(-100).nonzero(as_tuple=False).flatten()
+    assert active.numel() > 0
+    assert active[0].item() > 0
+    assert torch.equal(item["labels"][active], item["input_ids"][active])
+    assert item["labels"][item["attention_mask"].eq(0)].eq(-100).all()
+    assert ds.metric_namespace == "phase1_pretrain"
+
+
+def test_phase1_tiny_sequence_keeps_prompt_and_completion(tmp_path: Path):
+    """Even when truncated hard, Phase 1 keeps context before active completion labels."""
+    ds = CorpusJSONLDataset(
+        _corpus_dir(tmp_path),
+        max_len=8,
+        tokenizer=_FakeTokenizer(),
+        objective="phase1_pretrain",
+    )
+
+    item = ds[0]
+    active = item["labels"].ne(-100).nonzero(as_tuple=False).flatten()
+
+    assert active.numel() > 0
+    assert active[0].item() > 0
+
+
+def test_phase1_rejects_max_len_too_small(tmp_path: Path):
+    """A one-token Phase 1 sequence cannot hold prompt context and completion."""
+    with pytest.raises(ValueError, match="max_len >= 2"):
+        CorpusJSONLDataset(
+            _corpus_dir(tmp_path),
+            max_len=1,
+            tokenizer=_FakeTokenizer(),
+            objective="phase1_pretrain",
+        )
+
+
+def test_phase1_long_prompt_keeps_completion_marker(tmp_path: Path):
+    """Long resources are left-truncated so the prompt tail still names the task."""
+    tok = _FakeTokenizer()
+    ds = CorpusJSONLDataset(
+        _explicit_phase1_corpus_dir(
+            tmp_path,
+            {
+                "@odata.id": "/redfish/v1/Systems/1",
+                "Description": "A" * 500,
+            },
+            target={"@odata.id": "/redfish/v1/Systems/1", "Id": "1"},
+        ),
+        max_len=96,
+        tokenizer=tok,
+        objective="phase1_pretrain",
+    )
+
+    item = ds[0]
+    active = item["labels"].ne(-100).nonzero(as_tuple=False).flatten()
+    prompt_ids = item["input_ids"][:active[0].item()].tolist()
+    marker_ids = tok("### Complete Redfish JSON\n", return_tensors="pt",
+                     add_special_tokens=False)["input_ids"].squeeze(0).tolist()
+
+    assert _contains_subsequence(prompt_ids, marker_ids)
 
 
 def test_items_stack_like_the_trainer_collate(tmp_path: Path):
@@ -105,6 +203,17 @@ def test_missing_corpus_raises(tmp_path: Path):
     """A directory without examples.jsonl fails fast, not at first batch."""
     with pytest.raises(FileNotFoundError):
         CorpusJSONLDataset(str(tmp_path / "nope"), tokenizer=_FakeTokenizer())
+
+
+def test_unknown_objective_rejected(tmp_path: Path):
+    """The corpus objective is explicit; typos fail before tokenization."""
+    with pytest.raises(ValueError, match="unknown corpus objective"):
+        CorpusJSONLDataset(_corpus_dir(tmp_path), tokenizer=_FakeTokenizer(), objective="phase9")
+
+
+def _contains_subsequence(values: list[int], needle: list[int]) -> bool:
+    """Whether ``needle`` appears contiguously in ``values``."""
+    return any(values[i:i + len(needle)] == needle for i in range(len(values) - len(needle) + 1))
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/ds/test_corpus_dataset.py
+++ b/tests/ds/test_corpus_dataset.py
@@ -184,7 +184,7 @@ def test_trainer_duck_type_surface(tmp_path: Path):
     ds = CorpusJSONLDataset(_corpus_dir(tmp_path), max_len=16, tokenizer=_FakeTokenizer())
     for hook in ("disable_masking", "enable_masking", "mask_section", "mask_new_tokens",
                  "mask_targets", "mask_allowed_value", "mask_odata_id", "mask_targets_key",
-                 "mask_objects", "mask_arrays"):
+                 "mask_objects", "mask_arrays", "mask_api_prefix"):
         getattr(ds, hook)()  # must not raise
     assert ds.tokenizer is not None
     ds.load_tokenizer()  # idempotent

--- a/tests/modules/test_causal_lm_labels.py
+++ b/tests/modules/test_causal_lm_labels.py
@@ -108,6 +108,26 @@ def test_custom_collate_ignores_unmasked_legacy_extra_labels() -> None:
     assert set(batch) == {"input_ids", "attention_mask"}
 
 
+def test_custom_collate_ignores_all_ignored_extra_labels() -> None:
+    """All-ignored labels are invalid Phase 1 rows, not usable prompt masks."""
+    samples = [
+        {
+            "input_ids": torch.tensor([1, 2, 3]),
+            "attention_mask": torch.tensor([1, 1, 1]),
+            "labels": torch.tensor([-100, -100, -100]),
+        },
+        {
+            "input_ids": torch.tensor([4, 5, 6]),
+            "attention_mask": torch.tensor([1, 1, 1]),
+            "labels": torch.tensor([-100, -100, -100]),
+        },
+    ]
+
+    batch = LlmEmbeddingsTrainer.custom_collate_fn(samples)
+
+    assert set(batch) == {"input_ids", "attention_mask"}
+
+
 def test_validate_returns_percent_for_legacy_metric_contract() -> None:
     """Validation returns 0-100 percent; namespaced W&B accuracy divides by 100."""
 

--- a/tests/modules/test_causal_lm_labels.py
+++ b/tests/modules/test_causal_lm_labels.py
@@ -9,9 +9,15 @@ Author:
 Mus mbayramo@stanford.edu
 """
 
+from types import SimpleNamespace
+
 import torch
 
-from igc.modules.llm_train_state_encoder import build_causal_lm_labels
+from igc.modules.llm_train_state_encoder import (
+    LlmEmbeddingsTrainer,
+    build_causal_lm_labels,
+    causal_lm_labels_from_batch,
+)
 
 
 def test_labels_are_full_length_and_not_preshifted() -> None:
@@ -47,6 +53,89 @@ def test_pad_token_none_masks_only_attention_padding() -> None:
     attention_mask = torch.tensor([[1, 1, 0]])
     labels = build_causal_lm_labels(input_ids, attention_mask, pad_token_id=None)
     assert labels[0].tolist() == [5, 6, -100]
+
+
+def test_dataset_labels_are_used_without_rebuilding() -> None:
+    """Prompt-masked dataset labels win over legacy whole-sequence label building."""
+    input_ids = torch.tensor([[5, 6, 0]])
+    attention_mask = torch.tensor([[1, 1, 0]])
+    provided = torch.tensor([[-100, 6, -100]])
+    batch = {"labels": provided}
+
+    labels = causal_lm_labels_from_batch(batch, input_ids, attention_mask, pad_token_id=0)
+
+    assert torch.equal(labels, provided)
+
+
+def test_custom_collate_preserves_optional_labels() -> None:
+    """Phase 1 batches include labels while legacy batches keep the old two keys."""
+    samples = [
+        {
+            "input_ids": torch.tensor([1, 2]),
+            "attention_mask": torch.tensor([1, 1]),
+            "labels": torch.tensor([-100, 2]),
+        },
+        {
+            "input_ids": torch.tensor([3, 4]),
+            "attention_mask": torch.tensor([1, 1]),
+            "labels": torch.tensor([-100, 4]),
+        },
+    ]
+
+    batch = LlmEmbeddingsTrainer.custom_collate_fn(samples)
+
+    assert set(batch) == {"input_ids", "attention_mask", "labels"}
+    assert batch["labels"].tolist() == [[-100, 2], [-100, 4]]
+
+
+def test_custom_collate_ignores_unmasked_legacy_extra_labels() -> None:
+    """A stray legacy labels column is ignored unless it is prompt-masked."""
+    samples = [
+        {
+            "input_ids": torch.tensor([1, 2]),
+            "attention_mask": torch.tensor([1, 1]),
+            "labels": torch.tensor([99, 99]),
+        },
+        {
+            "input_ids": torch.tensor([3, 4]),
+            "attention_mask": torch.tensor([1, 1]),
+            "labels": torch.tensor([99, 99]),
+        },
+    ]
+
+    batch = LlmEmbeddingsTrainer.custom_collate_fn(samples)
+
+    assert set(batch) == {"input_ids", "attention_mask"}
+
+
+def test_validate_returns_percent_for_legacy_metric_contract() -> None:
+    """Validation returns 0-100 percent; namespaced W&B accuracy divides by 100."""
+
+    class TinyValidationModel(torch.nn.Module):
+        """Return deterministic logits with one correct and one wrong token."""
+
+        def forward(self, input_ids, attention_mask):
+            logits = torch.zeros(input_ids.shape[0], input_ids.shape[1], 8)
+            logits[:, 0, 2] = 10.0
+            logits[:, 1, 4] = 10.0
+            return SimpleNamespace(logits=logits)
+
+    trainer = LlmEmbeddingsTrainer.__new__(LlmEmbeddingsTrainer)
+    trainer.model = TinyValidationModel()
+    trainer._device = torch.device("cpu")
+    trainer._accelerator = None
+    trainer.tokenizer = SimpleNamespace(pad_token_id=0)
+    trainer.is_accelerator = False
+    batch = {
+        "input_ids": torch.tensor([[1, 2, 3, 0]]),
+        "attention_mask": torch.tensor([[1, 1, 1, 0]]),
+        "labels": torch.tensor([[-100, 2, 3, -100]]),
+    }
+
+    accuracy = LlmEmbeddingsTrainer.validate(trainer, [batch])
+
+    assert accuracy == 50.0
+    assert accuracy / 100.0 == 0.5
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_igc_main_corpus_path.py
+++ b/tests/modules/test_igc_main_corpus_path.py
@@ -1,0 +1,82 @@
+"""
+Offline regression tests for IgcMain corpus selection.
+
+Pins that a training launch with ``--corpus_dir`` initializes the written
+``CorpusJSONLDataset`` path before dispatching to train(), rather than eagerly
+rebuilding the legacy masked JSON dataset from raw captures.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+from argparse import Namespace
+
+from igc.modules import igc_main
+
+
+class _FakeMetricLogger:
+    """Tiny MetricLogger stand-in; IgcMain only needs construction here."""
+
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+
+class _FakeCorpusDataset:
+    """Records the corpus arguments used by IgcMain.dataset."""
+
+    constructed = []
+
+    def __init__(self, corpus_dir, default_tokenize=None, max_len=None, objective="legacy"):
+        self.corpus_dir = corpus_dir
+        self.default_tokenize = default_tokenize
+        self.max_len = max_len
+        self.objective = objective
+        self.tokenizer = object()
+        _FakeCorpusDataset.constructed.append(self)
+
+
+def _spec(tmp_path):
+    """Minimal IgcMain spec for exercising run() dispatch."""
+    return Namespace(
+        metric_report="tensorboard",
+        json_data_dir=str(tmp_path / "json"),
+        dataset_dir=str(tmp_path / "legacy_dataset"),
+        corpus_dir=str(tmp_path / "written_corpus"),
+        corpus_objective="phase1_pretrain",
+        model_type="gpt2",
+        seq_len=128,
+        recreate_dataset=False,
+        do_consistency_check=False,
+        copy_llm=False,
+        test_llm=False,
+        train="llm",
+    )
+
+
+def test_run_with_corpus_dir_does_not_build_legacy_masked_dataset(monkeypatch, tmp_path):
+    """``--corpus_dir`` reaches train() with CorpusJSONLDataset, not MaskedJSONDataset."""
+    trained = {}
+    _FakeCorpusDataset.constructed.clear()
+
+    def fail_legacy_dataset(*_args, **_kwargs):
+        raise AssertionError("MaskedJSONDataset must not be built when corpus_dir is set")
+
+    def fake_train(self):
+        trained["dataset"] = self.dataset
+
+    monkeypatch.setattr(igc_main, "MetricLogger", _FakeMetricLogger)
+    monkeypatch.setattr(igc_main, "MaskedJSONDataset", fail_legacy_dataset)
+    monkeypatch.setattr("igc.ds.corpus_dataset.CorpusJSONLDataset", _FakeCorpusDataset)
+    monkeypatch.setattr(igc_main.IgcMain, "train", fake_train)
+
+    main = igc_main.IgcMain(_spec(tmp_path))
+    main.run()
+
+    assert trained["dataset"] is _FakeCorpusDataset.constructed[0]
+    assert trained["dataset"].corpus_dir == str(tmp_path / "written_corpus")
+    assert trained["dataset"].default_tokenize == "gpt2"
+    assert trained["dataset"].max_len == 128
+    assert trained["dataset"].objective == "phase1_pretrain"
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/shared/test_arg_parser_action_repr.py
+++ b/tests/shared/test_arg_parser_action_repr.py
@@ -47,6 +47,15 @@ def test_raw_data_dir_is_defined(monkeypatch):
     assert args.raw_data_dir == "~/.json_responses"
 
 
+def test_corpus_objective_defaults_legacy_and_phase1_selectable(monkeypatch):
+    """--corpus_objective selects the explicit Phase 1 prompt/completion objective."""
+    defaults = _parse(monkeypatch, [])
+    phase1 = _parse(monkeypatch, ["--corpus_objective", "phase1_pretrain"])
+
+    assert defaults.corpus_objective == "legacy"
+    assert phase1.corpus_objective == "phase1_pretrain"
+
+
 def test_rl_sizes_are_ints(monkeypatch):
     """rl batch/buffer sizes parse as ints, not floats."""
     args = _parse(monkeypatch, [])


### PR DESCRIPTION
## Summary
- add a Phase 1 corpus objective that renders Redfish REST context plus JSON completion labels in the existing corpus dataset path
- preserve legacy corpus behavior by default and add --corpus_objective phase1_pretrain for opt-in runs
- add shared phase metric keys and Phase 1 W&B metric logging without creating a separate trainer
- wire run_profile.sh to pass corpus objective settings when IGC_CORPUS_DIR is set

## Tests
- /Users/spyroot/miniconda3/condabin/conda run -n igc-dev env KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 PYTHONFAULTHANDLER=1 python -m pytest -q tests/ds/test_corpus_dataset.py tests/modules/test_causal_lm_labels.py tests/shared/test_arg_parser_action_repr.py tests/modules/test_dataloader_blocks.py tests/modules/train/test_launch.py
- /Users/spyroot/miniconda3/condabin/conda run -n igc-dev python -m ruff check igc/ds/corpus_dataset.py igc/modules/llm_train_state_encoder.py igc/modules/igc_main.py igc/shared/shared_arg_parser.py igc/modules/base/metric_keys.py tests/ds/test_corpus_dataset.py tests/modules/test_causal_lm_labels.py tests/modules/test_dataloader_blocks.py tests/shared/test_arg_parser_action_repr.py tests/modules/train/test_launch.py
- /opt/homebrew/bin/bats tests/bats/run_profile.bats
- /opt/homebrew/bin/shellcheck scripts/run_profile.sh tests/bats/run_profile.bats
- git diff --check
- /Users/spyroot/miniconda3/condabin/conda run -n igc-dev env PYTHONFAULTHANDLER=1 KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1 make gate PYTHON=python