### PR TITLE
Remove unwired Phase 1 metric keys

### DIFF
--- a/docs/phase_1.md
+++ b/docs/phase_1.md
@@ -97,21 +97,31 @@ cross-entropy only on the `y_true` JSON completion.
 
 ## Phase 1 W&B Metrics
 
-Use a dedicated namespace so Phase 1 curves never mix with goal extraction or RL:
+Use the `PHASE1_WANDB_METRIC_KEYS` registry, defined in
+`igc/modules/base/metric_keys.py`, for metrics that the current trainer can emit.
+The live registry keeps Phase 1 curves separate from goal extraction or RL:
 
 - `phase1_pretrain/train/loss`
+- `phase1_pretrain/train/epoch_loss`
 - `phase1_pretrain/train/perplexity`
+- `phase1_pretrain/train/epoch_perplexity`
 - `phase1_pretrain/train/optimizer_step`
 - `phase1_pretrain/train/tokens_processed`
 - `phase1_pretrain/eval/loss`
 - `phase1_pretrain/eval/perplexity`
 - `phase1_pretrain/eval/token_accuracy`
+- `phase1_pretrain/throughput/train_tokens_per_sec`
+- `phase1_pretrain/throughput/train_samples_per_sec`
+
+The acceptance gate below still requires reconstruction, throughput, data-shape,
+calibration, and test-time evidence before a full Phase 1 run is accepted. These
+metric names are intentionally not in the live registry until the producer code
+lands:
+
 - `phase1_pretrain/eval/top_k_accuracy`
 - `phase1_pretrain/eval/json_parse_rate`
 - `phase1_pretrain/eval/json_exact_match_rate`
 - `phase1_pretrain/eval/odata_id_match_rate`
-- `phase1_pretrain/throughput/train_tokens_per_sec`
-- `phase1_pretrain/throughput/train_samples_per_sec`
 - `phase1_pretrain/throughput/eval_tokens_per_sec`
 - `phase1_pretrain/throughput/eval_samples_per_sec`
 - `phase1_pretrain/data/padding_ratio`

--- a/igc/modules/base/metric_keys.py
+++ b/igc/modules/base/metric_keys.py
@@ -38,12 +38,8 @@ PHASE1_WANDB_METRIC_KEYS = (
     phase_metric(PHASE1_PRETRAIN, "eval", "loss"),
     phase_metric(PHASE1_PRETRAIN, "eval", "perplexity"),
     phase_metric(PHASE1_PRETRAIN, "eval", "token_accuracy"),
-    phase_metric(PHASE1_PRETRAIN, "eval", "json_parse_rate"),
-    phase_metric(PHASE1_PRETRAIN, "eval", "json_exact_match_rate"),
-    phase_metric(PHASE1_PRETRAIN, "eval", "odata_id_match_rate"),
     phase_metric(PHASE1_PRETRAIN, "throughput", "train_tokens_per_sec"),
     phase_metric(PHASE1_PRETRAIN, "throughput", "train_samples_per_sec"),
-    phase_metric(PHASE1_PRETRAIN, "data", "padding_ratio"),
 )
 
 PHASE2_WANDB_METRIC_KEYS = (

--- a/tests/modules/test_phase1_metric_keys.py
+++ b/tests/modules/test_phase1_metric_keys.py
@@ -1,0 +1,31 @@
+"""Phase 1 metric-key registry must not advertise known dead tuples.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from igc.modules.base.metric_keys import (
+    PHASE1_PRETRAIN,
+    PHASE1_WANDB_METRIC_KEYS,
+    phase_metric,
+)
+
+
+def test_phase1_metric_registry_keeps_expected_live_keys() -> None:
+    """The current Phase 1 registry still covers train/eval/throughput basics."""
+    keys = set(PHASE1_WANDB_METRIC_KEYS)
+    assert phase_metric(PHASE1_PRETRAIN, "train", "loss") in keys
+    assert phase_metric(PHASE1_PRETRAIN, "train", "epoch_loss") in keys
+    assert phase_metric(PHASE1_PRETRAIN, "eval", "token_accuracy") in keys
+    assert phase_metric(PHASE1_PRETRAIN, "throughput", "train_tokens_per_sec") in keys
+
+
+def test_phase1_metric_registry_omits_unwired_structural_keys() -> None:
+    """Do not advertise structural/data metrics until a real producer lands."""
+    keys = set(PHASE1_WANDB_METRIC_KEYS)
+    assert phase_metric(PHASE1_PRETRAIN, "eval", "json_parse_rate") not in keys
+    assert phase_metric(PHASE1_PRETRAIN, "eval", "json_exact_match_rate") not in keys
+    assert phase_metric(PHASE1_PRETRAIN, "eval", "odata_id_match_rate") not in keys
+    assert phase_metric(PHASE1_PRETRAIN, "data", "padding_ratio") not in keys
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
## Summary
- remove Phase 1 W&B metric keys that still have no producer on main
- add a regression test so the known dead structural/data keys are not re-advertised silently

## Verification
- env KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 /Users/spyroot/miniconda3/condabin/conda run -n igc-dev python -m pytest -q tests/modules/test_phase1_metric_keys.py tests/ds/test_corpus_dataset.py tests/modules/test_igc_main_corpus_path.py
- /Users/spyroot/miniconda3/condabin/conda run -n igc-dev ruff check igc/modules/base/metric_keys.py tests/modules/test_phase1_metric_keys.py
- /opt/homebrew/bin/bats tests/bats/run_profile.bats
- git diff --check HEAD~1..HEAD