### PR TITLE
Select Phase 1 checkpoints by eval loss

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 *.tar.gz filter=lfs diff=lfs merge=lfs -text
 *.pt filter=lfs diff=lfs merge=lfs -text
+*.safetensors filter=lfs diff=lfs merge=lfs -text
 datasets/raw/*.pt filter=lfs diff=lfs merge=lfs -text
 datasets/raw/processed_dataset_gpt2.pt filter=lfs diff=lfs merge=lfs -text
 datasets/raw/processed_masked_dataset_gpt2.pt filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ vendor/model/capture layout. IGC consumes that output through `--corpus_manifest
 `--corpus_root`, and `--corpus_kind`, which are defined in `igc/shared/shared_arg_parser.py`:
 
 ```bash
-IGC_PROFILE=m1_gpt2_smoke \
+IGC_PROFILE=phase1_gpt2_smoke \
 IGC_METRIC_REPORT=tensorboard \
 bash scripts/run_profile.sh \
   --corpus_manifest /path/to/redfish_ctl/corpora/manifest.v1.json \

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,26 +90,26 @@ place. The math gate for these claims lives in [MATH_CHECKS.md](MATH_CHECKS.md).
 
 ```mermaid
 flowchart TD
-    M1["M1 backbone encoder\nconfig-driven causal/decoder model"]
+    RB["RedfishBackbone / model_x\nconfig-driven causal/decoder model"]
     S0["RedfishStateV0 extractor\nstructured state contract + fixtures"]
-    M2["M2 state pooler / autoencoder\npooled structured/text state"]
-    GE["GoalExtractor / GoalEncoder\ninstruction -> atomic goals + z_sub_goal"]
-    M4["M4 evaluator / reward\nstructured verify + dense reward"]
-    M5["M5 world model\nnext-state + status/task phase"]
-    M6["M6 RL policy\ncandidate scoring + replay/HER"]
+    SE["StateEncoder / StatePooler\npooled structured/text state"]
+    GE["GoalExtractor / GoalEncoder\ninstruction -> ordered REST goals + z_goal"]
+    RV["RewardVerifier\nstructured verify + dense reward"]
+    WM["WorldModel\nnext-state + status/task phase"]
+    RP["RLPolicy\ncandidate scoring + replay/HER"]
     Gate["Offline eval harness\nno GPU/network/live host by default"]
 
-    S0 --> M2
-    M1 --> M2
-    M1 --> GE
-    S0 --> M4
-    M2 --> M5
-    M4 --> M5
-    M2 --> M6
-    GE --> M6
-    M4 --> M6
-    M5 --> M6
-    M6 --> Gate
+    S0 --> SE
+    RB --> SE
+    RB --> GE
+    S0 --> RV
+    SE --> WM
+    RV --> WM
+    SE --> RP
+    GE --> RP
+    RV --> RP
+    WM --> RP
+    RP --> Gate
 ```
 
 ### RedfishStateV0 field budget
@@ -268,21 +268,23 @@ The design makes the hypothesis concrete, layer by layer:
 In short: **extract → discover → execute → transfer.** Every layer is built so the unit of
 generalization is *the skill of operating a tool API*, not *a specific API*.
 
-## 4. The six models and the training curriculum
+## 4. Trainable Components And Training Curriculum
 
-`igc` is not one model — it is six, with real dependencies. `M1` (the backbone) is the single root
-and the riskiest node: if hidden size `H` changes, every downstream magic dim breaks, so dims are
-de-hardcoded before the first backbone fit.
+`igc` is not one model. It is a dependency graph of separately named components with separate
+weights. The Redfish-aware backbone checkpoint is `model_x`; downstream state, goal, argument,
+reward, world-model, and policy components must name their own weight roles and output directories
+instead of reusing historical `M*` aliases. If hidden size `H` changes, every downstream magic dim
+breaks, so dims are de-hardcoded before the first backbone fit.
 
 ![Training curriculum](diagrams/05-training-curriculum.svg)
 
-| Stage | Model | Objective | Key metric | Compute |
+| Stage | Component | Objective | Key metric | Compute |
 | --- | --- | --- | --- | --- |
 | 0 | — | make it runnable + de-hardcode dims + backbone config-driven | `pytest -q` green, ruff clean | CPU |
-| 1 | M1 backbone / state encoder | causal-LM SFT over Redfish JSON → checkpoint A | held-out token acc ↑ vs measured GPT-2 baseline | 1-GPU |
-| 2 | M2 autoencoder · GoalExtractor/GoalEncoder · M4 reward | pool→latent 64 · NL→atomic goals · decomposed reward | recon MSE · extraction exact match · reward AUC | 1-GPU ×3 |
-| 3 | M5 world/transition | next-latent + status/job-phase classification | 1-step error, phase accuracy, rollout drift | 1-GPU |
-| 4 | M6 RL agent | goal-cond. DQN + HER on `ToolAction`, learned reward | success_rate per workload, episode_length | 1-GPU (longest) |
+| 1 | RedfishBackbone / `model_x` | causal-LM SFT over Redfish JSON → Phase 1 checkpoint | held-out token acc ↑ vs measured GPT-2 baseline | 1-GPU → multi-GPU |
+| 2 | StateEncoder · GoalExtractor/GoalEncoder · RewardVerifier | pool→latent 64 · text→ordered REST goals · decomposed reward | recon MSE · extraction exact match · reward AUC | 1-GPU ×3 |
+| 3 | WorldModel | next-latent + status/job-phase classification | 1-step error, phase accuracy, rollout drift | 1-GPU |
+| 4 | RLPolicy | goal-cond. DQN + HER on `ToolAction`, learned reward | success_rate per workload, episode_length | 1-GPU (longest) |
 
 ## 5. Backbone modernization (GPT-2 → flash-class LLM)
 
@@ -313,8 +315,8 @@ The target loader should use `AutoTokenizer` + a class arg, and `ValueHead` shou
 | 2 · Registry + Redfish adapter | `register/make`; Redfish plugin; `action_repr` flag + parity test; route `igc_rl_module` through `make_vec` | parity test green (one-hot ≡ tool for GET/HEAD) |
 | 3 · Offline prover envs | filesystem + sqlite plugins (real args, dynamic actions, exact verify, dry-run, destructive blocked) | per-env offline tests |
 | 4 · Trajectory + github | recorder + `TrajectoryDataset`; `CassetteSimulator`; github plugin (offline replay, live-gated) | record→load round-trip; github offline via cassette |
-| 5 · Backbone + M1/M2 | backbone-agnostic refactor; `StatePooler`; train M1 + M2 on NVL72 | small-model CPU green → 1-GPU overfit-a-batch smoke |
-| 6 · Learning layer | GoalExtractor/GoalEncoder + reward (M4) + world model (M5) + evaluators + preference data → RL agent (M6) | offline eval harness scores traces; GPU-marked training |
+| 5 · Backbone + state representation | backbone-agnostic refactor; `StatePooler`; train `model_x` and StateEncoder on NVL72 | small-model CPU green → 1-GPU overfit-a-batch smoke |
+| 6 · Learning layer | GoalExtractor/GoalEncoder + RewardVerifier + WorldModel + evaluators + preference data → RLPolicy | offline eval harness scores traces; GPU-marked training |
 | 7 · Guardrail + deploy | dry-run/approval/executor over `_is_live`; serve backbone + goal extractor via vLLM (TP=1); live Redfish canary behind the gate | guardrail blocks destructive-without-approval; offline gate stays green |
 
 ## 7. Infra · monitoring · deploy (NVL72)
@@ -325,7 +327,7 @@ NVL72 through a one-GPU-first Slurm/pyxis workflow.
 
 - **Monitoring** reuses the existing `MetricLogger` (`--metric_report` tb/wandb/mlflow): per-model
   curves (loss/perplexity/accuracy/grad-norm/tokens-per-sec; reward/success-rate/episode-length for
-  M6).
+  RLPolicy).
 - **Training-loop sanity checks:** overfit-a-batch, grad-norm clip + `isfinite` guard, LR
   warmup/cosine, deterministic seed, resume-from-checkpoint, early stop, a startup dim-contract
   assertion (`observation_space == latent_dim + goal_dim`), and a Buffer arity check.
@@ -397,12 +399,12 @@ discovery + the pointer policy** (score only discovered legal candidates → shr
 
 **Architecture — RL² cast as a Transformer.** The LLM backbone carries cross-episode history in its
 context = the in-context meta-learner (the Transformer analog of RL²'s RNN; cf. Decision Transformer /
-Algorithm Distillation). M1/M2 compress observations so a long history fits the context budget. **Dense
-first; MoE is a later upgrade** (upcycle/distill once there are many APIs + data + expert-parallel infra)
+Algorithm Distillation). StateEncoder/StatePooler compress observations so a long history fits the
+context budget. **Dense first; MoE is a later upgrade** (upcycle/distill once there are many APIs + data + expert-parallel infra)
 — MoE adds capacity/specialization, not the meta-learning (which lives in attention-over-history).
 
-**Backbone sizing — decoupled.** Small dense bf16 backbone for the hot-loop encoder/RL (M1/M2/M6,
-runs every step); a larger model may be used for the GoalExtractor if extraction metrics justify it
+**Backbone sizing — decoupled.** Small dense bf16 backbone for the hot-loop encoder/RL
+(RedfishBackbone/StateEncoder/RLPolicy, runs every step); a larger model may be used for the GoalExtractor if extraction metrics justify it
 (runs once per episode). Trainable =
 small/mid dense bf16 + LoRA + ZeRO-3 (`--sharding zero3`). DeepSeek-V4-Flash (284B FP8/FP4 MoE) is the
 **inference/teacher** only (deployed NVFP4), never the trainable backbone.
@@ -413,10 +415,10 @@ operator text, but deterministic code owns `true_y`; verify generated text again
 GoalExtractor before using it as supervised data.
 
 **Training curriculum.**
-1. **Represent** (supervised, separate): M1 backbone SFT + M2 autoencoder → compact states. Pretrained
-   first; RL LoRA-adapts on top (do not co-train the whole backbone with RL).
+1. **Represent** (supervised, separate): RedfishBackbone SFT + StateEncoder/StatePooler → compact
+   states. Pretrained first; RL LoRA-adapts on top (do not co-train the whole backbone with RL).
 2. **Extract** (distill) + **Reward** (build, parallel): GoalExtractor/GoalEncoder from the
-   generated goal dataset; M4 schema-driven verifier.
+   generated goal dataset; RewardVerifier schema-driven verifier.
 3. **Meta-RL — ONE optimization path:** the in-context RL²-Transformer policy over the API-sim
    distribution, with HER, a **BC/SFT warm-start** (imitate teacher demos before RL — the main lever
    against the sparse-reward cold start), and a **narrow→broad task curriculum**. Meta is not a phase
@@ -439,7 +441,7 @@ flowchart TB
     GE -->|goal-conditions| AGENT
 
     subgraph AGENT["Goal-conditioned RL2 agent (one shared policy)"]
-        ENC["M1/M2 encoder<br/>API response -> compact state vector"]
+        ENC["StateEncoder / StatePooler<br/>API response -> compact state vector"]
         HIST["Transformer over history<br/>state, action, reward = in-context task memory"]
         POL["Pointer policy<br/>score discovered legal candidates"]
         ARG["Argument decoder<br/>fill action values"]
@@ -454,8 +456,8 @@ flowchart TB
     ARG -->|REST call| SIM
     SIM -->|response| ENC
     DISC -->|legal candidates| POL
-    SIM --> M4["M4 evaluator<br/>verify Goal.spec vs state -> sparse reward"]
-    M4 --> HER["HER replay<br/>relabel achieved states"]
+    SIM --> RV["RewardVerifier<br/>verify Goal.spec vs state -> sparse reward"]
+    RV --> HER["HER replay<br/>relabel achieved states"]
     HER --> POL
 
     META["Meta-train over MANY API simulators<br/>-> generalize few-shot to a HELD-OUT API"]
@@ -477,7 +479,7 @@ flowchart LR
     CTX["Transformer context window<br/>compressed states + prev action + prev reward"]
     CTX --> POL["policy head (pointer scoring)"]
     POL --> ADAPT["in-context adaptation:<br/>behaviour improves across episodes<br/>WITHOUT weight updates"]
-    NOTE["M1/M2 compress each observation<br/>so a long history fits the context budget"]
+    NOTE["StateEncoder/StatePooler compress each observation<br/>so a long history fits the context budget"]
     CTX -.- NOTE
 ```
 
@@ -486,9 +488,9 @@ flowchart LR
 ```mermaid
 flowchart TB
     subgraph SEP["Separate prerequisite phases"]
-        REP["Represent<br/>M1 backbone SFT + M2 autoencoder<br/>small dense, pretrained first"]
+        REP["Represent<br/>RedfishBackbone SFT + StateEncoder<br/>small dense, pretrained first"]
         PLAN["Extract<br/>GoalExtractor / GoalEncoder"]
-        REW["Reward<br/>M4 schema-driven verifier"]
+        REW["Reward<br/>RewardVerifier schema-driven verifier"]
     end
     REP --> META
     PLAN --> META
@@ -507,9 +509,9 @@ flowchart LR
     DS -->|draft operator text X only| DISTILL["goal text set<br/>deterministic true_y labels"]
     DISTILL -->|SFT / contrastive| GEB["GoalExtractor / GoalEncoder<br/>(runs once per episode)"]
     SMALL["small dense bf16 backbone 1-7B<br/>+ LoRA + ZeRO-3 (hot loop)"]
-    SMALL --> M1["M1 state encoder"]
-    SMALL --> M2["M2 autoencoder"]
-    SMALL --> M6["M6 RL policy heads"]
+    SMALL --> RB["RedfishBackbone / model_x"]
+    SMALL --> SE["StateEncoder / StatePooler"]
+    SMALL --> RP["RLPolicy heads"]
     DS -.->|direct call for bootstrap| GEB
 ```
 
@@ -542,7 +544,7 @@ flowchart TB
     subgraph GATES["Grounding gates (run BEFORE any injection)"]
         G1["1 evidence-bound prompt<br/>uncited claims dropped"]
         G2["2 schema gate + .npy/ActionInfo override (§9.3)"]
-        G3["3 M4 replay · Evaluator.verify + MockServer"]
+        G3["3 RewardVerifier replay · Evaluator.verify + MockServer"]
         G4["4 online falsification<br/>confirm vs contradict => falsified"]
         G1 --> G2 --> G3 --> G4
     end
@@ -559,7 +561,7 @@ flowchart TB
     subgraph TRAIN["Gradient-trained (offline meta-train only)"]
         BC["BC warm-start (§10 main lever)"]
         AD["Algorithm Distillation<br/>teacher-free at test"]
-        SHAPE["potential shaping F=γΦ'−Φ over q_targets<br/>source reward stays M4 verify()"]
+        SHAPE["potential shaping F=γΦ'−Φ over q_targets<br/>source reward stays RewardVerifier.verify()"]
     end
 ```
 
@@ -568,7 +570,7 @@ flowchart TB
 Passive scorability (§1, §3.3 step 3) embeds an unseen op's declared text so the pointer
 head can *score* it; it does nothing to teach the op's effective signature, response
 shape, or error semantics, so cold-start exploration on a never-seen tool is blind
-trial-and-error under M4's sparse reward (§10). Tool-teaching layers an active induction
+trial-and-error under RewardVerifier's sparse reward (§10). Tool-teaching layers an active induction
 loop on top, leaving the passive path byte-identical when no card is present (the
 `card=None` parity guarantee, pinned by `tests/core/test_action_render_card.py`).
 
@@ -583,7 +585,7 @@ held-out-API trial's cards never leak across trials. Fields: `effective_signatur
 from observed 2xx bodies), `error_taxonomy` (`retriable | fatal | precondition_unmet`,
 each citing ≥1 `Transition`), `preconditions`/`usage_tips`, `provenance`
 (`llm | stub`, evidence ids, `k_observed`), `grounding` (`status ∈
-{provisional, grounded, contradicted}` + confirm/contradict + M4 counters), `version`,
+{provisional, grounded, contradicted}` + confirm/contradict + RewardVerifier counters), `version`,
 `content_hash` (blake2b of the canonical learned content — excludes the volatile
 grounding tallies so a counter tick does not churn the embedding cache), and
 `spec_fingerprint` (blake2b of `ToolSpec.arg_schema[op]` — a moved op schema
@@ -616,7 +618,8 @@ All four seams are inference-time (no weight update during held-out adaptation):
   argument is added to the cosine-normalized `score_candidates` (avoids scale-mixing a
   logit bias).
 - **B · RL² context block** — the same card text as a compact token block prepended once
-  per trial to the cross-episode history (§11.2); M1/M2 keep it within the context budget.
+  per trial to the cross-episode history (§11.2); StateEncoder/StatePooler keeps it within the
+  context budget.
 - **C · argument-decoder enum tightening** — `card.effective_signature` tightens
   `ArgumentSlot.choices`/`required` in `arg_slots_for`
   (`igc/modules/policy/argument_decoder.py`), but **only within `@Redfish.ActionInfo`
@@ -635,8 +638,8 @@ The teacher *will* fabricate; nothing is trusted on assertion. `ToolCardGrounder
 entries are dropped. (2) **schema + enum** — every arg slot must exist in
 `ToolSpec.arg_schema[op]`, and enum claims are clipped to `@Redfish.ActionInfo`
 allowable values; **the `.npy`/ActionInfo overrides the teacher on any enum conflict**
-(§9.3, resolved — binding contract). (3) **M4 replay** — each claim becomes an assertion
-checked via `Evaluator.verify` (M4, `igc/core/protocols.py`) + a no-op replay against
+(§9.3, resolved — binding contract). (3) **RewardVerifier replay** — each claim becomes an assertion
+checked via `Evaluator.verify` (RewardVerifier, `igc/core/protocols.py`) + a no-op replay against
 `MockServer`/cassette; only passing claims flip `grounding.status` to `grounded` (lands
 in slice 6b/6c — the offline slice carries gates 1, 2, 4). (4) **online falsification** —
 every real `StepResult` updates `n_confirmations`/`n_contradictions`; the status flows
@@ -653,11 +656,11 @@ and must not be reported as already-enforced.
 ### 12.6 Training
 
 Tool-teaching is **not a new phase**; it rides §10's single meta-RL optimization path
-(§11.3) inside Phase 6, and depends on M1/M2 (compress so `k` interactions + card fit the
-RL² budget), the gated teacher path, and M4 (the grounder). The interplay:
+(§11.3) inside Phase 6, and depends on StateEncoder/StatePooler (compress so `k` interactions +
+card fit the RL² budget), the gated teacher path, and RewardVerifier (the grounder). The interplay:
 
 - **BC/SFT warm-start** (§10's main lever against the sparse-reward cold start): teacher
-  demos enter BC *only after* M4 confirms they reached a sub-goal, carrying their ToolCard
+  demos enter BC *only after* RewardVerifier confirms they reached a sub-goal, carrying their ToolCard
   in context, so the policy learns the card→action mapping before RL.
 - **Algorithm Distillation** (the learned core): next-action cross-entropy over
   `[ToolCard, ep1(s,a,r), ep2…]` cross-episode histories, internalizing the across-episode
@@ -669,7 +672,7 @@ RL² budget), the gated teacher path, and M4 (the grounder). The interplay:
 - **Potential-based shaping**: a grounded card supplies a potential Φ over (precondition-met,
   expected-progress); shaping is `F = γΦ′ − Φ` over `q_targets`, which *provably cannot
   change the optimal policy*, and decays as real-Q confidence grows. **The source reward
-  stays M4's `verify()` — this is not a new reward channel** (it deliberately avoids a
+  stays RewardVerifier's `verify()` — this is not a new reward channel** (it deliberately avoids a
   second, hallucination-amplifying reward signal adjacent to the still-open §9.4
   reward-decomposition decision).
 
@@ -684,7 +687,7 @@ The primary metric extends §10's contribution (success_rate vs. number of adapt
 interactions on a **held-out API**) into a with-vs-without A/B: `curve_A` = passive
 pointer text only (§3.3); `curve_B` = + ToolCard teaching. The claim is that `curve_B`
 reaches a target success_rate in fewer interactions and at lower `episode_length` (the two
-M6 metrics, §4). Crucially, the **teacher-free distilled agent at test time must match the
+RLPolicy metrics, §4). Crucially, the **teacher-free distilled agent at test time must match the
 teacher-in-loop agent** — the honest proof the across-episode operator was internalized,
 not a present-teacher crutch.
 
@@ -706,9 +709,9 @@ not the objective but (i) the acquired unit is a REST-op acquisition skill over 
 *discovered* action surface, and (ii) the in-context history is seeded by an explicit,
 schema-bound, evidence-grounded, verifier-gated ToolCard — where vanilla
 AD/Decision-Transformer/in-context-RL start from raw `(s,a,r)`. Versus Voyager, a ToolCard
-is a grounded declarative spec adversarially checked against M4/observed evidence, not
+is a grounded declarative spec adversarially checked against RewardVerifier/observed evidence, not
 self-verified executable code; versus Toolformer, adaptation to a *new* tool is
-inference-time with zero weight update and the knowledge is an inspectable, M4-verified
+inference-time with zero weight update and the knowledge is an inspectable, RewardVerifier-verified
 data structure, not latent weights; versus RAP / ReAct / Reflexion, the card is the
 structured, schema-typed, verifier-gated counterpart that flows into a learned pointer
 Q-score plus argument-enum pruning *and* is distilled into weights.
@@ -722,6 +725,6 @@ already live in `spec.arg_schema[op][slot]['enum']` and already feed `arg_slots_
 the card's enum term adds value mainly where capture is *missing* — ablation (3) must
 isolate this honestly. (4) Card-as-context could become a test-time crutch — measured by
 the teacher-free vs teacher-in-loop ablation. (5) Safety rides on the **still-queued
-Phase-7 guardrail**. (6) The **M5 precondition seed is deferred** until M5 exists (§4
+Phase-7 guardrail**. (6) The **WorldModel precondition seed is deferred** until WorldModel exists (§4
 stage 3); it is not load-bearing for the contribution. Cards are dataset artifacts
 (gitignored like `~/.json_responses`), never committed.

--- a/docs/CRITICAL_SECTIONS.md
+++ b/docs/CRITICAL_SECTIONS.md
@@ -94,7 +94,8 @@ host's candidates are static and the projector weights are fixed within an optim
 **Fix (design decision [D-002](DECISIONS.md)).** Project the host's **unique** candidate set once
 per optimizer step, cache the keys, and score with `score_candidates` (an einsum over cached
 keys) for every state in the batch. The primitive already exists — `score_candidates` takes
-pre-projected keys — so the M6 training loop must use it rather than the full per-state forward.
+pre-projected keys — so the RLPolicy training loop must use it rather than the full per-state
+forward.
 
 **Result.** Pointer forward **0.193 s → 0.0038 s (~51×)** on CPU; on a 100k-step run this is the
 difference between hours and minutes of pure projection.

--- a/docs/MATH_CHECKS.md
+++ b/docs/MATH_CHECKS.md
@@ -124,12 +124,12 @@ flowchart LR
 
 | Stage | Objective | Required math checkout |
 | --- | --- | --- |
-| M1 backbone | language-model loss over Redfish text | tokenization mask, loss finite, small batch overfit, no hidden-size assumptions. |
-| M2 state pooler | pooled state reconstruction or auxiliary prediction | shape contract, no `seq_len * hidden_size` decoder blowup, finite gradients. |
+| RedfishBackbone / `model_x` | language-model loss over Redfish text | tokenization mask, loss finite, small batch overfit, no hidden-size assumptions. |
+| StateEncoder / StatePooler | pooled state reconstruction or auxiliary prediction | shape contract, no `seq_len * hidden_size` decoder blowup, finite gradients. |
 | GoalExtractor / GoalEncoder | instruction to atomic goal refs and latent sub-goals | atomic-goal exact match, dependency-edge F1, hard-negative retrieval, collapse checks. |
-| M4 evaluator/reward | structured success and dense reward | reward table for success/failure/progress/no-op; no embedding equality as final verifier. |
-| M5 world model | next state/status/task phase | one-step prediction target, terminal-state handling, rollout drift metric. |
-| M6 RL policy | candidate-action Q-learning with HER | terminal mask, legal-action mask, HER achieved-goal relabel, target sanity. |
+| RewardVerifier | structured success and dense reward | reward table for success/failure/progress/no-op; no embedding equality as final verifier. |
+| WorldModel | next state/status/task phase | one-step prediction target, terminal-state handling, rollout drift metric. |
+| RLPolicy | candidate-action Q-learning with HER | terminal mask, legal-action mask, HER achieved-goal relabel, target sanity. |
 
 ## Local tool policy
 

--- a/docs/NODE_ARTIFACTS.md
+++ b/docs/NODE_ARTIFACTS.md
@@ -1,9 +1,9 @@
 # Node artifacts: LFS push from a slot, and Docker Hub images
 
-How to move large artifacts (captured corpora, built datasets, tarballs, images) **without
-dragging multi-GB data across the shared VPN**. The rule: data that is generated on a training
-node is pushed *from* that node over its own datacenter uplink — never pulled to a laptop and
-pushed from there (a multi-GB transfer over the VPN has saturated the shared tunnel and blocked
+How to move large artifacts, including captured corpora, built datasets, model adapters, tarballs,
+and images, without dragging multi-GB data across the shared VPN. The rule: data that is generated
+on a training node is pushed *from* that node over its own datacenter uplink — never pulled to a laptop
+and pushed from there (a multi-GB transfer over the VPN has saturated the shared tunnel and blocked
 SSH for everyone).
 
 ## Push large LFS artifacts from a slot
@@ -17,6 +17,7 @@ capture corpora).
 # on the slot, in the repo checkout
 scripts/lfs_push_from_slot.sh ~/.json_responses/<host>          # push a captured host walk
 scripts/lfs_push_from_slot.sh datasets/raw/processed_dataset.pt # push a built dataset
+scripts/lfs_push_from_slot.sh models/model_x/adapter.safetensors # push a reviewed adapter
 ```
 
 It:

--- a/docs/NODE_ARTIFACTS.md
+++ b/docs/NODE_ARTIFACTS.md
@@ -8,10 +8,10 @@ SSH for everyone).
 
 ## Push large LFS artifacts from a slot
 
-`scripts/lfs_push_from_slot.sh` commits an artifact on a `data/<name>` branch and uploads its
-git-LFS objects to the remote from the node. Run it **on the slot**, inside the repo whose
-`.gitattributes` tracks that file type (the `igc` checkout, or the data-collection submodule for
-capture corpora).
+`scripts/lfs_push_from_slot.sh` commits explicitly supplied artifact paths on a `data/<name>` branch
+and uploads their git-LFS objects to the remote from the node. Run it **on the slot**, inside the repo
+whose `.gitattributes` tracks that file type (the `igc` checkout, or the data-collection submodule
+for capture corpora).
 
 ```bash
 # on the slot, in the repo checkout

--- a/docs/P0_PHASE_WORKFLOW.md
+++ b/docs/P0_PHASE_WORKFLOW.md
@@ -4,10 +4,21 @@ This is the current P0 split for Redfish language-model work. It keeps the immed
 goal separate from later goal/argument extraction, so Phase 1 can finish without being blocked by
 Phase 2 and Phase 3 dataset generation.
 
-Naming rule: `M1` and `M2` are architecture-stage names from `docs/ARCHITECTURE.md` (backbone encoder
-and state pooler/autoencoder). Launchable training profiles for this workflow use `phase1_*`,
-`phase2_*`, and `phase3_*` names so their dataset objective is visible in commands, W&B, and
-reports.
+Naming rule: current docs use phase names for launch surfaces and component names for weights. Do
+not introduce historical model-number aliases for profiles; those aliases were retired because they
+hide the dataset objective. Launchable profiles use `phase1_*`, `phase2_*`, and `phase3_*` names,
+while model artifacts use explicit roles such as `model_x`, `goal_extractor`, and
+`argument_extractor`.
+
+| Phase | Profile prefix | Weight role | W&B namespace | Dataset objective | Checkpoint rule |
+| --- | --- | --- | --- | --- | --- |
+| 1 | `phase1_*` | `model_x` | `phase1_finetune/*` | `phase1_pretrain` / Redfish JSON reconstruction | writes a separate Phase 1 checkpoint |
+| 2 | `phase2_goal_extractor_*` (planned) | `goal_extractor` | `phase2_goal_extraction/*` | `text_to_ordered_rest_api_list` | initializes from `model_x` only when requested; never overwrites it |
+| 3 | `phase3_argument_extractor_*` (planned) | `argument_extractor` | `phase3_argument_extraction/*` | `text_and_rest_api_list_to_calls` | initializes from `model_x` or `goal_extractor` only when requested; never overwrites either |
+
+Phase 2 and Phase 3 profile names are planned until their trainers land. Do not add live profiles
+unless `igc.modules.train.launch.profile_to_argv` can emit a runnable command with a distinct
+checkpoint/output directory and W&B namespace.
 
 ## Phase 1: Pretrain `model_x`
 

--- a/docs/P0_PHASE_WORKFLOW.md
+++ b/docs/P0_PHASE_WORKFLOW.md
@@ -4,6 +4,11 @@ This is the current P0 split for Redfish language-model work. It keeps the immed
 goal separate from later goal/argument extraction, so Phase 1 can finish without being blocked by
 Phase 2 and Phase 3 dataset generation.
 
+Naming rule: `M1` and `M2` are architecture-stage names from `docs/ARCHITECTURE.md` (backbone encoder
+and state pooler/autoencoder). Launchable training profiles for this workflow use `phase1_*`,
+`phase2_*`, and `phase3_*` names so their dataset objective is visible in commands, W&B, and
+reports.
+
 ## Phase 1: Pretrain `model_x`
 
 Purpose: train `model_x` on Redfish JSON reconstruction using full Redfish corpora and same-run
@@ -15,7 +20,7 @@ Deliverables:
 - Causal-LM labels masked over `x` and active only on the `y_true` JSON completion.
 - GPU launch ladder: local/offline unit tests, cheap smoke, short large-model smoke, then full
   Phase 1 run on the approved multi-node GPU training surface.
-- W&B metrics under `phase1_pretrain/*`, with train/eval/throughput/data/calibration/test
+- W&B metrics under `phase1_finetune/*`, with train/eval/throughput/data/calibration/test
   subgroups.
 - Checkpoint and evaluation report showing JSON parse rate, exact-match rate, and `@odata.id`
   match rate.
@@ -62,7 +67,7 @@ Real dataset build waits for the Phase 1 checkpoint. The accepted row shape is:
 ```
 
 Evaluation must report ordered exact match and set match separately.
-W&B metrics live under `phase2_goal_extract/*`, with train/eval/order/throughput/data/calibration/test
+W&B metrics live under `phase2_goal_extraction/*`, with train/eval/order/throughput/data/calibration/test
 subgroups.
 
 ## Phase 3: Method And Argument Extraction
@@ -71,7 +76,7 @@ Purpose: after Phase 2, fine-tune a specialized model that maps operator text pl
 `rest_api_list` to ordered calls with `rest_api`, `allowed_methods`, `method`, and `arguments`.
 
 Current P0 scope: mock-dataset plumbing and offline tests only.
-W&B metrics live under `phase3_argument_extract/*`, with train/eval/order/throughput/data/calibration/test
+W&B metrics live under `phase3_argument_extraction/*`, with train/eval/order/throughput/data/calibration/test
 subgroups.
 
 The accepted row shape is:

--- a/docs/RUN_ORCHESTRATION_PLAN.md
+++ b/docs/RUN_ORCHESTRATION_PLAN.md
@@ -37,7 +37,7 @@ The plan should consolidate these existing entrypoints instead of replacing them
 
 - `scripts/gb300_launch.sh`, the existing direct-Docker node launcher.
 - `scripts/submit_train.sh`, the existing Slurm submit helper.
-- `scripts/train_igc.sbatch` and `scripts/train_m1.sbatch`, the existing scheduled training scripts.
+- `scripts/train_igc.sbatch` and `scripts/train_phase1_smoke.sbatch`, the existing scheduled training scripts.
 - `scripts/preflight_nv72.sh`, the existing fleet-state preflight wrapper; the endpoint comes from
   the runtime environment.
 - `scripts/publish_checkpoint.sh`, the existing checkpoint copier and checksum manifest helper.

--- a/docs/SMOKE_LADDER.md
+++ b/docs/SMOKE_LADDER.md
@@ -19,19 +19,20 @@ pytest -q          # must be green; ruff check on touched files
 
 ## R1 — CPU mini-train (before any GPU time)
 
-A 20-step M1 run on the tiny dataset (`--device cpu`, `--num_workers 2`). Gates:
-loss decreases; a checkpoint is written; **the run resumes from its own checkpoint**
+A 20-step Phase 1/M1-backbone run on the tiny dataset (`--device cpu`, `--num_workers 2`).
+`M1` is the architecture-stage name for the backbone/state encoder, not a launch profile name.
+Gates: loss decreases; a checkpoint is written; **the run resumes from its own checkpoint**
 (kill it, restart, confirm the epoch advances instead of restarting at zero).
 
 ## R2 — 1 GPU, gpt2 smoke profile
 
-`m1_gpt2_smoke` via `scripts/run_profile.sh` on one GB300. Gates: fleet preflight passes;
+`phase1_gpt2_smoke` via `scripts/run_profile.sh` on one GB300. Gates: fleet preflight passes;
 the W&B run appears (single run — not one per rank); `kill -USR1` produces a resumable
 checkpoint; throughput is recorded.
 
 ## R3 — 1 GPU, modern backbone (LoRA)
 
-The `m1_local` profile (weights dir from `IGC_MODEL_DIR`) or a Qwen2.5 profile, 50 steps,
+The `phase1_local` profile (weights dir from `IGC_MODEL_DIR`) or a Qwen2.5 profile, 50 steps,
 **on a dataset rebuilt for that backbone** (`--recreate_dataset`; the tokenizer-provenance
 guard in the dataset loader refuses mismatched caches). Gates: the vocabulary assertion
 passes (no `safe_resize` refusal); loss decreases; checkpoint round-trips.

--- a/docs/SMOKE_LADDER.md
+++ b/docs/SMOKE_LADDER.md
@@ -19,8 +19,8 @@ pytest -q          # must be green; ruff check on touched files
 
 ## R1 — CPU mini-train (before any GPU time)
 
-A 20-step Phase 1/M1-backbone run on the tiny dataset (`--device cpu`, `--num_workers 2`).
-`M1` is the architecture-stage name for the backbone/state encoder, not a launch profile name.
+A 20-step Phase 1 RedfishBackbone run on the tiny dataset (`--device cpu`, `--num_workers 2`).
+The checkpoint role is `model_x`; launch profiles use `phase1_*` names, not historical aliases.
 Gates: loss decreases; a checkpoint is written; **the run resumes from its own checkpoint**
 (kill it, restart, confirm the epoch advances instead of restarting at zero).
 

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -47,7 +47,7 @@ root with `--corpus_manifest`, `--corpus_root`, and `--corpus_kind`, which are p
 `igc/shared/shared_arg_parser.py`:
 
 ```bash
-IGC_PROFILE=m1_gpt2_smoke \
+IGC_PROFILE=phase1_gpt2_smoke \
 IGC_METRIC_REPORT=tensorboard \
 bash scripts/run_profile.sh \
   --corpus_manifest /path/to/redfish_ctl/corpora/manifest.v1.json \
@@ -66,7 +66,7 @@ scheduler's node-selection flag.
 ## 3. Experiment tracking (Weights & Biases)
 
 The metric backend is selected by `--metric_report` (the run wires `igc.modules` `MetricLogger`).
-The M1 launcher defaults to `wandb`:
+The Phase 1 profile launcher defaults to `wandb`:
 
 ```bash
 export WANDB_API_KEY=...                 # required for wandb
@@ -74,16 +74,17 @@ export WANDB_PROJECT=igc                 # optional; defaults to "igc"
 # WANDB_NAME is auto-derived from the model + Slurm job id
 ```
 
-Current M1 state-encoder runs log `train/loss`, `train/lr`, `train/grad_norm`, `eval/accuracy`, and
-`train/epoch_loss`. Current RL-agent runs log `epoch_mean_loss`, `epoch_cumulative_reward`, and
-`epoch_goal_reached_count`. Treat perplexity, tokens/sec, GPU memory, and success-rate curves as
-planned instrumentation unless a later change adds those exact metric keys.
+Current Phase 1 corpus runs log under the `phase1_finetune/*` namespace when
+`--corpus_objective phase1_pretrain` is active. Current RL-agent runs log `epoch_mean_loss`,
+`epoch_cumulative_reward`, and `epoch_goal_reached_count`. Treat any metric not listed in
+`igc/modules/base/metric_keys.py` as planned instrumentation unless a later change adds that exact
+producer.
 
 To use TensorBoard instead, choose the variable for the launcher you are using:
 `IGC_METRIC_REPORT=tensorboard bash scripts/run_profile.sh` for the profile wrapper, or
 `IGC_REPORT=tensorboard sbatch scripts/train_m1.sbatch` for the sbatch smoke path.
 
-## 4. Launch (first GPU loop — M1 state encoder)
+## 4. Launch (Phase 1 JSON pretraining)
 
 There are two launch routes today:
 
@@ -91,24 +92,28 @@ There are two launch routes today:
 - `scripts/run_profile.sh`, the profile-backed wrapper, is for direct named-profile execution.
 
 The profile registry, defined in `igc/modules/train/profiles.py`, is the committed source of truth
-for named M1 state-encoder runs. Inspect a profile locally before spending GPU time:
+for named Phase 1 Redfish JSON pretraining runs. In the architecture docs, `M1` still names the
+backbone/state-encoder stage; the concrete launch profiles are named `phase1_*` so their data
+objective is explicit. Inspect a profile locally before spending GPU time:
 
 ```bash
-python -m igc.modules.train.launch --profile m1_gpt2_smoke
-python -m igc.modules.train.launch --profile m1_7b_rslora_r32 --print-argv
+python -m igc.modules.train.launch --profile phase1_gpt2_smoke
+python -m igc.modules.train.launch --profile phase1_7b_rslora_r32 --print-argv
 ```
 
-The smoke argv should include `--model_type gpt2` and `--max_train_steps 50`; the rsLoRA argv should
-include `--adapter_method rslora`, `--lora_r 32`, and `--lora_alpha 64`.
+The smoke argv should include `--profile phase1_gpt2_smoke`, `--corpus_objective phase1_pretrain`,
+`--model_type gpt2`, and `--max_train_steps 50`; the rsLoRA argv should include
+`--profile phase1_7b_rslora_r32`, `--adapter_method rslora`, `--lora_r 32`, and
+`--lora_alpha 64`.
 
 The `scripts/run_profile.sh` wrapper, committed as the profile-name launcher, resolves `IGC_PROFILE`
 through `igc.modules.train.launch`, then supplies `--json_data_dir`, `--output_dir`, and
 `--metric_report` from `IGC_DATA_DIR`, `IGC_OUTPUT_DIR`, and `IGC_METRIC_REPORT`:
 
 ```bash
-IGC_PROFILE=m1_gpt2_smoke \
+IGC_PROFILE=phase1_gpt2_smoke \
 IGC_DATA_DIR=$HOME/.json_responses \
-IGC_OUTPUT_DIR=experiments/m1_gpt2_smoke \
+IGC_OUTPUT_DIR=experiments/phase1_gpt2_smoke \
 bash scripts/run_profile.sh
 ```
 
@@ -116,7 +121,7 @@ Use `IGC_SET`, read by `scripts/run_profile.sh` as profile-field overrides, for 
 changes such as a shorter smoke or batch-size check:
 
 ```bash
-IGC_PROFILE=m1_3b_lora IGC_SET="batch_size=16 lr=2e-4" bash scripts/run_profile.sh
+IGC_PROFILE=phase1_3b_lora IGC_SET="batch_size=16 lr=2e-4" bash scripts/run_profile.sh
 ```
 
 `scripts/run_profile.sh` is the profile-backed local launcher. `scripts/train_m1.sbatch`, the older
@@ -183,7 +188,7 @@ the exact launch command and metrics before calling any sharded run successful.
 trainer — use it when you need knobs that `scripts/train_m1.sbatch` does not expose directly:
 
 ```bash
-IGC_PROFILE=m1_gpt2_smoke \
+IGC_PROFILE=phase1_gpt2_smoke \
 IGC_DATA_DIR=$HOME/.json_responses \
 IGC_METRIC_REPORT=tensorboard \
 bash scripts/run_profile.sh --gradient_accumulation_steps 4 --num_workers 2

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -24,7 +24,7 @@ export WANDB_ENTITY=spyroot
 export WANDB_PROJECT=igc
 ```
 
-`scripts/train_m1.sbatch` auto-sources `$IGC_DIR/.internal/wandb.env` when present (copy it to the
+`scripts/train_phase1_smoke.sbatch` auto-sources `$IGC_DIR/.internal/wandb.env` when present (copy it to the
 cluster login node alongside the checkout — it is not in git). If a key has been shared anywhere
 (chat, a paste, a screenshot), **rotate it** before using it.
 
@@ -82,19 +82,19 @@ producer.
 
 To use TensorBoard instead, choose the variable for the launcher you are using:
 `IGC_METRIC_REPORT=tensorboard bash scripts/run_profile.sh` for the profile wrapper, or
-`IGC_REPORT=tensorboard sbatch scripts/train_m1.sbatch` for the sbatch smoke path.
+`IGC_REPORT=tensorboard sbatch scripts/train_phase1_smoke.sbatch` for the sbatch smoke path.
 
 ## 4. Launch (Phase 1 JSON pretraining)
 
 There are two launch routes today:
 
-- `scripts/train_m1.sbatch`, the Slurm smoke launcher, is the normal scheduled GPU path.
+- `scripts/train_phase1_smoke.sbatch`, the Slurm smoke launcher, is the normal scheduled GPU path.
 - `scripts/run_profile.sh`, the profile-backed wrapper, is for direct named-profile execution.
 
 The profile registry, defined in `igc/modules/train/profiles.py`, is the committed source of truth
-for named Phase 1 Redfish JSON pretraining runs. In the architecture docs, `M1` still names the
-backbone/state-encoder stage; the concrete launch profiles are named `phase1_*` so their data
-objective is explicit. Inspect a profile locally before spending GPU time:
+for named Phase 1 Redfish JSON pretraining runs. Current launch profiles are named `phase1_*` so
+their data objective and checkpoint role are explicit. Inspect a profile locally before spending GPU
+time:
 
 ```bash
 python -m igc.modules.train.launch --profile phase1_gpt2_smoke
@@ -102,8 +102,8 @@ python -m igc.modules.train.launch --profile phase1_7b_rslora_r32 --print-argv
 ```
 
 The smoke argv should include `--profile phase1_gpt2_smoke`, `--corpus_objective phase1_pretrain`,
-`--model_type gpt2`, and `--max_train_steps 50`; the rsLoRA argv should include
-`--profile phase1_7b_rslora_r32`, `--adapter_method rslora`, `--lora_r 32`, and
+`--weights_role model_x`, `--model_type gpt2`, and `--max_train_steps 50`; the rsLoRA argv should include
+`--profile phase1_7b_rslora_r32`, `--weights_role model_x`, `--adapter_method rslora`, `--lora_r 32`, and
 `--lora_alpha 64`.
 
 The `scripts/run_profile.sh` wrapper, committed as the profile-name launcher, resolves `IGC_PROFILE`
@@ -124,23 +124,24 @@ changes such as a shorter smoke or batch-size check:
 IGC_PROFILE=phase1_3b_lora IGC_SET="batch_size=16 lr=2e-4" bash scripts/run_profile.sh
 ```
 
-`scripts/run_profile.sh` is the profile-backed local launcher. `scripts/train_m1.sbatch`, the older
-Slurm smoke launcher, does not read `IGC_PROFILE`; it still uses `IGC_MODEL`, `EPOCHS`, and
-`IGC_USE_PEFT`.
+`scripts/run_profile.sh` is the profile-backed local launcher. `scripts/train_phase1_smoke.sbatch`
+is the Slurm smoke launcher; it does not read `IGC_PROFILE` and still uses `IGC_MODEL`, `EPOCHS`,
+and `IGC_USE_PEFT`.
 
 ```bash
 # on a GB300 login node, with $HOME/igc and $HOME/.json_responses staged on the node
 export WANDB_API_KEY=...
-sbatch scripts/train_m1.sbatch                                  # gpt2 smoke — validates the path
-IGC_MODEL=<large-hf-decoder> EPOCHS=3 sbatch scripts/train_m1.sbatch   # then scale up
-squeue --me ; tail -f igc-m1-*.out                              # watch
+sbatch scripts/train_phase1_smoke.sbatch
+IGC_MODEL=<large-hf-decoder> EPOCHS=3 sbatch scripts/train_phase1_smoke.sbatch
+squeue --me
+tail -f igc-phase1-*.out
 ```
 
-[scripts/train_m1.sbatch](../scripts/train_m1.sbatch) runs `igc_main.py --train llm --llm latent`
-on 1 GPU with conservative fabric settings and unavailable nodes excluded by the launcher. **Start
-with the `gpt2` smoke** before spending a large model's time — it surfaces any remaining launch
-issues cheaply. A *large* model on one GPU needs LoRA — set `IGC_USE_PEFT=1` (LoRA via HF PEFT);
-full fine-tune is for the small validation model only.
+[scripts/train_phase1_smoke.sbatch](../scripts/train_phase1_smoke.sbatch) runs
+`igc_main.py --train llm --llm latent` on 1 GPU with conservative fabric settings and unavailable
+nodes excluded by the launcher. **Start with the `gpt2` smoke** before spending a large model's time
+— it surfaces any remaining launch issues cheaply. A *large* model on one GPU needs LoRA — set
+`IGC_USE_PEFT=1` (LoRA via HF PEFT); full fine-tune is for the small validation model only.
 
 The code-improvement and GPU-efficiency roadmap for 3B/7B state-encoder training lives in
 [TRAINING_OPTIMIZATION_PLAN.md](TRAINING_OPTIMIZATION_PLAN.md). Keep this page as the runnable launch
@@ -185,7 +186,7 @@ the exact launch command and metrics before calling any sharded run successful.
 ### Profile launcher for tuning
 
 `scripts/run_profile.sh` (documented in §4 above) also passes trailing arguments through to the
-trainer — use it when you need knobs that `scripts/train_m1.sbatch` does not expose directly:
+trainer — use it when you need knobs that `scripts/train_phase1_smoke.sbatch` does not expose directly:
 
 ```bash
 IGC_PROFILE=phase1_gpt2_smoke \
@@ -207,8 +208,8 @@ can find earlier checkpoints; see the script header for stage names and epoch kn
 
 ## 5. Checkpoints & weight sharing
 
-Checkpoints are node-local and must not be committed. With `scripts/train_m1.sbatch`, the default
-`output_dir` comes from `igc/shared/shared_main.py` and resolves to
+Checkpoints are node-local and must not be committed. With `scripts/train_phase1_smoke.sbatch`, the
+default `output_dir` comes from `igc/shared/shared_main.py` and resolves to
 `experiments/<model_batch_optimizer_scheduler_lr>/<module>`. With `scripts/train_igc.sbatch`, the
 launcher sets `--output_dir experiments/${IGC_RUN}`, so stages land under
 `experiments/${IGC_RUN}/<module>`.

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -83,39 +83,39 @@ producer.
 Phase 2/3 mock-plumbing metric names are constants only; no live W&B run is part of that lane.
 `PHASE2_GOAL_EXTRACT_METRIC_KEYS`, re-exported by `igc/ds/rest_goal_contract.py` from the shared
 `PHASE2_WANDB_METRIC_KEYS` registry in `igc/modules/base/metric_keys.py`, currently reserves:
-`phase2_goal_extract/train/{loss,perplexity,optimizer_step}`,
-`phase2_goal_extract/eval/{ordered_exact_match_rate,set_match_rate,precision,recall,f1,`
+`phase2_goal_extraction/train/{loss,perplexity,optimizer_step}`,
+`phase2_goal_extraction/eval/{ordered_exact_match_rate,set_match_rate,precision,recall,f1,`
 `missing_allowed_methods_rate}`,
-and `phase2_goal_extract/order/{kendall_tau,edit_distance}`.
+and `phase2_goal_extraction/order/{kendall_tau,edit_distance}`.
 `PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS`, re-exported by `igc/ds/rest_goal_contract.py` from the shared
 `PHASE3_WANDB_METRIC_KEYS` registry in `igc/modules/base/metric_keys.py`, currently reserves:
-`phase3_argument_extract/train/{loss,perplexity,optimizer_step}`,
-`phase3_argument_extract/eval/{call_ordered_exact_match_rate,method_exact_match_rate,`
+`phase3_argument_extraction/train/{loss,perplexity,optimizer_step}`,
+`phase3_argument_extraction/eval/{call_ordered_exact_match_rate,method_exact_match_rate,`
 `arguments_exact_match_rate,readonly_empty_arguments_rate}`,
-and `phase3_argument_extract/order/{kendall_tau,edit_distance}`.
+and `phase3_argument_extraction/order/{kendall_tau,edit_distance}`.
 Exact reserved keys:
 
 ```text
-phase2_goal_extract/train/loss
-phase2_goal_extract/train/perplexity
-phase2_goal_extract/train/optimizer_step
-phase2_goal_extract/eval/ordered_exact_match_rate
-phase2_goal_extract/eval/set_match_rate
-phase2_goal_extract/eval/precision
-phase2_goal_extract/eval/recall
-phase2_goal_extract/eval/f1
-phase2_goal_extract/eval/missing_allowed_methods_rate
-phase2_goal_extract/order/kendall_tau
-phase2_goal_extract/order/edit_distance
-phase3_argument_extract/train/loss
-phase3_argument_extract/train/perplexity
-phase3_argument_extract/train/optimizer_step
-phase3_argument_extract/eval/call_ordered_exact_match_rate
-phase3_argument_extract/eval/method_exact_match_rate
-phase3_argument_extract/eval/arguments_exact_match_rate
-phase3_argument_extract/eval/readonly_empty_arguments_rate
-phase3_argument_extract/order/kendall_tau
-phase3_argument_extract/order/edit_distance
+phase2_goal_extraction/train/loss
+phase2_goal_extraction/train/perplexity
+phase2_goal_extraction/train/optimizer_step
+phase2_goal_extraction/eval/ordered_exact_match_rate
+phase2_goal_extraction/eval/set_match_rate
+phase2_goal_extraction/eval/precision
+phase2_goal_extraction/eval/recall
+phase2_goal_extraction/eval/f1
+phase2_goal_extraction/eval/missing_allowed_methods_rate
+phase2_goal_extraction/order/kendall_tau
+phase2_goal_extraction/order/edit_distance
+phase3_argument_extraction/train/loss
+phase3_argument_extraction/train/perplexity
+phase3_argument_extraction/train/optimizer_step
+phase3_argument_extraction/eval/call_ordered_exact_match_rate
+phase3_argument_extraction/eval/method_exact_match_rate
+phase3_argument_extraction/eval/arguments_exact_match_rate
+phase3_argument_extraction/eval/readonly_empty_arguments_rate
+phase3_argument_extraction/order/kendall_tau
+phase3_argument_extraction/order/edit_distance
 ```
 
 To use TensorBoard instead, choose the variable for the launcher you are using:

--- a/docs/TRAINING_OPTIMIZATION_PLAN.md
+++ b/docs/TRAINING_OPTIMIZATION_PLAN.md
@@ -1,9 +1,9 @@
 # Training Optimization Plan
 
 This plan keeps the large-model training path from inheriting old GPT-2 and
-small-GPU assumptions. It is a code-improvement roadmap for M1 state-encoder
-training, GPU efficiency, Redfish data variation, simulator-backed data
-generation, and the evaluation gates needed before claiming that a 3B or 7B
+small-GPU assumptions. It is a code-improvement roadmap for Phase 1 Redfish JSON
+pretraining of the M1 backbone/state encoder, GPU efficiency, Redfish data variation,
+simulator-backed data generation, and the evaluation gates needed before claiming that a 3B or 7B
 backbone is better.
 
 The plan is public-safe by design. Operational secrets, live endpoints, raw
@@ -12,10 +12,14 @@ repository.
 
 ## Purpose
 
-The M1 state encoder is the first large-model training loop in `igc`. Its job is
-to learn a compact representation of Redfish resource state, action availability,
-and transition-relevant fields. That goal needs a modern large-model path, not
-defaults carried over from a GPT-2 smoke test.
+The M1 state encoder is the first large-model representation stage in `igc`. Phase 1 is the
+concrete Redfish JSON pretraining/fine-tune that starts that stage: it teaches `model_x` to
+reconstruct Redfish resource JSON from `x = {rest_api, allowed_methods, json}` before Phase 2/3
+specialize goal and argument extraction. That goal needs a modern large-model path, not defaults
+carried over from a GPT-2 smoke test.
+
+Profile names use the `phase1_*` prefix because they are launchable Phase 1 training profiles.
+`M1` and `M2` remain architecture-stage names in `docs/ARCHITECTURE.md`.
 
 The intended progression is:
 
@@ -48,11 +52,11 @@ become explicit config or launcher presets before routine 3B/7B training.
 
 | Profile | Purpose | Backbone | Adaptation | First-use gate |
 | --- | --- | --- | --- | --- |
-| `m1_gpt2_smoke` | Validate launch, labels, logging, checkpoint write, and data loading cheaply. | GPT-2 class | Full fine-tune is acceptable. | One short run with finite loss and checkpoint output. |
-| `m1_3b_lora` | Fast serious baseline for Redfish representation. | 3B dense decoder | LoRA, bf16 | Held-out loss and structural metrics better than smoke baseline. |
-| `m1_7b_lora` | Default target for the state encoder. | 7B/8B dense decoder | LoRA, bf16 | Beats 3B on held-out structure/action/state metrics within a reasonable cost budget. |
-| `m1_3b_full` | Controlled full fine-tune comparison. | 3B dense decoder | Full fine-tune, bf16 | Runs only after LoRA metrics and data splits are stable. |
-| `m1_7b_full_zero3` | Higher-ceiling experiment when LoRA underfits. | 7B/8B dense decoder | Full fine-tune with ZeRO-3/FSDP | Requires measured LoRA underfit and a successful smaller full-FT control. |
+| `phase1_gpt2_smoke` | Validate launch, labels, logging, checkpoint write, and data loading cheaply. | GPT-2 class | Full fine-tune is acceptable. | One short run with finite loss and checkpoint output. |
+| `phase1_3b_lora` | Fast serious baseline for Redfish JSON reconstruction. | 3B dense decoder | LoRA, bf16 | Held-out loss and structural metrics better than smoke baseline. |
+| `phase1_7b_lora` | Default large-backbone Phase 1 target. | 7B/8B dense decoder | LoRA, bf16 | Beats 3B on held-out structure/action/state metrics within a reasonable cost budget. |
+| `phase1_3b_full` | Controlled full fine-tune comparison. | 3B dense decoder | Full fine-tune, bf16 | Runs only after LoRA metrics and data splits are stable. |
+| `phase1_7b_full_zero3` | Higher-ceiling experiment when LoRA underfits. | 7B/8B dense decoder | Full fine-tune with ZeRO-3/FSDP | Requires measured LoRA underfit and a successful smaller full-FT control. |
 
 Planned profile knobs:
 
@@ -122,7 +126,7 @@ lora_config = LoraConfig(
 )
 ```
 
-Use this as the `m1_7b_rslora_r32` candidate after the plain LoRA control is
+Use this as the `phase1_7b_rslora_r32` candidate after the plain LoRA control is
 green. For a PiSSA run, keep the same rank/targets and change only the
 initializer, for example `init_lora_weights="pissa_niter_16"` if the installed
 PEFT version supports that initializer.

--- a/docs/TRAINING_OPTIMIZATION_PLAN.md
+++ b/docs/TRAINING_OPTIMIZATION_PLAN.md
@@ -2,7 +2,7 @@
 
 This plan keeps the large-model training path from inheriting old GPT-2 and
 small-GPU assumptions. It is a code-improvement roadmap for Phase 1 Redfish JSON
-pretraining of the M1 backbone/state encoder, GPU efficiency, Redfish data variation,
+pretraining of the RedfishBackbone / `model_x`, GPU efficiency, Redfish data variation,
 simulator-backed data generation, and the evaluation gates needed before claiming that a 3B or 7B
 backbone is better.
 
@@ -12,14 +12,15 @@ repository.
 
 ## Purpose
 
-The M1 state encoder is the first large-model representation stage in `igc`. Phase 1 is the
+The RedfishBackbone is the first large-model representation stage in `igc`. Phase 1 is the
 concrete Redfish JSON pretraining/fine-tune that starts that stage: it teaches `model_x` to
 reconstruct Redfish resource JSON from `x = {rest_api, allowed_methods, json}` before Phase 2/3
 specialize goal and argument extraction. That goal needs a modern large-model path, not defaults
 carried over from a GPT-2 smoke test.
 
 Profile names use the `phase1_*` prefix because they are launchable Phase 1 training profiles.
-`M1` and `M2` remain architecture-stage names in `docs/ARCHITECTURE.md`.
+StateEncoder and downstream components write separate checkpoint roles in later phases; they are not
+encoded in the Phase 1 profile name.
 
 The intended progression is:
 

--- a/docs/diagrams/05-training-curriculum.svg
+++ b/docs/diagrams/05-training-curriculum.svg
@@ -1,6 +1,6 @@
 <svg width="100%" viewBox="0 0 680 410" role="img" xmlns="http://www.w3.org/2000/svg">
-<title>igc training curriculum: six models staged on the NVL72</title>
-<desc>Stage 0 on CPU makes the code runnable and backbone-agnostic. Stage 1 trains M1 the backbone LLM. Stage 2 trains M2 autoencoder, GoalExtractor/GoalEncoder, and M4 reward in parallel off M1. Stage 3 trains M5 world model. Stage 4 trains M6 the RL agent, which consumes M2, goal latents, M4, and M5.</desc>
+<title>igc training curriculum: component weights staged on the NVL72</title>
+<desc>Stage 0 on CPU makes the code runnable and backbone-agnostic. Stage 1 trains the RedfishBackbone model_x. Stage 2 trains StateEncoder, GoalExtractor/GoalEncoder, and RewardVerifier in parallel off model_x. Stage 3 trains the WorldModel. Stage 4 trains RLPolicy, which consumes state latents, goal latents, verifier rewards, and world-model predictions.</desc>
 <style>
 svg{--surface-2:#ffffff;--surface-1:#f7f7f5;--surface-0:#f0efea;--text-primary:#1f1e1b;--text-secondary:#57564f;--text-muted:#8a897f;--border:#e3e2dc;--border-strong:#cbcabf}
 .t,.th,.ts{font-family:-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;fill:var(--text-primary)}
@@ -15,33 +15,33 @@ rect.c-purple{fill:#EEEDFE;stroke:#AFA9EC}.c-purple text{fill:#26215C}
 <marker id="a4" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="var(--text-secondary)"/></marker>
 </defs>
 
-<text class="th" x="40" y="24">igc training curriculum — six models, staged on the NVL72</text>
+<text class="th" x="40" y="24">igc training curriculum — component weights, staged on the NVL72</text>
 <text class="ts" x="40" y="42">teal = do first (CPU, free) · neutral = LLM fine-tune (1-GPU) · coral = RL agent (sink)</text>
 
 <g class="c-teal"><rect class="c-teal" x="110" y="52" width="460" height="42" rx="6"/><text class="th" x="340" y="71" text-anchor="middle">Stage 0 · CPU — make it runnable &amp; generic</text><text class="ts" x="340" y="87" text-anchor="middle">fix launch bugs · de-hardcode dims · backbone config-driven</text></g>
 <line x1="340" y1="94" x2="340" y2="105" stroke="var(--text-secondary)" marker-end="url(#a4)"/>
 
 <rect x="190" y="106" width="300" height="44" rx="6" fill="var(--surface-1)" stroke="var(--border-strong)"/>
-<text class="th" x="340" y="125" text-anchor="middle">M1 · backbone LLM (Stage 1 · 1-GPU)</text>
-<text class="ts" x="340" y="141" text-anchor="middle">causal-LM SFT · LoRA bf16 → checkpoint A</text>
+<text class="th" x="340" y="125" text-anchor="middle">RedfishBackbone / model_x (Stage 1)</text>
+<text class="ts" x="340" y="141" text-anchor="middle">causal-LM SFT · LoRA bf16 → model_x checkpoint</text>
 
-<text class="ts" x="340" y="170" text-anchor="middle">Stage 2 · 1-GPU ×3 (parallel, all consume A)</text>
+<text class="ts" x="340" y="170" text-anchor="middle">Stage 2 · separate weights (parallel, consume model_x)</text>
 <line x1="320" y1="150" x2="150" y2="180" stroke="var(--text-secondary)" marker-end="url(#a4)"/>
 <line x1="340" y1="150" x2="340" y2="180" stroke="var(--text-secondary)" marker-end="url(#a4)"/>
 <line x1="360" y1="150" x2="540" y2="180" stroke="var(--text-secondary)" marker-end="url(#a4)"/>
 
 <rect x="40" y="182" width="190" height="48" rx="6" fill="var(--surface-1)" stroke="var(--border)"/>
-<text class="th" x="135" y="202" text-anchor="middle">M2 · autoencoder</text>
+<text class="th" x="135" y="202" text-anchor="middle">StateEncoder</text>
 <text class="ts" x="135" y="218" text-anchor="middle">pool → latent 64</text>
 <rect x="245" y="182" width="190" height="48" rx="6" fill="var(--surface-1)" stroke="var(--border)"/>
 <text class="th" x="340" y="202" text-anchor="middle">GoalExtractor</text>
 <text class="ts" x="340" y="218" text-anchor="middle">NL → atomic goals</text>
 <rect x="450" y="182" width="190" height="48" rx="6" fill="var(--surface-1)" stroke="var(--border)"/>
-<text class="th" x="545" y="202" text-anchor="middle">M4 · reward</text>
-<text class="ts" x="545" y="218" text-anchor="middle">ValueHead · decomposed</text>
+<text class="th" x="545" y="202" text-anchor="middle">RewardVerifier</text>
+<text class="ts" x="545" y="218" text-anchor="middle">structured verify · dense reward</text>
 
 <rect x="60" y="258" width="250" height="44" rx="6" fill="var(--surface-1)" stroke="var(--border)"/>
-<text class="th" x="185" y="277" text-anchor="middle">M5 · world model (Stage 3)</text>
+<text class="th" x="185" y="277" text-anchor="middle">WorldModel (Stage 3)</text>
 <text class="ts" x="185" y="293" text-anchor="middle">learn pending→applied · jobs</text>
 
 <line x1="135" y1="230" x2="185" y2="258" stroke="var(--text-secondary)" marker-end="url(#a4)"/>
@@ -49,6 +49,6 @@ rect.c-purple{fill:#EEEDFE;stroke:#AFA9EC}.c-purple text{fill:#26215C}
 <line x1="545" y1="230" x2="492" y2="320" stroke="var(--text-secondary)" marker-end="url(#a4)"/>
 <line x1="300" y1="296" x2="240" y2="320" stroke="var(--text-secondary)" marker-end="url(#a4)"/>
 
-<g class="c-coral"><rect class="c-coral" x="170" y="324" width="340" height="46" rx="6"/><text class="th" x="340" y="344" text-anchor="middle">M6 · RL agent (Stage 4 · longest)</text><text class="ts" x="340" y="360" text-anchor="middle">goal-cond. DQN + HER on ToolAction</text></g>
-<text class="ts" x="340" y="388" text-anchor="middle">M6 consumes M2 latent · z_sub_goal · M4+M5 reward — and learns the optimal ordering</text>
+<g class="c-coral"><rect class="c-coral" x="170" y="324" width="340" height="46" rx="6"/><text class="th" x="340" y="344" text-anchor="middle">RLPolicy (Stage 4 · longest)</text><text class="ts" x="340" y="360" text-anchor="middle">goal-cond. DQN + HER on ToolAction</text></g>
+<text class="ts" x="340" y="388" text-anchor="middle">RLPolicy consumes state latent · z_goal · verifier/world signals — and learns ordering</text>
 </svg>

--- a/docs/phase_1.md
+++ b/docs/phase_1.md
@@ -1,8 +1,10 @@
 # Phase 1: Redfish JSON Pretraining
 
-Phase 1 trains `model_x` on Redfish JSON reconstruction. This phase does not train goal extraction,
-argument extraction, ordering, rewards, or RL behavior. It only teaches the chosen LLM the shape of
-Redfish resources, URI grammar, method context, and JSON completion.
+Phase 1 trains `model_x` on Redfish JSON reconstruction. In the architecture docs this is the
+pretraining/fine-tuning step that produces the M1 backbone checkpoint; M2, the state
+pooler/autoencoder, is a later consumer of that checkpoint. This phase does not train goal
+extraction, argument extraction, ordering, rewards, or RL behavior. It only teaches the chosen LLM
+the shape of Redfish resources, URI grammar, method context, and JSON completion.
 
 Names are fixed as follows:
 
@@ -101,37 +103,37 @@ Use the `PHASE1_WANDB_METRIC_KEYS` registry, defined in
 `igc/modules/base/metric_keys.py`, for metrics that the current trainer can emit.
 The live registry keeps Phase 1 curves separate from goal extraction or RL:
 
-- `phase1_pretrain/train/loss`
-- `phase1_pretrain/train/epoch_loss`
-- `phase1_pretrain/train/perplexity`
-- `phase1_pretrain/train/epoch_perplexity`
-- `phase1_pretrain/train/optimizer_step`
-- `phase1_pretrain/train/tokens_processed`
-- `phase1_pretrain/eval/loss`
-- `phase1_pretrain/eval/perplexity`
-- `phase1_pretrain/eval/token_accuracy`
-- `phase1_pretrain/throughput/train_tokens_per_sec`
-- `phase1_pretrain/throughput/train_samples_per_sec`
+- `phase1_finetune/train/loss`
+- `phase1_finetune/train/epoch_loss`
+- `phase1_finetune/train/perplexity`
+- `phase1_finetune/train/epoch_perplexity`
+- `phase1_finetune/train/optimizer_step`
+- `phase1_finetune/train/tokens_processed`
+- `phase1_finetune/eval/loss`
+- `phase1_finetune/eval/perplexity`
+- `phase1_finetune/eval/token_accuracy`
+- `phase1_finetune/throughput/train_tokens_per_sec`
+- `phase1_finetune/throughput/train_samples_per_sec`
 
 The acceptance gate below still requires reconstruction, throughput, data-shape,
 calibration, and test-time evidence before a full Phase 1 run is accepted. These
 metric names are intentionally not in the live registry until the producer code
 lands:
 
-- `phase1_pretrain/eval/top_k_accuracy`
-- `phase1_pretrain/eval/json_parse_rate`
-- `phase1_pretrain/eval/json_exact_match_rate`
-- `phase1_pretrain/eval/odata_id_match_rate`
-- `phase1_pretrain/throughput/eval_tokens_per_sec`
-- `phase1_pretrain/throughput/eval_samples_per_sec`
-- `phase1_pretrain/data/padding_ratio`
-- `phase1_pretrain/data/mean_sequence_length`
-- `phase1_pretrain/data/max_sequence_length`
-- `phase1_pretrain/calibration/log_prob_per_token`
-- `phase1_pretrain/calibration/ece`
-- `phase1_pretrain/test/latency_sec_p50`
-- `phase1_pretrain/test/latency_sec_p95`
-- `phase1_pretrain/test/memory_peak_mb`
+- `phase1_finetune/eval/top_k_accuracy`
+- `phase1_finetune/eval/json_parse_rate`
+- `phase1_finetune/eval/json_exact_match_rate`
+- `phase1_finetune/eval/odata_id_match_rate`
+- `phase1_finetune/throughput/eval_tokens_per_sec`
+- `phase1_finetune/throughput/eval_samples_per_sec`
+- `phase1_finetune/data/padding_ratio`
+- `phase1_finetune/data/mean_sequence_length`
+- `phase1_finetune/data/max_sequence_length`
+- `phase1_finetune/calibration/log_prob_per_token`
+- `phase1_finetune/calibration/ece`
+- `phase1_finetune/test/latency_sec_p50`
+- `phase1_finetune/test/latency_sec_p95`
+- `phase1_finetune/test/memory_peak_mb`
 
 ## Acceptance Gate
 

--- a/docs/phase_1.md
+++ b/docs/phase_1.md
@@ -106,8 +106,12 @@ cross-entropy only on the `y_true` JSON completion.
 ## Phase 1 W&B Metrics
 
 Use the `PHASE1_WANDB_METRIC_KEYS` registry, defined in
-`igc/modules/base/metric_keys.py`, for metrics that the current trainer can emit.
+`igc/modules/base/metric_keys.py`, for metrics that the current Phase 1 training
+surface tracks or reserves.
 The live registry keeps Phase 1 curves separate from goal extraction or RL:
+
+Current Phase 1 has the W&B namespace and basic training/eval metrics, but it does
+not yet have the full train/validation/test/calibration gate.
 
 - `phase1_finetune/train/loss`
 - `phase1_finetune/train/epoch_loss`
@@ -140,6 +144,29 @@ lands:
 - `phase1_finetune/test/latency_sec_p50`
 - `phase1_finetune/test/latency_sec_p95`
 - `phase1_finetune/test/memory_peak_mb`
+
+## Phase 1 Stopping Rule
+
+Full Phase 1 fine-tuning should select `model_x` by validation loss, not by the
+test split and not by token accuracy alone:
+
+- primary metric: `phase1_finetune/eval/loss`
+- mode: minimize
+- patience: 3 evaluation calls
+- min delta: 0.005 to 0.01 validation loss
+- max epochs: 5 to 10 for small corpora unless the validation curve still improves
+- evaluation cadence: 4 evaluations per epoch as the starting point
+- save cadence: every evaluation call
+
+For example, if one epoch has 100 optimizer steps, start with `eval_steps=25`
+and `save_steps=25`. Save a checkpoint at every evaluation, track the lowest
+validation loss, stop after three evaluations without a meaningful improvement,
+and restore the checkpoint with the lowest validation loss.
+
+Secondary and diagnostic metrics:
+
+- secondary: `phase1_finetune/eval/perplexity`
+- diagnostic: `phase1_finetune/eval/token_accuracy`
 
 ## Acceptance Gate
 

--- a/docs/phase_1.md
+++ b/docs/phase_1.md
@@ -1,14 +1,16 @@
 # Phase 1: Redfish JSON Pretraining
 
-Phase 1 trains `model_x` on Redfish JSON reconstruction. In the architecture docs this is the
-pretraining/fine-tuning step that produces the M1 backbone checkpoint; M2, the state
-pooler/autoencoder, is a later consumer of that checkpoint. This phase does not train goal
-extraction, argument extraction, ordering, rewards, or RL behavior. It only teaches the chosen LLM
+Phase 1 trains `model_x` on Redfish JSON reconstruction. This is the RedfishBackbone
+pretraining/fine-tuning step; StateEncoder, goal extraction, argument extraction, rewards, and RL
+policy training are separate consumers with separate weights. This phase only teaches the chosen LLM
 the shape of Redfish resources, URI grammar, method context, and JSON completion.
 
 Names are fixed as follows:
 
 - `model_x`: the chosen base LLM after this Redfish JSON pretraining step.
+- `weights_role`: `model_x`; this run writes a separate Phase 1 checkpoint.
+- `profile`: a `phase1_*` training profile from `igc/modules/train/profiles.py`.
+- `corpus_objective`: `phase1_pretrain`, the Redfish JSON reconstruction objective.
 - `x`: the input context shown to the model.
 - `y_true`: the exact target JSON the model should emit.
 - `y_pred`: the model output during inference or evaluation.
@@ -23,6 +25,10 @@ words, this phase trains:
 ```text
 P(y_true.json | x.rest_api, x.allowed_methods, x.json)
 ```
+
+Checkpoint rule: Phase 1 writes `model_x` only. Later Phase 2/3 runs may initialize from that
+checkpoint, but they must write `goal_extractor` and `argument_extractor` checkpoints in distinct
+output directories and W&B groups.
 
 ## JSONL Row
 

--- a/docs/phase_2.md
+++ b/docs/phase_2.md
@@ -172,37 +172,37 @@ Cross-entropy is computed on the target JSON tokens. Evaluation parses `y_pred`,
 
 ## Phase 2 W&B Metrics
 
-- `phase2_goal_extract/train/loss`
-- `phase2_goal_extract/train/perplexity`
-- `phase2_goal_extract/train/optimizer_step`
-- `phase2_goal_extract/eval/loss`
-- `phase2_goal_extract/eval/perplexity`
-- `phase2_goal_extract/eval/token_accuracy`
-- `phase2_goal_extract/eval/ordered_exact_match_rate`
-- `phase2_goal_extract/eval/set_match_rate`
-- `phase2_goal_extract/eval/precision`
-- `phase2_goal_extract/eval/recall`
-- `phase2_goal_extract/eval/f1`
-- `phase2_goal_extract/eval/top_k_api_accuracy`
-- `phase2_goal_extract/eval/invalid_api_rate`
-- `phase2_goal_extract/eval/missing_required_api_rate`
-- `phase2_goal_extract/eval/missing_allowed_methods_rate`
-- `phase2_goal_extract/eval/order_violation_rate`
-- `phase2_goal_extract/order/kendall_tau`
-- `phase2_goal_extract/order/edit_distance`
-- `phase2_goal_extract/throughput/train_tokens_per_sec`
-- `phase2_goal_extract/throughput/train_samples_per_sec`
-- `phase2_goal_extract/throughput/eval_tokens_per_sec`
-- `phase2_goal_extract/throughput/eval_samples_per_sec`
-- `phase2_goal_extract/data/avg_num_apis`
-- `phase2_goal_extract/data/max_num_apis`
-- `phase2_goal_extract/data/mean_sequence_length`
-- `phase2_goal_extract/data/padding_ratio`
-- `phase2_goal_extract/calibration/log_prob_per_sequence`
-- `phase2_goal_extract/calibration/ece`
-- `phase2_goal_extract/test/latency_sec_p50`
-- `phase2_goal_extract/test/latency_sec_p95`
-- `phase2_goal_extract/test/memory_peak_mb`
+- `phase2_goal_extraction/train/loss`
+- `phase2_goal_extraction/train/perplexity`
+- `phase2_goal_extraction/train/optimizer_step`
+- `phase2_goal_extraction/eval/loss`
+- `phase2_goal_extraction/eval/perplexity`
+- `phase2_goal_extraction/eval/token_accuracy`
+- `phase2_goal_extraction/eval/ordered_exact_match_rate`
+- `phase2_goal_extraction/eval/set_match_rate`
+- `phase2_goal_extraction/eval/precision`
+- `phase2_goal_extraction/eval/recall`
+- `phase2_goal_extraction/eval/f1`
+- `phase2_goal_extraction/eval/top_k_api_accuracy`
+- `phase2_goal_extraction/eval/invalid_api_rate`
+- `phase2_goal_extraction/eval/missing_required_api_rate`
+- `phase2_goal_extraction/eval/missing_allowed_methods_rate`
+- `phase2_goal_extraction/eval/order_violation_rate`
+- `phase2_goal_extraction/order/kendall_tau`
+- `phase2_goal_extraction/order/edit_distance`
+- `phase2_goal_extraction/throughput/train_tokens_per_sec`
+- `phase2_goal_extraction/throughput/train_samples_per_sec`
+- `phase2_goal_extraction/throughput/eval_tokens_per_sec`
+- `phase2_goal_extraction/throughput/eval_samples_per_sec`
+- `phase2_goal_extraction/data/avg_num_apis`
+- `phase2_goal_extraction/data/max_num_apis`
+- `phase2_goal_extraction/data/mean_sequence_length`
+- `phase2_goal_extraction/data/padding_ratio`
+- `phase2_goal_extraction/calibration/log_prob_per_sequence`
+- `phase2_goal_extraction/calibration/ece`
+- `phase2_goal_extraction/test/latency_sec_p50`
+- `phase2_goal_extraction/test/latency_sec_p95`
+- `phase2_goal_extraction/test/memory_peak_mb`
 
 When Phase 2 moves beyond mock plumbing, its acceptance gate must mirror Phase 1: approved full
 corpora, readable W&B plots, checkpoint/report storage, and reviewed Git LFS artifact metadata.

--- a/docs/phase_2.md
+++ b/docs/phase_2.md
@@ -8,6 +8,10 @@ Names are fixed as follows:
 - `D0`: Phase 1 JSON reconstruction data.
 - `D1`: Phase 2 text-to-ordered-REST-goal data.
 - `model_x`: the Phase 1 Redfish-tuned LLM.
+- `goal_extractor`: the separate Phase 2 fine-tuned weight role.
+- `profile`: a planned `phase2_goal_extractor_*` training profile.
+- `base_weights_role`: `model_x`, when Phase 2 initializes from the Phase 1 checkpoint.
+- `weights_role`: `goal_extractor`; Phase 2 must not overwrite the Phase 1 checkpoint.
 - `x`: the input context shown to the model.
 - `y_true`: the exact target label stored in the dataset.
 - `y_pred`: the model output during inference or evaluation.
@@ -20,6 +24,10 @@ Phase 2 output is ordered. If the operator sentence says "check tasks, then chec
 target order is tasks first and systems second. If the sentence has no explicit order, the dataset
 builder still stores a deterministic order and marks that order as weak evidence so evaluation can
 separate exact-order accuracy from set-recall.
+
+Checkpoint rule: Phase 2 writes only `goal_extractor` artifacts. A run config must record the input
+checkpoint path for `model_x`, the output path for `goal_extractor`, the `phase2_goal_extraction/*`
+W&B namespace, and the exact `D1` dataset manifest used for training.
 
 ## D1 Build Input
 

--- a/docs/phase_3.md
+++ b/docs/phase_3.md
@@ -133,37 +133,37 @@ body is not proof that the resource accepts that value in a PATCH or POST body.
 
 ## Phase 3 W&B Metrics
 
-- `phase3_argument_extract/train/loss`
-- `phase3_argument_extract/train/perplexity`
-- `phase3_argument_extract/train/optimizer_step`
-- `phase3_argument_extract/eval/loss`
-- `phase3_argument_extract/eval/perplexity`
-- `phase3_argument_extract/eval/token_accuracy`
-- `phase3_argument_extract/eval/call_ordered_exact_match_rate`
-- `phase3_argument_extract/eval/call_order_correct_rate`
-- `phase3_argument_extract/eval/step_exact_match_rate`
-- `phase3_argument_extract/eval/rest_api_exact_match_rate`
-- `phase3_argument_extract/eval/allowed_methods_exact_match_rate`
-- `phase3_argument_extract/eval/method_exact_match_rate`
-- `phase3_argument_extract/eval/arguments_json_parse_rate`
-- `phase3_argument_extract/eval/arguments_exact_match_rate`
-- `phase3_argument_extract/eval/invalid_method_rate`
-- `phase3_argument_extract/eval/readonly_empty_arguments_rate`
-- `phase3_argument_extract/order/kendall_tau`
-- `phase3_argument_extract/order/edit_distance`
-- `phase3_argument_extract/throughput/train_tokens_per_sec`
-- `phase3_argument_extract/throughput/train_samples_per_sec`
-- `phase3_argument_extract/throughput/eval_tokens_per_sec`
-- `phase3_argument_extract/throughput/eval_samples_per_sec`
-- `phase3_argument_extract/data/avg_num_calls`
-- `phase3_argument_extract/data/avg_arguments_length`
-- `phase3_argument_extract/data/mean_sequence_length`
-- `phase3_argument_extract/data/padding_ratio`
-- `phase3_argument_extract/calibration/log_prob_per_call`
-- `phase3_argument_extract/calibration/ece_method`
-- `phase3_argument_extract/test/latency_sec_p50`
-- `phase3_argument_extract/test/latency_sec_p95`
-- `phase3_argument_extract/test/memory_peak_mb`
+- `phase3_argument_extraction/train/loss`
+- `phase3_argument_extraction/train/perplexity`
+- `phase3_argument_extraction/train/optimizer_step`
+- `phase3_argument_extraction/eval/loss`
+- `phase3_argument_extraction/eval/perplexity`
+- `phase3_argument_extraction/eval/token_accuracy`
+- `phase3_argument_extraction/eval/call_ordered_exact_match_rate`
+- `phase3_argument_extraction/eval/call_order_correct_rate`
+- `phase3_argument_extraction/eval/step_exact_match_rate`
+- `phase3_argument_extraction/eval/rest_api_exact_match_rate`
+- `phase3_argument_extraction/eval/allowed_methods_exact_match_rate`
+- `phase3_argument_extraction/eval/method_exact_match_rate`
+- `phase3_argument_extraction/eval/arguments_json_parse_rate`
+- `phase3_argument_extraction/eval/arguments_exact_match_rate`
+- `phase3_argument_extraction/eval/invalid_method_rate`
+- `phase3_argument_extraction/eval/readonly_empty_arguments_rate`
+- `phase3_argument_extraction/order/kendall_tau`
+- `phase3_argument_extraction/order/edit_distance`
+- `phase3_argument_extraction/throughput/train_tokens_per_sec`
+- `phase3_argument_extraction/throughput/train_samples_per_sec`
+- `phase3_argument_extraction/throughput/eval_tokens_per_sec`
+- `phase3_argument_extraction/throughput/eval_samples_per_sec`
+- `phase3_argument_extraction/data/avg_num_calls`
+- `phase3_argument_extraction/data/avg_arguments_length`
+- `phase3_argument_extraction/data/mean_sequence_length`
+- `phase3_argument_extraction/data/padding_ratio`
+- `phase3_argument_extraction/calibration/log_prob_per_call`
+- `phase3_argument_extraction/calibration/ece_method`
+- `phase3_argument_extraction/test/latency_sec_p50`
+- `phase3_argument_extraction/test/latency_sec_p95`
+- `phase3_argument_extraction/test/memory_peak_mb`
 
 When Phase 3 moves beyond mock plumbing, its acceptance gate must mirror Phase 1: approved full
 corpora, readable W&B plots, checkpoint/report storage, and reviewed Git LFS artifact metadata.

--- a/docs/phase_3.md
+++ b/docs/phase_3.md
@@ -7,7 +7,12 @@ the ordered `rest_api_list` from Phase 2, the model must produce the method and 
 Names are fixed as follows:
 
 - `D1`: Phase 2 text-to-ordered-REST-goal data.
-- `model_x`: the Phase 1 Redfish-tuned LLM, cloned or continued for this fine-tune.
+- `model_x`: the Phase 1 Redfish-tuned LLM.
+- `goal_extractor`: the separate Phase 2 weight role, used upstream to produce `rest_api_list`.
+- `argument_extractor`: the separate Phase 3 fine-tuned weight role.
+- `profile`: a planned `phase3_argument_extractor_*` training profile.
+- `base_weights_role`: `model_x` or `goal_extractor`, whichever the run explicitly initializes from.
+- `weights_role`: `argument_extractor`; Phase 3 must not overwrite Phase 1 or Phase 2 checkpoints.
 - `x`: the input context shown to the model.
 - `y_true`: the exact target label stored in the dataset.
 - `y_pred`: the model output during inference or evaluation.
@@ -20,6 +25,10 @@ Names are fixed as follows:
 
 Phase 3 does not choose new REST APIs. It fills `method` and `arguments` for the ordered
 `rest_api_list` already produced by Phase 2.
+
+Checkpoint rule: Phase 3 writes only `argument_extractor` artifacts. A run config must record the
+input checkpoint path, the output path for `argument_extractor`, the `phase3_argument_extraction/*`
+W&B namespace, and the exact dataset manifest used for training.
 
 ## Phase 3 Row From D1
 

--- a/igc/ds/corpus_dataset.py
+++ b/igc/ds/corpus_dataset.py
@@ -31,11 +31,11 @@ from torch.utils.data import Dataset
 
 from igc.ds.sources.corpus_io import iter_examples, read_manifest
 from igc.ds.sources.mixer import DataManifest
-from igc.modules.base.metric_keys import PHASE1_PRETRAIN
+from igc.modules.base.metric_keys import PHASE1_FINETUNE, PHASE1_OBJECTIVE_PRETRAIN
 
 
 LEGACY_OBJECTIVE = "legacy"
-PHASE1_PRETRAIN_OBJECTIVE = PHASE1_PRETRAIN
+PHASE1_PRETRAIN_OBJECTIVE = PHASE1_OBJECTIVE_PRETRAIN
 CORPUS_OBJECTIVES = (LEGACY_OBJECTIVE, PHASE1_PRETRAIN_OBJECTIVE)
 
 
@@ -64,7 +64,7 @@ class CorpusJSONLDataset(Dataset):
         if objective not in CORPUS_OBJECTIVES:
             raise ValueError(
                 f"unknown corpus objective {objective!r}; choose from {CORPUS_OBJECTIVES}")
-        self.metric_namespace = PHASE1_PRETRAIN if objective == PHASE1_PRETRAIN_OBJECTIVE else ""
+        self.metric_namespace = PHASE1_FINETUNE if objective == PHASE1_PRETRAIN_OBJECTIVE else ""
 
         examples_path = os.path.join(self._corpus_dir, "examples.jsonl")
         if not os.path.isfile(examples_path):

--- a/igc/modules/base/igc_base_module.py
+++ b/igc/modules/base/igc_base_module.py
@@ -36,7 +36,14 @@ BatchItem = namedtuple('BatchItem', ['prompt', 'goal'])
 
 # a checkpoint state
 CheckpointState = namedtuple('Checkpoint', [
-    'last_epoch', 'scheduler_state', 'initial_lr', 'best_accuracy', 'batch_idx'])
+    'last_epoch',        # epoch stored in the checkpoint (0 when starting fresh)
+    'scheduler_state',   # raw scheduler state dict(s) from the checkpoint, or None
+    'initial_lr',        # learning rate recorded at save time, or None
+    'best_accuracy',     # legacy accuracy channel (last_accuracy at save time)
+    'batch_idx',         # mid-epoch batch index for batch-level resume (0 otherwise)
+    'best_metric',       # best-selection metric at save time (loss or accuracy), or None
+    'best_metric_mode',  # which metric best_metric holds: 'loss' | 'accuracy' | None
+], defaults=(None, None))  # the two best_metric fields are absent in legacy checkpoints
 
 
 class DownloadModuleError(Exception):
@@ -580,6 +587,8 @@ class IgcModule(IgcBaseState):
             is_best_accuracy: Optional[bool] = False,
             batch_idx: Optional[int] = None,
             model_state_dict: Optional[Dict] = None,
+            best_metric: Optional[float] = None,
+            best_metric_mode: Optional[str] = None,
     ) -> str:
         """
         Save model checkpoint.
@@ -597,6 +606,10 @@ class IgcModule(IgcBaseState):
         :param last_accuracy: if the last accuracy provide we save it , so we can track it.
         :param is_best_accuracy: if the is_best_accuracy accuracy we save it as separate file.
         :param batch_idx:  if we're saving during batch training, we save the batch_idx
+        :param best_metric: best-selection metric so far (validation loss or accuracy),
+                            persisted so a resumed run keeps its best tracking.
+        :param best_metric_mode: which metric ``best_metric`` holds: ``'loss'`` or
+                                 ``'accuracy'``; restore only honors a matching mode.
         :return:  return path where checkpoint saved
         """
 
@@ -634,6 +647,13 @@ class IgcModule(IgcBaseState):
 
         if last_accuracy is not None:
             checkpoint['last_accuracy'] = last_accuracy
+
+        # persisted together so a resumed run can restore best tracking without
+        # mistaking a loss-mode best for an accuracy-mode best (or vice versa).
+        if best_metric is not None:
+            checkpoint['best_metric'] = float(best_metric)
+        if best_metric_mode is not None:
+            checkpoint['best_metric_mode'] = str(best_metric_mode)
 
         if initial_lr is not None:
             checkpoint['initial_lr'] = initial_lr
@@ -771,13 +791,19 @@ class IgcModule(IgcBaseState):
         initial_lr = checkpoint['initial_lr'] if "initial_lr" in checkpoint else None
         batch_idx = checkpoint['batch_idx'] if "batch_idx" in checkpoint else 0
         epoch = checkpoint['epoch'] if "epoch" in checkpoint else 0
+        # legacy checkpoints predate the best-metric channel; both default to None
+        # so a resumed trainer knows to start best tracking fresh.
+        best_metric = checkpoint.get('best_metric')
+        best_metric_mode = checkpoint.get('best_metric_mode')
 
         self.logger.info(
             f"Rank: {self.rank} module {self.module_name} "
             f"loaded checkpoint from "
             f"{checkpoint_file}, epoch: {epoch}")
 
-        return CheckpointState(epoch, scheduler, initial_lr, last_accuracy, batch_idx)
+        return CheckpointState(
+            epoch, scheduler, initial_lr, last_accuracy, batch_idx,
+            best_metric, best_metric_mode)
 
     @staticmethod
     def load(

--- a/igc/modules/base/metric_factory.py
+++ b/igc/modules/base/metric_factory.py
@@ -152,13 +152,18 @@ def _wandb_run_meta(kw: dict) -> dict:
     :return: a dict of ``name``, ``group``, ``job_type``, ``tags``, ``config``.
     """
     train, llm = kw.get("train"), kw.get("llm")
+    profile = str(kw.get("profile") or "")
+    corpus_objective = str(kw.get("corpus_objective") or "")
     stage_map = {
         ("llm", "latent"): "m1-state-encoder",
         ("llm", "all"): "m1m2-encoder",
         ("llm", "goal"): "goal-extractor-legacy",
         ("llm", "parameter"): "param-extractor-legacy",
     }
-    if train in ("agent",) or kw.get("rl"):
+    rl_stage = str(kw.get("rl") or "").lower()
+    if profile.startswith("phase1_") or corpus_objective == "phase1_pretrain":
+        stage = "phase1-finetune"
+    elif train in ("agent",) or rl_stage not in ("", "none"):
         stage = "m6-rl-agent"
     else:
         stage = stage_map.get((train, llm), f"{train or 'run'}-{llm}" if llm else (train or "run"))
@@ -186,6 +191,7 @@ def _wandb_run_meta(kw: dict) -> dict:
         "model_type", "train", "llm", "rl", "num_train_epochs",
         "per_device_train_batch_size", "num_workers", "use_peft",
         "lora_r", "lora_alpha", "sharding", "llm_torch_dtype", "device",
+        "profile", "weights_role", "corpus_objective",
     ]
     config = {k: kw[k] for k in config_keys if k in kw}
 

--- a/igc/modules/base/metric_keys.py
+++ b/igc/modules/base/metric_keys.py
@@ -9,15 +9,16 @@ Mus mbayramo@stanford.edu
 """
 from __future__ import annotations
 
-PHASE1_PRETRAIN = "phase1_pretrain"
-PHASE2_GOAL_EXTRACT = "phase2_goal_extract"
-PHASE3_ARGUMENT_EXTRACT = "phase3_argument_extract"
+PHASE1_OBJECTIVE_PRETRAIN = "phase1_pretrain"
+PHASE1_FINETUNE = "phase1_finetune"
+PHASE2_GOAL_EXTRACT = "phase2_goal_extraction"
+PHASE3_ARGUMENT_EXTRACT = "phase3_argument_extraction"
 
 
 def phase_metric(namespace: str, group: str, name: str) -> str:
     """Return a stable ``<namespace>/<group>/<name>`` metric key.
 
-    :param namespace: Phase namespace, for example :data:`PHASE1_PRETRAIN`.
+    :param namespace: Phase namespace, for example :data:`PHASE1_FINETUNE`.
     :param group: Metric group such as ``train`` or ``eval``.
     :param name: Metric name inside the group.
     :return: Slash-separated W&B/TensorBoard metric key.
@@ -29,17 +30,17 @@ def phase_metric(namespace: str, group: str, name: str) -> str:
 
 
 PHASE1_WANDB_METRIC_KEYS = (
-    phase_metric(PHASE1_PRETRAIN, "train", "loss"),
-    phase_metric(PHASE1_PRETRAIN, "train", "epoch_loss"),
-    phase_metric(PHASE1_PRETRAIN, "train", "perplexity"),
-    phase_metric(PHASE1_PRETRAIN, "train", "epoch_perplexity"),
-    phase_metric(PHASE1_PRETRAIN, "train", "optimizer_step"),
-    phase_metric(PHASE1_PRETRAIN, "train", "tokens_processed"),
-    phase_metric(PHASE1_PRETRAIN, "eval", "loss"),
-    phase_metric(PHASE1_PRETRAIN, "eval", "perplexity"),
-    phase_metric(PHASE1_PRETRAIN, "eval", "token_accuracy"),
-    phase_metric(PHASE1_PRETRAIN, "throughput", "train_tokens_per_sec"),
-    phase_metric(PHASE1_PRETRAIN, "throughput", "train_samples_per_sec"),
+    phase_metric(PHASE1_FINETUNE, "train", "loss"),
+    phase_metric(PHASE1_FINETUNE, "train", "epoch_loss"),
+    phase_metric(PHASE1_FINETUNE, "train", "perplexity"),
+    phase_metric(PHASE1_FINETUNE, "train", "epoch_perplexity"),
+    phase_metric(PHASE1_FINETUNE, "train", "optimizer_step"),
+    phase_metric(PHASE1_FINETUNE, "train", "tokens_processed"),
+    phase_metric(PHASE1_FINETUNE, "eval", "loss"),
+    phase_metric(PHASE1_FINETUNE, "eval", "perplexity"),
+    phase_metric(PHASE1_FINETUNE, "eval", "token_accuracy"),
+    phase_metric(PHASE1_FINETUNE, "throughput", "train_tokens_per_sec"),
+    phase_metric(PHASE1_FINETUNE, "throughput", "train_samples_per_sec"),
 )
 
 PHASE2_WANDB_METRIC_KEYS = (

--- a/igc/modules/llm_train_state_encoder.py
+++ b/igc/modules/llm_train_state_encoder.py
@@ -10,6 +10,7 @@ Author:Mus mbayramo@stanford.edu
 """
 import argparse
 import time
+from dataclasses import dataclass
 from typing import Optional, Tuple, Union, List
 
 import numpy as np
@@ -32,6 +33,18 @@ from igc.ds.redfish_masked_dataset import (
     MaskedJSONDataset,
     MaskingType
 )
+
+
+@dataclass(frozen=True)
+class ValidationMetrics:
+    """Aggregated validation metrics shared by every rank.
+
+    :param loss: Token-weighted validation cross-entropy loss.
+    :param accuracy: Shifted-token accuracy as a percentage for legacy logging.
+    """
+
+    loss: float
+    accuracy: float
 
 
 def build_causal_lm_labels(input_ids, attention_mask, pad_token_id=None):
@@ -138,6 +151,31 @@ def reached_max_steps(global_step: int, max_steps: Optional[int]) -> bool:
     return max_steps is not None and max_steps > 0 and global_step >= max_steps
 
 
+def validation_accuracy(value: Union[ValidationMetrics, float]) -> float:
+    """Return percent token accuracy from either old or structured validation output."""
+    if isinstance(value, ValidationMetrics):
+        return value.accuracy
+    return float(value)
+
+
+def validation_loss(value: Union[ValidationMetrics, float]) -> float:
+    """Return validation loss, or ``inf`` when only legacy accuracy is available."""
+    if isinstance(value, ValidationMetrics):
+        return value.loss
+    return float("inf")
+
+
+def shifted_token_loss(logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+    """Return HF CausalLM-style shifted CE loss for full-length labels."""
+    shifted_logits = logits[..., :-1, :].contiguous()
+    shifted_labels = labels[..., 1:].contiguous()
+    return F.cross_entropy(
+        shifted_logits.view(-1, shifted_logits.size(-1)),
+        shifted_labels.view(-1).long(),
+        ignore_index=-100,
+    )
+
+
 def unwrap_accelerate(wrapped, inner_attr: str):
     """Return the base optimizer/scheduler that accelerate wrapped, or ``wrapped``.
 
@@ -226,9 +264,13 @@ class LlmEmbeddingsTrainer(LlmModule):
         )
 
         self._mask_probability = 1.0
-        self._best_validation_metric = float('-inf')
         self.dataset = dataset
         self._metric_namespace = getattr(dataset, "metric_namespace", "")
+        self._select_best_by_eval_loss = bool(self._metric_namespace)
+        self._best_validation_metric = float('inf') if self._select_best_by_eval_loss else float('-inf')
+        self._early_stopping_patience = int(getattr(spec, "early_stopping_patience", 3) or 3)
+        self._early_stopping_min_delta = float(
+            getattr(spec, "early_stopping_min_delta", 0.005) or 0.005)
 
         self.logger.info(
             f"Rank {self.rank} creating llm trainer, num epochs {self.num_epochs} "
@@ -347,12 +389,14 @@ class LlmEmbeddingsTrainer(LlmModule):
         """Perform validation on the embedding language model.
 
         :param validation_dataset: Iterable validation dataloader of tokenized batches.
-        :return: Accuracy percentage on the validation dataset.
+        :return: Token-weighted loss and accuracy percentage on the validation dataset.
         """
 
         self.model.eval()
         correct_predictions = 0
         total_predictions = 0
+        loss_sum = 0.0
+        loss_tokens = 0
 
         with torch.no_grad():
             for i, batch in enumerate(validation_dataset):
@@ -361,14 +405,25 @@ class LlmEmbeddingsTrainer(LlmModule):
                 labels = causal_lm_labels_from_batch(
                     batch, input_ids, attention_mask, self.tokenizer.pad_token_id)
 
-                batch_inputs = {'input_ids': input_ids, 'attention_mask': attention_mask}
+                batch_inputs = {
+                    'input_ids': input_ids,
+                    'attention_mask': attention_mask,
+                    'labels': labels,
+                }
 
                 outputs = self.model(**batch_inputs)
+                loss = outputs.loss
+                if loss is None:
+                    loss = shifted_token_loss(outputs.logits, labels)
                 predictions = torch.argmax(outputs.logits[:, :-1, :], dim=-1)
                 targets = labels[:, 1:]
                 valid = targets.ne(-100)
                 correct_predictions += ((predictions == targets) & valid).sum().item()
-                total_predictions += valid.sum().item()
+                active = int(valid.sum().item())
+                total_predictions += active
+                if active and torch.isfinite(loss):
+                    loss_sum += float(loss.item()) * active
+                    loss_tokens += active
 
         # Global metric: each rank validates only its own eval shard, so a rank-LOCAL accuracy makes
         # ranks disagree on "best" and enter the epoch-boundary save collective asymmetrically — the
@@ -376,15 +431,24 @@ class LlmEmbeddingsTrainer(LlmModule):
         # computes the SAME global accuracy (accelerate's reduce is an all-reduce: sum lands on all).
         if getattr(self, "is_accelerator", False) and getattr(self, "accelerator", None) is not None:
             stats = torch.tensor(
-                [float(correct_predictions), float(total_predictions)],
+                [
+                    float(correct_predictions),
+                    float(total_predictions),
+                    float(loss_sum),
+                    float(loss_tokens),
+                ],
                 dtype=torch.float64, device=self.device)
             stats = self.accelerator.reduce(stats, reduction="sum")
-            correct_predictions, total_predictions = stats[0].item(), stats[1].item()
+            correct_predictions = stats[0].item()
+            total_predictions = stats[1].item()
+            loss_sum = stats[2].item()
+            loss_tokens = stats[3].item()
 
         # Guard: with drop_last + a small eval shard a rank can get 0 eval batches; a
-        # bare division would crash (and take the fleet down mid-epoch) — return 0.0.
+        # bare division would crash (and take the fleet down mid-epoch).
         accuracy = (correct_predictions / total_predictions * 100.0) if total_predictions else 0.0
-        return accuracy
+        loss = (loss_sum / loss_tokens) if loss_tokens else float("inf")
+        return ValidationMetrics(loss=loss, accuracy=accuracy)
 
     def is_distributed(self):
         """
@@ -569,10 +633,12 @@ class LlmEmbeddingsTrainer(LlmModule):
         )
 
         last_epoch = checkpoint_state.last_epoch
-        # Seed the pre-loop accuracy with the restored best, not the epoch number: on epochs
-        # where eval doesn't run, this value feeds `is_best_accuracy` below, so an epoch
-        # integer here would spuriously beat _best_validation_metric and corrupt best-checkpoint tracking.
-        validation_accuracy = checkpoint_state.best_accuracy
+        # Legacy runs seed best tracking from the checkpoint's accuracy channel. Phase 1
+        # selects by validation loss, so a fresh run starts at +inf until the first eval.
+        validation_result = ValidationMetrics(
+            loss=float("inf"),
+            accuracy=checkpoint_state.best_accuracy,
+        )
         self._trainer_args.epochs = self.num_epochs - last_epoch
         _accum = max(1, int(getattr(self._trainer_args, "gradient_accumulation_steps", 1)))
         self._trainer_args.steps_per_epoch = optimizer_steps_per_epoch(
@@ -645,6 +711,7 @@ class LlmEmbeddingsTrainer(LlmModule):
         epochs_done = last_epoch
         tokens_processed = 0
         samples_processed = 0
+        early_stop_bad_evals = 0
 
         if total_batches == calculated_total_batches:
             print(f"Rank {self.rank}, Staring training, "
@@ -776,18 +843,52 @@ class LlmEmbeddingsTrainer(LlmModule):
             epoch_step = (epoch + 1) * total_batches - 1
 
             # validation on epoch or freq
+            did_eval = False
+            is_best_checkpoint = False
             if self.on_epoch_eval or ((epoch + 1) % self._eval_freq == 0):
-                validation_accuracy = self.validate(eval_dataloader)
+                did_eval = True
+                validation_result = self.validate(eval_dataloader)
+                validation_acc = validation_accuracy(validation_result)
+                validation_eval_loss = validation_loss(validation_result)
                 if self.is_rank_zero():
-                    self.metric_logger.log_metric("eval/accuracy", validation_accuracy, epoch_step)
+                    self.metric_logger.log_metric("eval/accuracy", validation_acc, epoch_step)
                     if self._metric_namespace:
                         self.metric_logger.log_metric(
                             phase_metric(self._metric_namespace, "eval", "token_accuracy"),
-                            validation_accuracy / 100.0,
+                            validation_acc / 100.0,
+                            epoch_step)
+                        self.metric_logger.log_metric(
+                            phase_metric(self._metric_namespace, "eval", "loss"),
+                            validation_eval_loss,
+                            epoch_step)
+                        self.metric_logger.log_metric(
+                            phase_metric(self._metric_namespace, "eval", "perplexity"),
+                            float(np.exp(min(validation_eval_loss, 20.0))),
                             epoch_step)
 
-                print(f"Rank {self.rank} Epoch {epoch + 1} - Validation Accuracy: "
-                      f"{validation_accuracy} Best: {self._best_validation_metric}")
+                if self._select_best_by_eval_loss:
+                    # Phase 1: lower validation loss is better. min_delta prevents tiny
+                    # floating-point noise from resetting patience.
+                    selection_metric = validation_eval_loss
+                    improved = (
+                        selection_metric
+                        < self._best_validation_metric - self._early_stopping_min_delta
+                    )
+                else:
+                    # Legacy metric path: higher validation accuracy is better.
+                    selection_metric = validation_acc
+                    improved = selection_metric > self._best_validation_metric
+
+                if improved:
+                    self._best_validation_metric = selection_metric
+                    early_stop_bad_evals = 0
+                    is_best_checkpoint = True
+                else:
+                    early_stop_bad_evals += 1
+
+                print(f"Rank {self.rank} Epoch {epoch + 1} - Validation Loss: "
+                      f"{validation_eval_loss:.6f} Accuracy: {validation_acc:.4f} "
+                      f"Best: {self._best_validation_metric}")
 
             if num_batches > 0:
                 average_loss = total_loss / num_batches
@@ -806,9 +907,9 @@ class LlmEmbeddingsTrainer(LlmModule):
                 print(f"Rank {self.rank} Epoch {epoch + 1}/{self.num_epochs} - Average Loss: {average_loss}")
             epochs_done = epoch + 1
 
-            # save best checkpoint
-            is_best_accuracy = validation_accuracy > self._best_validation_metric
-            should_save = is_best_accuracy or (epoch + 1) % self._save_freq == 0
+            # Save every evaluation (for Phase 1 restore-best) and still honor the
+            # legacy periodic save frequency on no-eval epochs.
+            should_save = did_eval or (epoch + 1) % self._save_freq == 0
             gathered_state = None
             if self.is_accelerator and self._module_checkpoint_dir is not None:
                 # rank 0's verdict must be uniform, and the state-dict gather is a
@@ -817,11 +918,6 @@ class LlmEmbeddingsTrainer(LlmModule):
                 should_save = broadcast_flag(self.accelerator, should_save)
                 if should_save:
                     gathered_state = self.accelerator.get_state_dict(self.model)
-            # Every rank tracks the SAME best now that validation_accuracy is a global metric, so
-            # is_best_accuracy is computed identically across ranks next epoch and no rank diverges
-            # into the save collective alone (the _ALLGATHER_BASE hang). Update on improvement only.
-            if is_best_accuracy:
-                self._best_validation_metric = validation_accuracy
             if self.is_rank_zero():
                 if should_save:
                     if self._module_checkpoint_dir is not None:
@@ -838,17 +934,17 @@ class LlmEmbeddingsTrainer(LlmModule):
                                 model_state_dict=gathered_state,
                                 optimizer=opt,
                                 scheduler=shed,
-                                last_accuracy=validation_accuracy,
+                                last_accuracy=validation_accuracy(validation_result),
                                 initial_lr=self._lr,
-                                is_best_accuracy=is_best_accuracy,
+                                is_best_accuracy=is_best_checkpoint,
                             )
                         else:
                             self.save_checkpoint(
                                 self._module_checkpoint_dir,
                                 epoch + 1,
-                                last_accuracy=validation_accuracy,
+                                last_accuracy=validation_accuracy(validation_result),
                                 initial_lr=self._lr,
-                                is_best_accuracy=is_best_accuracy,
+                                is_best_accuracy=is_best_checkpoint,
                             )
 
             # Epoch-boundary barrier: all ranks meet here AFTER the rank-0 checkpoint
@@ -858,6 +954,17 @@ class LlmEmbeddingsTrainer(LlmModule):
             # (ranks spinning, one idle). Collective — every rank must reach it.
             if self.is_accelerator:
                 self.accelerator.wait_for_everyone()
+
+            if (
+                    did_eval
+                    and self._select_best_by_eval_loss
+                    and early_stop_bad_evals >= self._early_stopping_patience):
+                if self.is_rank_zero():
+                    self.logger.info(
+                        "Early stopping Phase 1: validation loss did not improve by "
+                        f"{self._early_stopping_min_delta} for "
+                        f"{self._early_stopping_patience} evaluations.")
+                break
 
         if self._is_quantize:
             self.model = convert(self.model)
@@ -879,7 +986,10 @@ class LlmEmbeddingsTrainer(LlmModule):
                         "optimizer_steps": global_opt_steps,
                         "best_eval": self._best_validation_metric,
                     },
-                    metrics={"eval/accuracy": validation_accuracy},
+                    metrics={
+                        "eval/accuracy": validation_accuracy(validation_result),
+                        "eval/loss": validation_loss(validation_result),
+                    },
                     dataset_fields=manifest_fields() if callable(manifest_fields) else None,
                     started_at=run_started_at,
                     ended_at=time.strftime("%Y-%m-%dT%H:%M:%S"),
@@ -1032,13 +1142,14 @@ class LlmEmbeddingsTrainer(LlmModule):
 
             # validation on epoch or freq
             if self.on_epoch_eval or ((epoch + 1) % self._eval_freq == 0):
-                validation_accuracy = self.validate(eval_dataloader)
+                validation_result = self.validate(eval_dataloader)
+                validation_acc = validation_accuracy(validation_result)
                 if self.is_rank_zero():
-                    self.metric_logger.log_metric("llm_emb_accuracy", validation_accuracy, epoch)
+                    self.metric_logger.log_metric("llm_emb_accuracy", validation_acc, epoch)
                     # self.metric_logger.log_metric("llm_emb_perplexity", perplexity, epoch)
 
                 print(f"Rank {self.rank} Epoch {epoch + 1} - Validation Accuracy: "
-                      f"{validation_accuracy} Best: {self._best_validation_metric}")
+                      f"{validation_acc} Best: {self._best_validation_metric}")
 
             if num_batches > 0:
                 average_loss = total_loss / num_batches

--- a/igc/modules/llm_train_state_encoder.py
+++ b/igc/modules/llm_train_state_encoder.py
@@ -179,6 +179,49 @@ def validation_loss(value: Union[ValidationMetrics, float]) -> float:
     return float("inf")
 
 
+def resolve_early_stopping(spec) -> Tuple[int, float]:
+    """Resolve the early-stopping knobs from the run spec.
+
+    Missing/``None`` values fall back to the Phase 1 defaults; an explicit ``0`` is
+    honored — patience ``0`` (or negative) disables early stopping entirely, and
+    min_delta ``0.0`` means any improvement resets patience.
+
+    :param spec: argparse.Namespace-like run spec.
+    :return: ``(patience, min_delta)``.
+    """
+    patience = getattr(spec, "early_stopping_patience", None)
+    min_delta = getattr(spec, "early_stopping_min_delta", None)
+    return (
+        3 if patience is None else int(patience),
+        0.005 if min_delta is None else float(min_delta),
+    )
+
+
+def restored_best_metric(checkpoint_state, select_by_loss: bool) -> Optional[float]:
+    """Best-selection metric to resume best-checkpoint tracking from, or ``None``.
+
+    Only a checkpoint whose ``best_metric_mode`` matches the trainer's current
+    selection mode is trusted (a loss-mode best must never seed accuracy-mode
+    tracking, and vice versa). Accuracy mode additionally falls back to the legacy
+    ``best_accuracy`` channel that old checkpoints carry; loss mode has no legacy
+    channel and starts fresh at ``+inf``.
+
+    :param checkpoint_state: :class:`~igc.modules.base.igc_base_module.CheckpointState`.
+    :param select_by_loss: True when the trainer selects best by eval loss.
+    :return: the metric to seed ``_best_validation_metric`` with, or ``None``.
+    """
+    mode = "loss" if select_by_loss else "accuracy"
+    best_metric = getattr(checkpoint_state, "best_metric", None)
+    best_mode = getattr(checkpoint_state, "best_metric_mode", None)
+    if best_metric is not None and best_mode == mode and np.isfinite(best_metric):
+        return float(best_metric)
+    if not select_by_loss:
+        legacy = getattr(checkpoint_state, "best_accuracy", None)
+        if legacy is not None and np.isfinite(legacy):
+            return float(legacy)
+    return None
+
+
 def shifted_token_loss(logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
     """Return HF CausalLM-style shifted CE loss for full-length labels."""
     shifted_logits = logits[..., :-1, :].contiguous()
@@ -282,9 +325,10 @@ class LlmEmbeddingsTrainer(LlmModule):
         self._metric_namespace = getattr(dataset, "metric_namespace", "")
         self._select_best_by_eval_loss = bool(self._metric_namespace)
         self._best_validation_metric = float('inf') if self._select_best_by_eval_loss else float('-inf')
-        self._early_stopping_patience = int(getattr(spec, "early_stopping_patience", 3) or 3)
-        self._early_stopping_min_delta = float(
-            getattr(spec, "early_stopping_min_delta", 0.005) or 0.005)
+        # None-aware on purpose: an explicit 0 disables early stopping / zeroes the
+        # delta; a bare `or` default would silently swallow it.
+        self._early_stopping_patience, self._early_stopping_min_delta = (
+            resolve_early_stopping(spec))
 
         self.logger.info(
             f"Rank {self.rank} creating llm trainer, num epochs {self.num_epochs} "
@@ -658,6 +702,18 @@ class LlmEmbeddingsTrainer(LlmModule):
             loss=float("inf"),
             accuracy=checkpoint_state.best_accuracy,
         )
+        # Resume best-checkpoint tracking from the persisted best (mode-matched):
+        # without this, a resumed loss-mode run stays at +inf and flags the FIRST
+        # post-resume eval as "best" — overwriting the true best checkpoint and
+        # resetting early-stop patience.
+        _restored_best = restored_best_metric(
+            checkpoint_state, self._select_best_by_eval_loss)
+        if _restored_best is not None:
+            self._best_validation_metric = _restored_best
+            self.logger.info(
+                f"Rank {self.rank} resumed best validation metric "
+                f"{self._best_validation_metric} "
+                f"({'loss' if self._select_best_by_eval_loss else 'accuracy'} mode).")
         self._trainer_args.epochs = self.num_epochs - last_epoch
         _accum = max(1, int(getattr(self._trainer_args, "gradient_accumulation_steps", 1)))
         self._trainer_args.steps_per_epoch = optimizer_steps_per_epoch(
@@ -956,6 +1012,10 @@ class LlmEmbeddingsTrainer(LlmModule):
                                 last_accuracy=validation_accuracy(validation_result),
                                 initial_lr=self._lr,
                                 is_best_accuracy=is_best_checkpoint,
+                                best_metric=self._best_validation_metric,
+                                best_metric_mode=(
+                                    "loss" if self._select_best_by_eval_loss
+                                    else "accuracy"),
                             )
                         else:
                             self.save_checkpoint(
@@ -964,6 +1024,10 @@ class LlmEmbeddingsTrainer(LlmModule):
                                 last_accuracy=validation_accuracy(validation_result),
                                 initial_lr=self._lr,
                                 is_best_accuracy=is_best_checkpoint,
+                                best_metric=self._best_validation_metric,
+                                best_metric_mode=(
+                                    "loss" if self._select_best_by_eval_loss
+                                    else "accuracy"),
                             )
 
             # Epoch-boundary barrier: all ranks meet here AFTER the rank-0 checkpoint
@@ -977,6 +1041,7 @@ class LlmEmbeddingsTrainer(LlmModule):
             if (
                     did_eval
                     and self._select_best_by_eval_loss
+                    and self._early_stopping_patience > 0
                     and early_stop_bad_evals >= self._early_stopping_patience):
                 if self.is_rank_zero():
                     self.logger.info(

--- a/igc/modules/llm_train_state_encoder.py
+++ b/igc/modules/llm_train_state_encoder.py
@@ -46,6 +46,20 @@ class ValidationMetrics:
     loss: float
     accuracy: float
 
+    def __float__(self) -> float:
+        """Return legacy accuracy percentage when used as a scalar."""
+        return float(self.accuracy)
+
+    def __eq__(self, other) -> bool:
+        """Preserve legacy tests/callers that compared ``validate()`` to a float."""
+        if isinstance(other, (int, float)):
+            return self.accuracy == float(other)
+        return super().__eq__(other)
+
+    def __truediv__(self, other):
+        """Preserve legacy ``validate(...) / 100`` accuracy normalization."""
+        return self.accuracy / other
+
 
 def build_causal_lm_labels(input_ids, attention_mask, pad_token_id=None):
     """Build full-length next-token labels for a Hugging Face CausalLM.
@@ -411,8 +425,13 @@ class LlmEmbeddingsTrainer(LlmModule):
                     'labels': labels,
                 }
 
-                outputs = self.model(**batch_inputs)
-                loss = outputs.loss
+                try:
+                    outputs = self.model(**batch_inputs)
+                except TypeError as exc:
+                    if "labels" not in str(exc):
+                        raise
+                    outputs = self.model(input_ids=input_ids, attention_mask=attention_mask)
+                loss = getattr(outputs, "loss", None)
                 if loss is None:
                     loss = shifted_token_loss(outputs.logits, labels)
                 predictions = torch.argmax(outputs.logits[:, :-1, :], dim=-1)

--- a/igc/modules/shared/llm_shared.py
+++ b/igc/modules/shared/llm_shared.py
@@ -6,7 +6,7 @@ Author:Mus mbayramo@stanford.edu
 import argparse
 import os
 import pkgutil
-from typing import Optional, Union, Dict, Tuple
+from typing import Any, Optional, Union, Dict, Tuple
 
 from transformers import (
     AutoModelForCausalLM,
@@ -48,6 +48,44 @@ def _uses_conv1d_attention(model) -> bool:
     except ImportError:
         return False
     return any(isinstance(m, Conv1D) for m in model.modules())
+
+
+def _config_name_or_path(model: Any) -> str:
+    """Best-effort Hugging Face model id/path, including PEFT wrapper shapes."""
+    candidates = [
+        getattr(model, "config", None),
+        getattr(getattr(model, "base_model", None), "config", None),
+        getattr(getattr(getattr(model, "base_model", None), "model", None), "config", None),
+        getattr(getattr(model, "model", None), "config", None),
+    ]
+    for config in candidates:
+        if config is None:
+            continue
+        name = getattr(config, "_name_or_path", None) or getattr(config, "name_or_path", None)
+        if name:
+            return str(name).rstrip("/")
+    return ""
+
+
+def _tokenizer_name_or_path(tokenizer: Any) -> str:
+    """Best-effort Hugging Face tokenizer id/path."""
+    name = getattr(tokenizer, "name_or_path", None)
+    return str(name).rstrip("/") if name else ""
+
+
+def _same_backbone(model: Any, tokenizer: Any) -> bool:
+    """Whether model and tokenizer advertise the same HF id/path."""
+    model_name = _config_name_or_path(model)
+    tokenizer_name = _tokenizer_name_or_path(tokenizer)
+    return bool(model_name and tokenizer_name and model_name == tokenizer_name)
+
+
+def _is_small_padded_vocab_gap(current: int, target: int) -> bool:
+    """Whether ``current`` looks like a padded vocab size rather than a wrong tokenizer."""
+    gap = current - target
+    if gap <= 0:
+        return False
+    return gap <= max(16, min(4096, int(current * 0.05)))
 
 
 def _from_pretrained_best_attention(model_id: str, load_kwargs: dict):
@@ -162,11 +200,16 @@ def safe_resize_token_embeddings(
     current = model.get_input_embeddings().num_embeddings
     target = len(tokenizer)
     if target < current and not force_shrink:
+        if _same_backbone(model, tokenizer) or (
+                not _config_name_or_path(model)
+                and _is_small_padded_vocab_gap(current, target)):
+            return model
         raise ValueError(
             f"Refusing to shrink token embeddings from {current} to {target}: this "
-            f"tokenizer does not belong to the backbone (a shrink silently deletes "
-            f"pretrained embedding rows). Rebuild the dataset tokenizer for this "
-            f"backbone, or pass force_shrink=True to override.")
+            f"tokenizer does not belong to the backbone, or the model/tokenizer "
+            f"identity is unavailable (a shrink silently deletes pretrained "
+            f"embedding rows). Rebuild the dataset tokenizer for this backbone, or "
+            f"pass force_shrink=True to override.")
     if target != current:
         model.resize_token_embeddings(target)
     return model

--- a/igc/modules/shared/llm_shared.py
+++ b/igc/modules/shared/llm_shared.py
@@ -80,14 +80,6 @@ def _same_backbone(model: Any, tokenizer: Any) -> bool:
     return bool(model_name and tokenizer_name and model_name == tokenizer_name)
 
 
-def _is_small_padded_vocab_gap(current: int, target: int) -> bool:
-    """Whether ``current`` looks like a padded vocab size rather than a wrong tokenizer."""
-    gap = current - target
-    if gap <= 0:
-        return False
-    return gap <= max(16, min(4096, int(current * 0.05)))
-
-
 def _from_pretrained_best_attention(model_id: str, load_kwargs: dict):
     """Load a causal LM preferring the fastest attention kernel the env supports.
 
@@ -200,9 +192,7 @@ def safe_resize_token_embeddings(
     current = model.get_input_embeddings().num_embeddings
     target = len(tokenizer)
     if target < current and not force_shrink:
-        if _same_backbone(model, tokenizer) or (
-                not _config_name_or_path(model)
-                and _is_small_padded_vocab_gap(current, target)):
+        if _same_backbone(model, tokenizer):
             return model
         raise ValueError(
             f"Refusing to shrink token embeddings from {current} to {target}: this "

--- a/igc/modules/train/__init__.py
+++ b/igc/modules/train/__init__.py
@@ -1,4 +1,4 @@
-"""Training configuration: the M1 profile registry + adapter specs.
+"""Training configuration: the Phase 1 profile registry + adapter specs.
 
 One source of truth for named training profiles (``docs/TRAINING_OPTIMIZATION_PLAN.md``)
 so a large-model run cannot silently inherit GPT-2 / small-GPU defaults. Pure stdlib —

--- a/igc/modules/train/emit.py
+++ b/igc/modules/train/emit.py
@@ -29,7 +29,7 @@ _SETTINGS_KEYS = (
     "per_device_train_batch_size", "gradient_accumulation_steps", "num_train_epochs",
     "llm_learning_rate", "llm_scheduler", "llm_optimizer", "mixed_precision",
     "sharding", "use_accelerator", "use_peft", "lora_r", "lora_alpha", "lora_dropout",
-    "masking_type", "num_workers", "seed",
+    "masking_type", "num_workers", "seed", "profile", "corpus_objective",
 )
 
 # any spec key containing one of these is never emitted, whatever its value.
@@ -79,9 +79,16 @@ def build_run_bundle(spec_vars: Dict, *,
     model = str(spec_vars.get("model_type", ""))
     use_peft = bool(spec_vars.get("use_peft", False))
     started_tag = started_at.replace(":", "").replace("-", "") or "run"
+    profile = str(spec_vars.get("profile", "") or "")
+    is_phase1 = (
+        spec_vars.get("phase") == "phase1_finetune"
+        or spec_vars.get("corpus_objective") == "phase1_pretrain"
+        or profile.startswith("phase1_")
+    )
+    family = "phase1" if is_phase1 else "m1"
     manifest = RunManifest(
-        run_id=f"m1-{os.path.basename(model) or 'model'}-{started_tag}",
-        profile=str(spec_vars.get("profile", "") or ""),
+        run_id=f"{family}-{os.path.basename(model) or 'model'}-{started_tag}",
+        profile=profile,
         model=model,
         tokenizer=model,
         adapter_method=str(spec_vars.get("adapter_method", "lora")) if use_peft else "none",

--- a/igc/modules/train/emit.py
+++ b/igc/modules/train/emit.py
@@ -29,7 +29,8 @@ _SETTINGS_KEYS = (
     "per_device_train_batch_size", "gradient_accumulation_steps", "num_train_epochs",
     "llm_learning_rate", "llm_scheduler", "llm_optimizer", "mixed_precision",
     "sharding", "use_accelerator", "use_peft", "lora_r", "lora_alpha", "lora_dropout",
-    "masking_type", "num_workers", "seed", "profile", "weights_role", "corpus_objective",
+    "early_stopping_patience", "early_stopping_min_delta", "masking_type", "num_workers",
+    "seed", "profile", "weights_role", "corpus_objective",
 )
 
 # any spec key containing one of these is never emitted, whatever its value.

--- a/igc/modules/train/emit.py
+++ b/igc/modules/train/emit.py
@@ -29,7 +29,7 @@ _SETTINGS_KEYS = (
     "per_device_train_batch_size", "gradient_accumulation_steps", "num_train_epochs",
     "llm_learning_rate", "llm_scheduler", "llm_optimizer", "mixed_precision",
     "sharding", "use_accelerator", "use_peft", "lora_r", "lora_alpha", "lora_dropout",
-    "masking_type", "num_workers", "seed", "profile", "corpus_objective",
+    "masking_type", "num_workers", "seed", "profile", "weights_role", "corpus_objective",
 )
 
 # any spec key containing one of these is never emitted, whatever its value.

--- a/igc/modules/train/launch.py
+++ b/igc/modules/train/launch.py
@@ -57,6 +57,8 @@ def profile_to_argv(profile: TrainingProfile) -> List[str]:
         "--num_workers", str(profile.num_workers),
         "--llm_learning_rate", str(profile.lr),
         "--llm_scheduler", profile.scheduler,
+        "--early_stopping_patience", str(profile.early_stopping_patience),
+        "--early_stopping_min_delta", str(profile.early_stopping_min_delta),
         "--seq_len", str(profile.seq_len),
     ]
     if profile.max_steps is not None:

--- a/igc/modules/train/launch.py
+++ b/igc/modules/train/launch.py
@@ -1,10 +1,11 @@
-"""Resolve a named M1 profile into an ``igc_main.py`` command line (self-serve launch).
+"""Resolve a named Phase 1 profile into an ``igc_main.py`` command line.
 
-So an experiment can be run by NAME rather than a long, error-prone flag list:
-``python -m igc.modules.train.launch --profile m1_7b_rslora_r32 --print-argv`` prints the
-exact argv, and ``scripts/run_profile.sh`` feeds it to ``igc_main.py`` with the data/output
-dirs supplied from the environment (kept out of code so nothing endpoint- or path-specific
-is committed). Without ``--print-argv`` it prints the resolved profile
+So a Phase 1 Redfish JSON pretraining/fine-tune can be run by NAME rather than a long,
+error-prone flag list:
+``python -m igc.modules.train.launch --profile phase1_7b_rslora_r32 --print-argv`` prints
+the exact argv, and ``scripts/run_profile.sh`` feeds it to ``igc_main.py`` with the
+data/output dirs supplied from the environment (kept out of code so nothing endpoint- or
+path-specific is committed). Without ``--print-argv`` it prints the resolved profile
 (:meth:`~igc.modules.train.profiles.TrainingProfile.describe`) for the log.
 
 Pure stdlib; the argv is deterministic and offline-testable.
@@ -21,18 +22,33 @@ from typing import List
 from igc.modules.train.profiles import TrainingProfile, profile_names, resolve_profile
 
 
+_RENAMED_PROFILES = {
+    "m1_gpt2_smoke": "phase1_gpt2_smoke",
+    "m1_3b_lora": "phase1_3b_lora",
+    "m1_7b_lora": "phase1_7b_lora",
+    "m1_7b_rslora_r32": "phase1_7b_rslora_r32",
+    "m1_local": "phase1_local",
+    "m1_3b_full": "phase1_3b_full",
+    "m1_7b_full_zero3": "phase1_7b_full_zero3",
+}
+
+
 def profile_to_argv(profile: TrainingProfile) -> List[str]:
-    """Map a resolved profile to the ``igc_main.py`` M1 (state-encoder) argv.
+    """Map a resolved profile to the ``igc_main.py`` Phase 1 argv.
 
     Data/output locations are intentionally NOT included — the launcher supplies
     ``--json_data_dir`` / ``--output_dir`` from the environment so no path or endpoint is
-    baked into committed code.
+    baked into committed code. The profile does include ``--corpus_objective`` so the
+    resolved command states the real data objective instead of hiding Phase 1 behind the
+    internal ``--llm latent`` trainer route.
 
     :param profile: the resolved :class:`~igc.modules.train.profiles.TrainingProfile`.
     :return: the argv list (train stage, model, optimization, adapter, sharding).
     """
     argv = [
-        "--train", "llm", "--llm", "latent",
+        "--profile", profile.name,
+        "--train", "llm", "--llm", profile.llm_stage,
+        "--corpus_objective", profile.corpus_objective,
         "--model_type", profile.model,
         "--llm_torch_dtype", profile.torch_dtype,
         "--per_device_train_batch_size", str(profile.batch_size),
@@ -61,8 +77,8 @@ def profile_to_argv(profile: TrainingProfile) -> List[str]:
 
 def main(argv=None) -> int:
     """CLI: resolve ``--profile`` and print either its argv or its description."""
-    ap = argparse.ArgumentParser(description="Resolve an M1 training profile to a command line.")
-    ap.add_argument("--profile", required=True, choices=profile_names(),
+    ap = argparse.ArgumentParser(description="Resolve a Phase 1 training profile to a command line.")
+    ap.add_argument("--profile", required=True,
                     help="Named training profile from igc.modules.train.profiles.")
     ap.add_argument("--print-argv", action="store_true",
                     help="Print the space-joined igc_main.py argv (for a launcher).")
@@ -74,7 +90,15 @@ def main(argv=None) -> int:
     for kv in args.set:
         key, _, value = kv.partition("=")
         overrides[key] = _coerce(value)
-    profile = resolve_profile(args.profile, **overrides)
+    try:
+        profile = resolve_profile(args.profile, **overrides)
+    except KeyError:
+        renamed = _RENAMED_PROFILES.get(args.profile)
+        if renamed is not None:
+            ap.error(f"profile {args.profile!r} was renamed to {renamed!r}; use phase1_* names")
+        ap.error(
+            f"unknown profile {args.profile!r}; valid profiles: {', '.join(profile_names())}"
+        )
 
     if args.print_argv:
         print(" ".join(profile_to_argv(profile)))

--- a/igc/modules/train/launch.py
+++ b/igc/modules/train/launch.py
@@ -47,6 +47,7 @@ def profile_to_argv(profile: TrainingProfile) -> List[str]:
     """
     argv = [
         "--profile", profile.name,
+        "--weights_role", profile.weights_role,
         "--train", "llm", "--llm", profile.llm_stage,
         "--corpus_objective", profile.corpus_objective,
         "--model_type", profile.model,

--- a/igc/modules/train/profiles.py
+++ b/igc/modules/train/profiles.py
@@ -4,7 +4,7 @@
 truth; this module makes the Phase 1 profile/adapter matrix executable so every run resolves
 to an explicit, logged config instead of carrying over GPT-2 / small-GPU defaults. A
 :class:`TrainingProfile` fully determines a run (phase, objective, model, precision, batch,
-accumulation, lr, scheduler, warmup, sharding, sequence length, and the
+weight role, accumulation, lr, scheduler, warmup, sharding, sequence length, and the
 :class:`AdapterSpec`); :func:`resolve_profile` applies overrides and :func:`describe` yields
 the flat dict a launcher prints and logs to W&B config.
 
@@ -75,6 +75,7 @@ class TrainingProfile:
     name: str
     model: str
     phase: str = "phase1_finetune"
+    weights_role: str = "model_x"
     llm_stage: str = "latent"
     corpus_objective: str = "phase1_pretrain"
     use_peft: bool = True
@@ -96,7 +97,7 @@ class TrainingProfile:
         """Flat, log-safe dict of the resolved config (for stdout + W&B config)."""
         d = {
             "profile": self.name, "model": self.model, "use_peft": self.use_peft,
-            "phase": self.phase, "llm_stage": self.llm_stage,
+            "phase": self.phase, "weights_role": self.weights_role, "llm_stage": self.llm_stage,
             "corpus_objective": self.corpus_objective,
             "precision": self.precision, "torch_dtype": self.torch_dtype,
             "batch_size": self.batch_size, "grad_accum": self.grad_accum, "lr": self.lr,

--- a/igc/modules/train/profiles.py
+++ b/igc/modules/train/profiles.py
@@ -89,6 +89,8 @@ class TrainingProfile:
     warmup_ratio: float = 0.03
     epochs: int = 3                  # used when max_steps is None
     max_steps: Optional[int] = None  # hard step cap (overrides epochs when set)
+    early_stopping_patience: int = 3
+    early_stopping_min_delta: float = 0.005
     sharding: str = "none"           # none | zero3 | fsdp
     seq_len: int = 1024
     num_workers: int = 8
@@ -102,7 +104,10 @@ class TrainingProfile:
             "precision": self.precision, "torch_dtype": self.torch_dtype,
             "batch_size": self.batch_size, "grad_accum": self.grad_accum, "lr": self.lr,
             "scheduler": self.scheduler, "warmup_ratio": self.warmup_ratio,
-            "epochs": self.epochs, "max_steps": self.max_steps, "sharding": self.sharding,
+            "epochs": self.epochs, "max_steps": self.max_steps,
+            "early_stopping_patience": self.early_stopping_patience,
+            "early_stopping_min_delta": self.early_stopping_min_delta,
+            "sharding": self.sharding,
             "seq_len": self.seq_len, "num_workers": self.num_workers,
         }
         if self.use_peft and self.adapter is not None:

--- a/igc/modules/train/profiles.py
+++ b/igc/modules/train/profiles.py
@@ -1,11 +1,12 @@
-"""Named M1 state-encoder training profiles + adapter specs (the run contract).
+"""Named Phase 1 Redfish JSON pretraining profiles + adapter specs.
 
-``docs/TRAINING_OPTIMIZATION_PLAN.md`` is the source of truth; this module makes its
-profile/adapter matrix executable so every run resolves to an explicit, logged config
-instead of carrying over GPT-2 / small-GPU defaults. A :class:`TrainingProfile` fully
-determines a run (model, precision, batch, accumulation, lr, scheduler, warmup, sharding,
-sequence length, and the :class:`AdapterSpec`); :func:`resolve_profile` applies overrides
-and :func:`describe` yields the flat dict a launcher prints and logs to W&B config.
+``docs/P0_PHASE_WORKFLOW.md`` and ``docs/TRAINING_OPTIMIZATION_PLAN.md`` are the source of
+truth; this module makes the Phase 1 profile/adapter matrix executable so every run resolves
+to an explicit, logged config instead of carrying over GPT-2 / small-GPU defaults. A
+:class:`TrainingProfile` fully determines a run (phase, objective, model, precision, batch,
+accumulation, lr, scheduler, warmup, sharding, sequence length, and the
+:class:`AdapterSpec`); :func:`resolve_profile` applies overrides and :func:`describe` yields
+the flat dict a launcher prints and logs to W&B config.
 
 Pure standard library on purpose (no torch/peft): imported by the launcher and tests,
 and must stay cheap/offline. :func:`apply_lora_kwargs` produces the exact kwargs for
@@ -63,14 +64,19 @@ class AdapterSpec:
 
 @dataclass(frozen=True)
 class TrainingProfile:
-    """A fully-resolved M1 run: model + precision + optimization + adapter.
+    """A fully-resolved Phase 1 run: model + precision + optimization + adapter.
 
     ``use_peft=False`` marks a full fine-tune (``adapter`` is ignored); large full FTs set
-    ``sharding`` to ``zero3``/``fsdp``.
+    ``sharding`` to ``zero3``/``fsdp``. ``llm_stage`` is the internal trainer route; Phase 1
+    currently uses the latent/state-encoder trainer path while the profile/objective name
+    records that the data task is Redfish JSON reconstruction.
     """
 
     name: str
     model: str
+    phase: str = "phase1_finetune"
+    llm_stage: str = "latent"
+    corpus_objective: str = "phase1_pretrain"
     use_peft: bool = True
     adapter: Optional[AdapterSpec] = field(default_factory=AdapterSpec)
     precision: str = "bf16"          # accelerate mixed_precision
@@ -90,6 +96,8 @@ class TrainingProfile:
         """Flat, log-safe dict of the resolved config (for stdout + W&B config)."""
         d = {
             "profile": self.name, "model": self.model, "use_peft": self.use_peft,
+            "phase": self.phase, "llm_stage": self.llm_stage,
+            "corpus_objective": self.corpus_objective,
             "precision": self.precision, "torch_dtype": self.torch_dtype,
             "batch_size": self.batch_size, "grad_accum": self.grad_accum, "lr": self.lr,
             "scheduler": self.scheduler, "warmup_ratio": self.warmup_ratio,
@@ -103,41 +111,42 @@ class TrainingProfile:
         return d
 
 
-# The named profiles of docs/TRAINING_OPTIMIZATION_PLAN.md §Target Training Profiles.
+# The named profiles of docs/P0_PHASE_WORKFLOW.md §Phase 1 and
+# docs/TRAINING_OPTIMIZATION_PLAN.md §Target Training Profiles.
 PROFILES: Dict[str, TrainingProfile] = {
-    "m1_gpt2_smoke": TrainingProfile(
-        name="m1_gpt2_smoke", model="gpt2", use_peft=False, adapter=None,
+    "phase1_gpt2_smoke": TrainingProfile(
+        name="phase1_gpt2_smoke", model="gpt2", use_peft=False, adapter=None,
         precision="no", torch_dtype="float32", batch_size=8, lr=5e-5,
         max_steps=50, seq_len=256, sharding="none",
     ),
-    "m1_3b_lora": TrainingProfile(
-        name="m1_3b_lora", model="Qwen/Qwen2.5-3B-Instruct",
+    "phase1_3b_lora": TrainingProfile(
+        name="phase1_3b_lora", model="Qwen/Qwen2.5-3B-Instruct",
         adapter=AdapterSpec(method="lora", r=16, alpha=32),
         batch_size=8, grad_accum=2, lr=1e-4, warmup_ratio=0.03,
     ),
-    "m1_7b_lora": TrainingProfile(
-        name="m1_7b_lora", model="Qwen/Qwen2.5-7B-Instruct",
+    "phase1_7b_lora": TrainingProfile(
+        name="phase1_7b_lora", model="Qwen/Qwen2.5-7B-Instruct",
         adapter=AdapterSpec(method="lora", r=16, alpha=32),
         batch_size=8, grad_accum=4, lr=1e-4, warmup_ratio=0.03,
     ),
-    "m1_7b_rslora_r32": TrainingProfile(
-        name="m1_7b_rslora_r32", model="Qwen/Qwen2.5-7B-Instruct",
+    "phase1_7b_rslora_r32": TrainingProfile(
+        name="phase1_7b_rslora_r32", model="Qwen/Qwen2.5-7B-Instruct",
         adapter=AdapterSpec(method="rslora", r=32, alpha=64, init="default"),
         batch_size=8, grad_accum=4, lr=1e-4, warmup_ratio=0.03,
     ),
-    "m1_local": TrainingProfile(
+    "phase1_local": TrainingProfile(
         # local weights dir from the environment (e.g. the staged DeepSeek-V4-Flash or
         # any node-local backbone) -- no path is baked into committed code.
-        name="m1_local", model="$IGC_MODEL_DIR",
+        name="phase1_local", model="$IGC_MODEL_DIR",
         adapter=AdapterSpec(method="lora", r=16, alpha=32),
         batch_size=8, grad_accum=4, lr=1e-4, warmup_ratio=0.03,
     ),
-    "m1_3b_full": TrainingProfile(
-        name="m1_3b_full", model="Qwen/Qwen2.5-3B-Instruct", use_peft=False, adapter=None,
+    "phase1_3b_full": TrainingProfile(
+        name="phase1_3b_full", model="Qwen/Qwen2.5-3B-Instruct", use_peft=False, adapter=None,
         batch_size=4, grad_accum=8, lr=2e-5, sharding="zero3", warmup_ratio=0.03,
     ),
-    "m1_7b_full_zero3": TrainingProfile(
-        name="m1_7b_full_zero3", model="Qwen/Qwen2.5-7B-Instruct", use_peft=False, adapter=None,
+    "phase1_7b_full_zero3": TrainingProfile(
+        name="phase1_7b_full_zero3", model="Qwen/Qwen2.5-7B-Instruct", use_peft=False, adapter=None,
         batch_size=2, grad_accum=16, lr=1e-5, sharding="zero3", warmup_ratio=0.03,
     ),
 }
@@ -166,7 +175,7 @@ def resolve_profile(name: str, **overrides) -> TrainingProfile:
         if bad:
             raise ValueError(f"unknown profile override(s) {sorted(bad)}; valid: {sorted(valid)}")
         base = replace(base, **overrides)
-    # expand $ENV_VAR model references (e.g. m1_local's $IGC_MODEL_DIR) at resolve
+    # expand $ENV_VAR model references (e.g. phase1_local's $IGC_MODEL_DIR) at resolve
     # time so the env decides the weights dir, never committed code.
     if "$" in base.model:
         expanded = os.path.expandvars(base.model)

--- a/igc/modules/train/report_cli.py
+++ b/igc/modules/train/report_cli.py
@@ -1,4 +1,4 @@
-"""CLI to summarize and compare M1 training runs.
+"""CLI to summarize and compare Phase 1 training runs.
 
 The training run writes a per-run ``report.json`` (a :class:`ResultBundle` from
 :mod:`igc.modules.train.report`); this command turns those into the human
@@ -64,7 +64,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     :return: process exit code (0 ok, 2 nothing matched).
     """
     parser = argparse.ArgumentParser(
-        description="Summarize and compare igc M1 training report.json files.")
+        description="Summarize and compare igc Phase 1 training report.json files.")
     parser.add_argument("reports", nargs="+", help="report.json paths or globs.")
     parser.add_argument(
         "--baseline", default="lora",

--- a/igc/shared/shared_arg_parser.py
+++ b/igc/shared/shared_arg_parser.py
@@ -430,6 +430,12 @@ def add_trainer_group(parser):
              "Used for run metadata and reports; launch behavior still comes "
              "from the explicit CLI flags."
     )
+    parser.add_argument(
+        "--weights_role",
+        type=str, default="",
+        help="Named checkpoint role written by this run, such as model_x, "
+             "goal_extractor, or argument_extractor."
+    )
 
     # indicate that we train
     parser.add_argument(

--- a/igc/shared/shared_arg_parser.py
+++ b/igc/shared/shared_arg_parser.py
@@ -408,6 +408,18 @@ def add_trainer_group(parser):
              " If provided, overrides num_train_epochs.")
 
     trainer_group.add_argument(
+        "--early_stopping_patience",
+        type=int, default=3,
+        help="Number of evaluation calls without meaningful improvement before"
+             " stopping Phase 1 fine-tuning.")
+
+    trainer_group.add_argument(
+        "--early_stopping_min_delta",
+        type=float, default=0.005,
+        help="Minimum validation-loss improvement required to reset Phase 1"
+             " early-stopping patience.")
+
+    trainer_group.add_argument(
         "--output_dir",
         type=str, default=None,
         help="Where to store the model.")

--- a/igc/shared/shared_arg_parser.py
+++ b/igc/shared/shared_arg_parser.py
@@ -223,13 +223,13 @@ def add_scheduler_group(parser):
 
     scheduler_group.add_argument(
         "--base_lr",
-        type=int, default=0.01,
+        type=float, default=0.01,
         help="Initial learning rate which is the lower boundary in the cycle for each parameter group.."
     )
 
     scheduler_group.add_argument(
         "--max_lr",
-        type=int, default=5e-5,
+        type=float, default=None,
         help="Upper learning rate boundaries in the cycle for each parameter group. ."
     )
 
@@ -947,8 +947,10 @@ def shared_arg_parser(
         args.device = None
 
     # set defaults
+    if args.max_lr is None:
+        args.max_lr = args.llm_learning_rate
     if args.div_factor is None:
-        args.div_factor = args.max_lr / 0.008
+        args.div_factor = 25.0
 
     # args.device = get_device(rank=int(os.environ.get('LOCAL_RANK', -1))) \
     #     if args.device == "auto" else args.device

--- a/igc/shared/shared_arg_parser.py
+++ b/igc/shared/shared_arg_parser.py
@@ -423,6 +423,14 @@ def add_trainer_group(parser):
         help="Random seed to be used with data samplers."
     )
 
+    parser.add_argument(
+        "--profile",
+        type=str, default="",
+        help="Resolved named training profile, such as phase1_7b_rslora_r32. "
+             "Used for run metadata and reports; launch behavior still comes "
+             "from the explicit CLI flags."
+    )
+
     # indicate that we train
     parser.add_argument(
         "--train",

--- a/scripts/gpu_train_profile.py
+++ b/scripts/gpu_train_profile.py
@@ -1,5 +1,5 @@
 """
-Multi-GPU per-section profiler for the state-encoder training step (S0/M1 backbone).
+Multi-GPU per-section profiler for the Phase 1 RedfishBackbone training step.
 
 igc has offline CPU hot-path benchmarks (``scripts/bench_hot_paths.py`` — the RL decision path)
 and a distributed dataset-isolation harness (``scripts/gpu_dataset_isolation.py`` — the epoch-2

--- a/scripts/lfs_push_from_slot.sh
+++ b/scripts/lfs_push_from_slot.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# lfs_push_from_slot.sh — push large artifacts (captured corpora, built datasets, model adapters,
-# tarballs)
+# lfs_push_from_slot.sh — push explicitly supplied large artifacts (captured corpora, built
+# datasets, model adapters, tarballs)
 # from a GB300 slot DIRECTLY to the git-LFS remote over the node's own uplink, so the data
 # never crosses the shared VPN. Only the operator has GB300 access; run this ON the slot.
 #

--- a/scripts/lfs_push_from_slot.sh
+++ b/scripts/lfs_push_from_slot.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# lfs_push_from_slot.sh — push large artifacts (captured corpora, built datasets, tarballs)
+# lfs_push_from_slot.sh — push large artifacts (captured corpora, built datasets, model adapters,
+# tarballs)
 # from a GB300 slot DIRECTLY to the git-LFS remote over the node's own uplink, so the data
 # never crosses the shared VPN. Only the operator has GB300 access; run this ON the slot.
 #

--- a/scripts/run_profile.sh
+++ b/scripts/run_profile.sh
@@ -14,7 +14,7 @@
 #
 #   # override a profile field, or pass extra igc_main flags after --:
 #   IGC_PROFILE=phase1_3b_lora IGC_SET="batch_size=16 lr=2e-4" bash scripts/run_profile.sh -- --recreate_dataset
-#   IGC_PROFILE=phase1_gpt2_smoke IGC_SET="corpus_objective=legacy" bash scripts/run_profile.sh
+#   IGC_PROFILE=phase1_gpt2_smoke IGC_SET="max_steps=10" bash scripts/run_profile.sh
 #
 # Profiles: phase1_gpt2_smoke phase1_3b_lora phase1_7b_lora
 #           phase1_7b_rslora_r32 phase1_3b_full phase1_7b_full_zero3

--- a/scripts/run_profile.sh
+++ b/scripts/run_profile.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Run an M1 state-encoder experiment by PROFILE NAME.
+# Run a Phase 1 Redfish JSON pretraining experiment by PROFILE NAME.
 #
 # Public-safe: this script contains no endpoints, hosts, credentials, or private
 # paths. Data and output locations come from the environment, and the training flags
@@ -7,23 +7,29 @@
 # per docs/TRAINING_OPTIMIZATION_PLAN.md).
 #
 # Usage:
-#   IGC_PROFILE=m1_7b_rslora_r32 \
+#   IGC_PROFILE=phase1_7b_rslora_r32 \
 #   IGC_DATA_DIR=~/.json_responses \
-#   IGC_OUTPUT_DIR=experiments/m1_7b_rslora_r32 \
+#   IGC_OUTPUT_DIR=experiments/phase1_7b_rslora_r32 \
 #   bash scripts/run_profile.sh
 #
 #   # override a profile field, or pass extra igc_main flags after --:
-#   IGC_PROFILE=m1_3b_lora IGC_SET="batch_size=16 lr=2e-4" bash scripts/run_profile.sh -- --recreate_dataset
+#   IGC_PROFILE=phase1_3b_lora IGC_SET="batch_size=16 lr=2e-4" bash scripts/run_profile.sh -- --recreate_dataset
+#   IGC_PROFILE=phase1_gpt2_smoke IGC_SET="corpus_objective=legacy" bash scripts/run_profile.sh
 #
-# Profiles: m1_gpt2_smoke m1_3b_lora m1_7b_lora m1_7b_rslora_r32 m1_3b_full m1_7b_full_zero3
+# Profiles: phase1_gpt2_smoke phase1_3b_lora phase1_7b_lora
+#           phase1_7b_rslora_r32 phase1_3b_full phase1_7b_full_zero3
 set -euo pipefail
 
-PROFILE="${IGC_PROFILE:?set IGC_PROFILE (e.g. m1_7b_rslora_r32)}"
+PROFILE="${IGC_PROFILE:?set IGC_PROFILE (e.g. phase1_7b_rslora_r32)}"
 DATA_DIR="${IGC_DATA_DIR:-$HOME/.json_responses}"
 CORPUS_DIR="${IGC_CORPUS_DIR:-}"
-CORPUS_OBJECTIVE="${IGC_CORPUS_OBJECTIVE:-legacy}"
 OUT_DIR="${IGC_OUTPUT_DIR:-experiments/${PROFILE}}"
 METRIC_REPORT="${IGC_METRIC_REPORT:-wandb}"
+
+if [ -n "${IGC_CORPUS_OBJECTIVE:-}" ]; then
+    echo "IGC_CORPUS_OBJECTIVE is retired; use IGC_SET=\"corpus_objective=...\" so the resolved profile emits one objective flag." >&2
+    exit 2
+fi
 
 # Auto-load W&B credentials so the run streams to the dashboard with no manual export.
 # The env file is gitignored (creds never committed); override the path via IGC_WANDB_ENV.
@@ -43,7 +49,7 @@ SET_ARGS=()
 for kv in ${IGC_SET:-}; do SET_ARGS+=(--set "$kv"); done
 CORPUS_ARGS=()
 if [ -n "$CORPUS_DIR" ]; then
-    CORPUS_ARGS+=(--corpus_dir "$CORPUS_DIR" --corpus_objective "$CORPUS_OBJECTIVE")
+    CORPUS_ARGS+=(--corpus_dir "$CORPUS_DIR")
 fi
 
 echo "== resolved profile: ${PROFILE} =="

--- a/scripts/train_phase1_smoke.sbatch
+++ b/scripts/train_phase1_smoke.sbatch
@@ -1,14 +1,14 @@
 #!/bin/bash
-# First end-to-end GPU loop: train M1, the state-encoder (causal/masked-LM SFT,
-# igc/modules/llm_train_state_encoder.py LlmEmbeddingsTrainer) on ONE GB300.
+# First end-to-end GPU loop: Phase 1 Redfish JSON pretraining
+# (igc/modules/llm_train_state_encoder.py LlmEmbeddingsTrainer) on ONE GB300.
 # Validate on a small model first, then set IGC_MODEL to a large decoder and scale.
 # Runbook + cautions: GPU_ACCESS.md. Full guide: docs/TRAINING.md.
 #
 #   export WANDB_API_KEY=...            # in your shell, NOT here (rotate if ever shared)
-#   sbatch scripts/train_m1.sbatch                          # gpt2 smoke -> wandb
-#   IGC_MODEL=<hf-repo-id> EPOCHS=3 sbatch scripts/train_m1.sbatch
+#   sbatch scripts/train_phase1_smoke.sbatch                          # gpt2 smoke -> wandb
+#   IGC_MODEL=<hf-repo-id> EPOCHS=3 sbatch scripts/train_phase1_smoke.sbatch
 #
-#SBATCH --job-name=igc-m1
+#SBATCH --job-name=igc-phase1
 #SBATCH --partition=debug
 #SBATCH --nodes=1
 #SBATCH --gres=gpu:1
@@ -46,10 +46,10 @@ if [ "${IGC_REPORT}" = "wandb" ]; then
     : "${WANDB_API_KEY:?set WANDB_API_KEY in your env or ${IGC_DIR}/.internal/wandb.env to use wandb}"
     export WANDB_API_KEY
     export WANDB_PROJECT="${WANDB_PROJECT:-igc}"
-    export WANDB_NAME="${WANDB_NAME:-m1-${IGC_MODEL//\//_}-${SLURM_JOB_ID:-local}}"
+    export WANDB_NAME="${WANDB_NAME:-phase1-${IGC_MODEL//\//_}-${SLURM_JOB_ID:-local}}"
 fi
 
-echo "igc M1 SFT | model=${IGC_MODEL} epochs=${EPOCHS} report=${IGC_REPORT} node=$(hostname)"
+echo "igc Phase 1 SFT | model=${IGC_MODEL} epochs=${EPOCHS} report=${IGC_REPORT} node=$(hostname)"
 
 # shellcheck disable=SC2016  # The single-quoted payload is evaluated inside the container.
 srun --container-image="${NGC_IMAGE}" \
@@ -61,6 +61,8 @@ srun --container-image="${NGC_IMAGE}" \
         nvidia-smi -L
         python igc_main.py \
             --train llm --llm latent \
+            --weights_role model_x \
+            --corpus_objective phase1_pretrain \
             --model_type "'"${IGC_MODEL}"'" \
             --num_train_epochs "'"${EPOCHS}"'" \
             --json_data_dir /root/.json_responses \

--- a/tests/bats/lfs_push_from_slot.bats
+++ b/tests/bats/lfs_push_from_slot.bats
@@ -1,0 +1,13 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+    export REPO_ROOT
+}
+
+@test "model adapter safetensors files are tracked by Git LFS" {
+    run git -C "${REPO_ROOT}" check-attr filter -- models/model_x/adapter.safetensors
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"models/model_x/adapter.safetensors: filter: lfs"* ]]
+}

--- a/tests/bats/run_profile.bats
+++ b/tests/bats/run_profile.bats
@@ -17,7 +17,7 @@ if [[ "${1:-}" == "-m" && "${2:-}" == "igc.modules.train.launch" ]]; then
     printf '%s\n' "$*" >>"${RUN_PROFILE_CALLS_FILE}"
     for arg in "$@"; do
         if [[ "$arg" == "--print-argv" ]]; then
-            echo "--train llm --batch_size 2"
+            echo "--train llm --corpus_objective phase1_pretrain --batch_size 2"
             exit 0
         fi
     done
@@ -46,10 +46,9 @@ EOF
     install_python_stub
 
     run env \
-        IGC_PROFILE=m1_gpt2_smoke \
+        IGC_PROFILE=phase1_gpt2_smoke \
         IGC_DATA_DIR="${BATS_TEST_TMPDIR}/data" \
         IGC_CORPUS_DIR="${BATS_TEST_TMPDIR}/corpus" \
-        IGC_CORPUS_OBJECTIVE=phase1_pretrain \
         IGC_OUTPUT_DIR="${BATS_TEST_TMPDIR}/out" \
         IGC_METRIC_REPORT=tensorboard \
         IGC_SET="batch_size=2 lr=1e-4" \
@@ -61,16 +60,26 @@ EOF
     [ -d "${BATS_TEST_TMPDIR}/out" ]
 
     calls="$(cat "${BATS_TEST_TMPDIR}/calls.txt")"
-    [[ "$calls" == *"--profile m1_gpt2_smoke"* ]]
+    [[ "$calls" == *"--profile phase1_gpt2_smoke"* ]]
     [[ "$calls" == *"--set batch_size=2"* ]]
     [[ "$calls" == *"--set lr=1e-4"* ]]
     [[ "$calls" == *"--print-argv"* ]]
 
     final_args="$(cat "${BATS_TEST_TMPDIR}/final-args.txt")"
-    [[ "$final_args" == *"igc_main.py --train llm --batch_size 2"* ]]
+    [[ "$final_args" == *"igc_main.py --train llm --corpus_objective phase1_pretrain --batch_size 2"* ]]
     [[ "$final_args" == *"--json_data_dir ${BATS_TEST_TMPDIR}/data"* ]]
     [[ "$final_args" == *"--corpus_dir ${BATS_TEST_TMPDIR}/corpus"* ]]
     [[ "$final_args" == *"--corpus_objective phase1_pretrain"* ]]
     [[ "$final_args" == *"--output_dir ${BATS_TEST_TMPDIR}/out"* ]]
     [[ "$final_args" == *"--metric_report tensorboard -- --recreate_dataset"* ]]
+}
+
+@test "run_profile rejects retired IGC_CORPUS_OBJECTIVE env override" {
+    run env \
+        IGC_PROFILE=phase1_gpt2_smoke \
+        IGC_CORPUS_OBJECTIVE=legacy \
+        bash "${REPO_ROOT}/scripts/run_profile.sh"
+
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"IGC_CORPUS_OBJECTIVE is retired"* ]]
 }

--- a/tests/ds/test_corpus_dataset.py
+++ b/tests/ds/test_corpus_dataset.py
@@ -154,7 +154,7 @@ def test_phase1_items_mask_prompt_and_padding_labels(tmp_path: Path):
     assert active[0].item() > 0
     assert torch.equal(item["labels"][active], item["input_ids"][active])
     assert item["labels"][item["attention_mask"].eq(0)].eq(-100).all()
-    assert ds.metric_namespace == "phase1_pretrain"
+    assert ds.metric_namespace == "phase1_finetune"
 
 
 def test_phase1_tiny_sequence_keeps_prompt_and_completion(tmp_path: Path):

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -1028,28 +1028,28 @@ def test_ordered_calls_parser_rejects_readonly_arguments() -> None:
 def test_wandb_metric_keys_are_stage_scoped_and_not_m3_names() -> None:
     """Phase 2/3 contract constants reuse the shared W&B metric registry."""
     expected_phase2 = (
-        "phase2_goal_extract/train/loss",
-        "phase2_goal_extract/train/perplexity",
-        "phase2_goal_extract/train/optimizer_step",
-        "phase2_goal_extract/eval/ordered_exact_match_rate",
-        "phase2_goal_extract/eval/set_match_rate",
-        "phase2_goal_extract/eval/precision",
-        "phase2_goal_extract/eval/recall",
-        "phase2_goal_extract/eval/f1",
-        "phase2_goal_extract/eval/missing_allowed_methods_rate",
-        "phase2_goal_extract/order/kendall_tau",
-        "phase2_goal_extract/order/edit_distance",
+        "phase2_goal_extraction/train/loss",
+        "phase2_goal_extraction/train/perplexity",
+        "phase2_goal_extraction/train/optimizer_step",
+        "phase2_goal_extraction/eval/ordered_exact_match_rate",
+        "phase2_goal_extraction/eval/set_match_rate",
+        "phase2_goal_extraction/eval/precision",
+        "phase2_goal_extraction/eval/recall",
+        "phase2_goal_extraction/eval/f1",
+        "phase2_goal_extraction/eval/missing_allowed_methods_rate",
+        "phase2_goal_extraction/order/kendall_tau",
+        "phase2_goal_extraction/order/edit_distance",
     )
     expected_phase3 = (
-        "phase3_argument_extract/train/loss",
-        "phase3_argument_extract/train/perplexity",
-        "phase3_argument_extract/train/optimizer_step",
-        "phase3_argument_extract/eval/call_ordered_exact_match_rate",
-        "phase3_argument_extract/eval/method_exact_match_rate",
-        "phase3_argument_extract/eval/arguments_exact_match_rate",
-        "phase3_argument_extract/eval/readonly_empty_arguments_rate",
-        "phase3_argument_extract/order/kendall_tau",
-        "phase3_argument_extract/order/edit_distance",
+        "phase3_argument_extraction/train/loss",
+        "phase3_argument_extraction/train/perplexity",
+        "phase3_argument_extraction/train/optimizer_step",
+        "phase3_argument_extraction/eval/call_ordered_exact_match_rate",
+        "phase3_argument_extraction/eval/method_exact_match_rate",
+        "phase3_argument_extraction/eval/arguments_exact_match_rate",
+        "phase3_argument_extraction/eval/readonly_empty_arguments_rate",
+        "phase3_argument_extraction/order/kendall_tau",
+        "phase3_argument_extraction/order/edit_distance",
     )
 
     assert PHASE2_GOAL_EXTRACT_METRIC_KEYS == PHASE2_WANDB_METRIC_KEYS
@@ -1063,20 +1063,20 @@ def test_wandb_metric_keys_are_stage_scoped_and_not_m3_names() -> None:
     assert len(PHASE2_GOAL_EXTRACT_METRIC_KEYS) == len(set(PHASE2_GOAL_EXTRACT_METRIC_KEYS))
     assert len(PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS) == len(set(PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS))
     assert (
-        "phase2_goal_extract/eval/ordered_exact_match_rate"
+        "phase2_goal_extraction/eval/ordered_exact_match_rate"
         in PHASE2_GOAL_EXTRACT_METRIC_KEYS
     )
-    assert "phase2_goal_extract/eval/set_match_rate" in PHASE2_GOAL_EXTRACT_METRIC_KEYS
+    assert "phase2_goal_extraction/eval/set_match_rate" in PHASE2_GOAL_EXTRACT_METRIC_KEYS
     assert (
-        "phase3_argument_extract/eval/readonly_empty_arguments_rate"
+        "phase3_argument_extraction/eval/readonly_empty_arguments_rate"
         in PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS
     )
     assert (
-        "phase3_argument_extract/eval/arguments_exact_match_rate"
+        "phase3_argument_extraction/eval/arguments_exact_match_rate"
         in PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS
     )
-    assert all(k.startswith("phase2_goal_extract/") for k in PHASE2_GOAL_EXTRACT_METRIC_KEYS)
-    assert all(k.startswith("phase3_argument_extract/") for k in PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS)
+    assert all(k.startswith("phase2_goal_extraction/") for k in PHASE2_GOAL_EXTRACT_METRIC_KEYS)
+    assert all(k.startswith("phase3_argument_extraction/") for k in PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS)
     assert not any(k.startswith("m3_") for k in PHASE2_GOAL_EXTRACT_METRIC_KEYS)
     assert not any(k.startswith("m3_") for k in PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS)
 
@@ -1090,10 +1090,10 @@ def test_training_docs_pin_phase23_metric_constants() -> None:
     assert "PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS" in training_doc
     assert "PHASE2_WANDB_METRIC_KEYS" in training_doc
     assert "PHASE3_WANDB_METRIC_KEYS" in training_doc
-    assert "phase2_goal_extract/eval/{ordered_exact_match_rate,set_match_rate" in training_doc
-    assert "phase2_goal_extract/order/{kendall_tau,edit_distance}" in training_doc
-    assert "phase3_argument_extract/eval/{call_ordered_exact_match_rate" in training_doc
-    assert "phase3_argument_extract/order/{kendall_tau,edit_distance}" in training_doc
+    assert "phase2_goal_extraction/eval/{ordered_exact_match_rate,set_match_rate" in training_doc
+    assert "phase2_goal_extraction/order/{kendall_tau,edit_distance}" in training_doc
+    assert "phase3_argument_extraction/eval/{call_ordered_exact_match_rate" in training_doc
+    assert "phase3_argument_extraction/order/{kendall_tau,edit_distance}" in training_doc
     for metric_key in PHASE2_GOAL_EXTRACT_METRIC_KEYS:
         assert metric_key in training_doc
     for metric_key in PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS:

--- a/tests/gpu/test_m1_train_step_live.py
+++ b/tests/gpu/test_m1_train_step_live.py
@@ -137,6 +137,10 @@ def _plain_trainer(tmp_path):
     trainer._pin_memory = False
     trainer._is_quantize = False
     trainer._best_validation_metric = float("-inf")
+    trainer._metric_namespace = ""
+    trainer._select_best_by_eval_loss = False
+    trainer._early_stopping_patience = 3
+    trainer._early_stopping_min_delta = 0.005
     trainer._masked_freq = 1
     trainer._current_mask_method_counter = 0
     trainer._current_mask_method_idx = 0

--- a/tests/modules/test_checkpoint_best_metric.py
+++ b/tests/modules/test_checkpoint_best_metric.py
@@ -1,0 +1,135 @@
+"""Offline regressions for best-metric persistence across checkpoint save/resume.
+
+Pins the Phase 1 resume fix: a loss-mode run must persist its best validation
+metric (`best_metric` + `best_metric_mode` in the checkpoint, both created by
+``IgcModule.save_checkpoint``) and restore it on resume via
+``restored_best_metric`` — otherwise ``_best_validation_metric`` restarts at
+``+inf`` and the first post-resume eval is always flagged "best", overwriting
+the true best checkpoint and resetting early-stop patience. Also pins
+``resolve_early_stopping`` honoring an explicit ``0`` (a bare ``or`` default
+silently swallowed it). CPU-only, no GPU/network/downloads.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import argparse
+
+import loguru
+import torch
+from torch.utils.data import TensorDataset
+
+from igc.modules.base.igc_base_module import CheckpointState, IgcModule
+from igc.modules.llm_train_state_encoder import (
+    resolve_early_stopping,
+    restored_best_metric,
+)
+
+
+def _module(tmp_path):
+    """A minimal IgcModule (bypasses the heavy __init__) for checkpoint calls."""
+    m = IgcModule.__new__(IgcModule)
+    m.rank = 0
+    m.module_name = "tmod"
+    m.logger = loguru.logger
+    m.model = torch.nn.Linear(2, 2)
+    m.optimizer = torch.optim.SGD(m.model.parameters(), lr=0.1)
+    m.scheduler = None
+    m.dataset = TensorDataset(torch.arange(10, dtype=torch.float32))
+    m._trainer_args = argparse.Namespace(seed=42, output_dir=str(tmp_path))
+    m._module_checkpoint_dir = str(tmp_path)
+    return m
+
+
+def test_save_checkpoint_persists_best_metric_and_mode(tmp_path):
+    """best_metric/best_metric_mode round-trip through the checkpoint file."""
+    m = _module(tmp_path)
+    path = m.save_checkpoint(
+        str(tmp_path), epoch=1, best_metric=1.25, best_metric_mode="loss")
+    checkpoint = torch.load(path, weights_only=True)
+    assert checkpoint["best_metric"] == 1.25
+    assert checkpoint["best_metric_mode"] == "loss"
+
+
+def test_load_checkpoint_returns_best_metric_fields(tmp_path):
+    """load_checkpoint surfaces the persisted best metric in CheckpointState."""
+    m = _module(tmp_path)
+    m.save_checkpoint(str(tmp_path), epoch=1, best_metric=0.75, best_metric_mode="loss")
+    state = m.load_checkpoint(str(tmp_path), map_location="cpu")
+    assert state.best_metric == 0.75
+    assert state.best_metric_mode == "loss"
+
+
+def test_load_legacy_checkpoint_defaults_best_metric_none(tmp_path):
+    """A checkpoint written without the new channel loads with None defaults."""
+    m = _module(tmp_path)
+    m.save_checkpoint(str(tmp_path), epoch=1, last_accuracy=42.0)
+    state = m.load_checkpoint(str(tmp_path), map_location="cpu")
+    assert state.best_metric is None
+    assert state.best_metric_mode is None
+    assert state.best_accuracy == 42.0
+
+
+def test_checkpoint_state_five_positional_still_constructs():
+    """Legacy 5-positional CheckpointState construction keeps working."""
+    state = CheckpointState(0, None, 0, float('-inf'), 0)
+    assert state.best_metric is None
+    assert state.best_metric_mode is None
+
+
+def test_restored_best_metric_loss_mode_matches():
+    """Loss mode restores a loss-mode best_metric."""
+    state = CheckpointState(3, None, 1e-4, 55.0, 0, 1.5, "loss")
+    assert restored_best_metric(state, select_by_loss=True) == 1.5
+
+
+def test_restored_best_metric_rejects_mode_mismatch():
+    """An accuracy-mode best never seeds loss-mode tracking (and vice versa)."""
+    acc_state = CheckpointState(3, None, 1e-4, 55.0, 0, 55.0, "accuracy")
+    assert restored_best_metric(acc_state, select_by_loss=True) is None
+    loss_state = CheckpointState(3, None, 1e-4, float('-inf'), 0, 1.5, "loss")
+    assert restored_best_metric(loss_state, select_by_loss=False) is None
+
+
+def test_restored_best_metric_loss_mode_legacy_starts_fresh():
+    """Loss mode has no legacy channel: a legacy checkpoint restores nothing."""
+    state = CheckpointState(3, None, 1e-4, 55.0, 0)
+    assert restored_best_metric(state, select_by_loss=True) is None
+
+
+def test_restored_best_metric_accuracy_mode_legacy_fallback():
+    """Accuracy mode falls back to the legacy finite best_accuracy channel."""
+    state = CheckpointState(3, None, 1e-4, 55.0, 0)
+    assert restored_best_metric(state, select_by_loss=False) == 55.0
+
+
+def test_restored_best_metric_filters_non_finite():
+    """Sentinel -inf/+inf values never seed best tracking."""
+    inf_best = CheckpointState(3, None, 1e-4, float('-inf'), 0, float('inf'), "loss")
+    assert restored_best_metric(inf_best, select_by_loss=True) is None
+    assert restored_best_metric(inf_best, select_by_loss=False) is None
+
+
+def test_resolve_early_stopping_defaults():
+    """Missing/None knobs fall back to the Phase 1 defaults."""
+    assert resolve_early_stopping(argparse.Namespace()) == (3, 0.005)
+    spec = argparse.Namespace(
+        early_stopping_patience=None, early_stopping_min_delta=None)
+    assert resolve_early_stopping(spec) == (3, 0.005)
+
+
+def test_resolve_early_stopping_honors_explicit_zero():
+    """An explicit 0 disables patience / zeroes min_delta instead of defaulting."""
+    spec = argparse.Namespace(
+        early_stopping_patience=0, early_stopping_min_delta=0.0)
+    assert resolve_early_stopping(spec) == (0, 0.0)
+
+
+def test_resolve_early_stopping_explicit_values():
+    """Explicit non-default knobs pass through unchanged."""
+    spec = argparse.Namespace(
+        early_stopping_patience=7, early_stopping_min_delta=0.01)
+    assert resolve_early_stopping(spec) == (7, 0.01)
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_eval_metric_gather.py
+++ b/tests/modules/test_eval_metric_gather.py
@@ -20,30 +20,39 @@ from igc.modules.llm_train_state_encoder import LlmEmbeddingsTrainer
 
 
 def test_validate_all_reduces_the_metric():
-    """validate() must all-reduce the eval counts so accuracy is a single global value."""
+    """validate() must all-reduce eval counts/loss so every rank sees one global metric."""
     src = inspect.getsource(LlmEmbeddingsTrainer.validate)
     assert "accelerator.reduce" in src, (
-        "validate() must reduce (correct, total) across ranks so every rank computes the same "
-        "global accuracy; a rank-local accuracy makes ranks disagree on 'best' and deadlock the save."
+        "validate() must reduce (correct, total, loss_sum, loss_tokens) across ranks so every "
+        "rank computes the same global eval metric; rank-local best values deadlock the save."
     )
 
 
 def test_best_metric_tracked_on_all_ranks_not_only_rank_zero():
-    """The best-metric update must run on ALL ranks (gated on is_best_accuracy), not under is_rank_zero.
+    """The best-metric update must run on ALL ranks, not under is_rank_zero.
 
-    If only rank 0 tracks the best, the non-zero ranks keep -inf, compute is_best_accuracy
+    If only rank 0 tracks the best, the non-zero ranks keep stale metrics, compute best-save state
     differently, and enter the save collective asymmetrically -> the _ALLGATHER_BASE hang.
     """
     src = inspect.getsource(LlmEmbeddingsTrainer)
-    assert src.count("self._best_validation_metric = validation_accuracy") == 1, (
+    assert src.count("self._best_validation_metric = selection_metric") == 1, (
         "expected exactly one best-metric assignment (the rank-0-only one was removed)"
     )
-    idx = src.index("self._best_validation_metric = validation_accuracy")
+    idx = src.index("self._best_validation_metric = selection_metric")
     preceding = src[:idx]
-    assert preceding.rfind("if is_best_accuracy:") > preceding.rfind("if self.is_rank_zero()"), (
-        "the best-metric update must be gated on is_best_accuracy on every rank, i.e. BEFORE / "
+    assert preceding.rfind("if improved:") > preceding.rfind("if self.is_rank_zero()"), (
+        "the best-metric update must be gated on improved on every rank, i.e. BEFORE / "
         "outside the is_rank_zero() block, so all ranks agree on 'best'."
     )
+
+
+def test_phase1_best_metric_is_eval_loss_minimize_with_min_delta():
+    """Phase 1 must select checkpoints by lower eval loss, not higher token accuracy."""
+    src = inspect.getsource(LlmEmbeddingsTrainer._train)
+    assert "self._select_best_by_eval_loss" in src
+    assert "selection_metric = validation_eval_loss" in src
+    assert "self._early_stopping_min_delta" in src
+    assert "< self._best_validation_metric" in src
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_phase1_metric_keys.py
+++ b/tests/modules/test_phase1_metric_keys.py
@@ -4,7 +4,7 @@ Author:
 Mus mbayramo@stanford.edu
 """
 from igc.modules.base.metric_keys import (
-    PHASE1_PRETRAIN,
+    PHASE1_FINETUNE,
     PHASE1_WANDB_METRIC_KEYS,
     phase_metric,
 )
@@ -13,19 +13,19 @@ from igc.modules.base.metric_keys import (
 def test_phase1_metric_registry_keeps_expected_live_keys() -> None:
     """The current Phase 1 registry still covers train/eval/throughput basics."""
     keys = set(PHASE1_WANDB_METRIC_KEYS)
-    assert phase_metric(PHASE1_PRETRAIN, "train", "loss") in keys
-    assert phase_metric(PHASE1_PRETRAIN, "train", "epoch_loss") in keys
-    assert phase_metric(PHASE1_PRETRAIN, "eval", "token_accuracy") in keys
-    assert phase_metric(PHASE1_PRETRAIN, "throughput", "train_tokens_per_sec") in keys
+    assert phase_metric(PHASE1_FINETUNE, "train", "loss") in keys
+    assert phase_metric(PHASE1_FINETUNE, "train", "epoch_loss") in keys
+    assert phase_metric(PHASE1_FINETUNE, "eval", "token_accuracy") in keys
+    assert phase_metric(PHASE1_FINETUNE, "throughput", "train_tokens_per_sec") in keys
 
 
 def test_phase1_metric_registry_omits_unwired_structural_keys() -> None:
     """Do not advertise structural/data metrics until a real producer lands."""
     keys = set(PHASE1_WANDB_METRIC_KEYS)
-    assert phase_metric(PHASE1_PRETRAIN, "eval", "json_parse_rate") not in keys
-    assert phase_metric(PHASE1_PRETRAIN, "eval", "json_exact_match_rate") not in keys
-    assert phase_metric(PHASE1_PRETRAIN, "eval", "odata_id_match_rate") not in keys
-    assert phase_metric(PHASE1_PRETRAIN, "data", "padding_ratio") not in keys
+    assert phase_metric(PHASE1_FINETUNE, "eval", "json_parse_rate") not in keys
+    assert phase_metric(PHASE1_FINETUNE, "eval", "json_exact_match_rate") not in keys
+    assert phase_metric(PHASE1_FINETUNE, "eval", "odata_id_match_rate") not in keys
+    assert phase_metric(PHASE1_FINETUNE, "data", "padding_ratio") not in keys
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_validation_metrics.py
+++ b/tests/modules/test_validation_metrics.py
@@ -12,7 +12,11 @@ Mus mbayramo@stanford.edu
 
 import torch
 
-from igc.modules.llm_train_state_encoder import LlmEmbeddingsTrainer
+from igc.modules.llm_train_state_encoder import (
+    LlmEmbeddingsTrainer,
+    ValidationMetrics,
+    shifted_token_loss,
+)
 
 
 def _aligned_logits(targets, vocab=7):
@@ -61,6 +65,44 @@ def test_all_pad_batch_is_zero_not_nan():
         torch.zeros(1, 3, 7), targets, None
     )
     assert accuracy == 0.0
+
+
+class _ValidationModel(torch.nn.Module):
+    """Tiny model that exposes logits and CE loss when labels are passed."""
+
+    def __init__(self, logits: torch.Tensor):
+        super().__init__()
+        self._logits = logits
+
+    def forward(self, input_ids, attention_mask, labels=None):
+        """Return a Hugging Face-like object with logits and loss."""
+        loss = None
+        if labels is not None:
+            loss = shifted_token_loss(self._logits, labels)
+        return type("Output", (), {"logits": self._logits, "loss": loss})()
+
+
+def test_validate_returns_loss_and_accuracy_from_labels():
+    """Validation reports CE loss plus percent token accuracy from prompt-masked labels."""
+    labels = torch.tensor([[0, 1, 2, -100]])
+    logits = torch.zeros(1, 4, 5)
+    logits[0, 0, 1] = 5.0  # predicts labels[:, 1] correctly
+    logits[0, 1, 3] = 5.0  # predicts labels[:, 2] incorrectly
+    trainer = LlmEmbeddingsTrainer.__new__(LlmEmbeddingsTrainer)
+    trainer.model = _ValidationModel(logits)
+    trainer._device = torch.device("cpu")
+    trainer.tokenizer = type("Tok", (), {"pad_token_id": 0})()
+    trainer.is_accelerator = False
+
+    metrics = trainer.validate([{
+        "input_ids": torch.tensor([[0, 1, 2, 3]]),
+        "attention_mask": torch.ones(1, 4, dtype=torch.long),
+        "labels": labels,
+    }])
+
+    assert isinstance(metrics, ValidationMetrics)
+    assert metrics.accuracy == 50.0
+    assert torch.isclose(torch.tensor(metrics.loss), shifted_token_loss(logits, labels))
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_wandb_run_meta.py
+++ b/tests/modules/test_wandb_run_meta.py
@@ -24,6 +24,36 @@ def test_m1_state_encoder_labels():
     assert meta["config"]["num_train_epochs"] == 5 and meta["config"]["model_type"].endswith("0.5B-Instruct")
 
 
+def test_phase1_profile_labels_finetune_even_when_rl_defaults_none():
+    """Phase 1 latent-route fine-tuning must not be mislabeled as M6 when rl='none'."""
+    meta = _wandb_run_meta({
+        "profile": "phase1_7b_rslora_r32",
+        "weights_role": "model_x",
+        "corpus_objective": "phase1_pretrain",
+        "train": "llm",
+        "llm": "latent",
+        "rl": "none",
+        "model_type": "Qwen/Qwen2.5-7B-Instruct",
+        "num_train_epochs": 3,
+        "per_device_train_batch_size": 8,
+        "use_peft": True,
+        "lora_r": 32,
+    })
+
+    assert meta["group"] == "phase1-finetune"
+    assert meta["name"] == "phase1-finetune-qwen2.5-7b-instruct-e3-bs8"
+    assert "phase1-finetune" in meta["tags"]
+    assert "m6-rl-agent" not in meta["tags"]
+    assert meta["config"]["profile"] == "phase1_7b_rslora_r32"
+    assert meta["config"]["weights_role"] == "model_x"
+
+
+def test_rl_none_does_not_force_m6_label():
+    """The argparse default rl='none' is not an active RL stage."""
+    meta = _wandb_run_meta({"train": "llm", "llm": "latent", "rl": "none"})
+    assert meta["group"] == "m1-state-encoder"
+
+
 def test_goal_extractor_and_rl_stages():
     """Other selections map to their stages (legacy goal extractor, m6 RL agent)."""
     assert _wandb_run_meta({"train": "llm", "llm": "goal"})["group"] == "goal-extractor-legacy"

--- a/tests/modules/train/test_emit.py
+++ b/tests/modules/train/test_emit.py
@@ -27,6 +27,7 @@ def _spec(**over):
         "per_device_train_batch_size": 8, "gradient_accumulation_steps": 4,
         "num_train_epochs": 3, "llm_learning_rate": 5e-5,
         "llm_scheduler": "OneCycleLR", "llm_optimizer": "AdamW",
+        "early_stopping_patience": 3, "early_stopping_min_delta": 0.005,
         "mixed_precision": "bf16", "sharding": "none", "use_accelerator": False,
         "masking_type": "NO_MASK", "num_workers": 8, "seed": 42,
         "weights_role": "model_x",
@@ -78,6 +79,8 @@ def test_settings_scrubbed_of_sensitive_keys():
     # the allowlisted run knobs made it through
     assert m.settings["gradient_accumulation_steps"] == "4"
     assert m.settings["llm_scheduler"] == "OneCycleLR"
+    assert m.settings["early_stopping_patience"] == "3"
+    assert m.settings["early_stopping_min_delta"] == "0.005"
     assert m.settings["weights_role"] == "model_x"
 
 

--- a/tests/modules/train/test_emit.py
+++ b/tests/modules/train/test_emit.py
@@ -29,6 +29,7 @@ def _spec(**over):
         "llm_scheduler": "OneCycleLR", "llm_optimizer": "AdamW",
         "mixed_precision": "bf16", "sharding": "none", "use_accelerator": False,
         "masking_type": "NO_MASK", "num_workers": 8, "seed": 42,
+        "weights_role": "model_x",
     }
     spec.update(over)
     return spec
@@ -77,6 +78,7 @@ def test_settings_scrubbed_of_sensitive_keys():
     # the allowlisted run knobs made it through
     assert m.settings["gradient_accumulation_steps"] == "4"
     assert m.settings["llm_scheduler"] == "OneCycleLR"
+    assert m.settings["weights_role"] == "model_x"
 
 
 def test_emit_writes_readable_report(tmp_path: Path):

--- a/tests/modules/train/test_emit_edges.py
+++ b/tests/modules/train/test_emit_edges.py
@@ -19,7 +19,8 @@ def _spec(**overrides):
     """Minimal parsed-spec dict with realistic run-report keys."""
     spec = {
         "model_type": "Qwen/Qwen2.5-7B-Instruct",
-        "profile": "m1_7b_rslora_r32",
+        "profile": "phase1_7b_rslora_r32",
+        "corpus_objective": "phase1_pretrain",
         "use_peft": True,
         "adapter_method": "rslora",
         "lora_r": "32",
@@ -58,7 +59,19 @@ def test_run_id_is_stable_for_model_basename_and_timestamp():
         started_at="2026-07-10T01:02:03",
     )
 
-    assert bundle.manifest.run_id == "m1-Qwen2.5-7B-Instruct-20260710T010203"
+    assert bundle.manifest.run_id == "phase1-Qwen2.5-7B-Instruct-20260710T010203"
+
+
+def test_phase1_profile_keeps_phase1_run_family_with_legacy_objective():
+    """A Phase 1 profile name, not only the corpus objective, selects the phase1 run family."""
+    bundle = build_run_bundle(
+        _spec(model_type="/models/Qwen2.5-7B-Instruct", corpus_objective="legacy"),
+        training={},
+        argv=[],
+        started_at="2026-07-10T01:02:03",
+    )
+
+    assert bundle.manifest.run_id == "phase1-Qwen2.5-7B-Instruct-20260710T010203"
 
 
 def test_report_copies_training_and_metrics_inputs():
@@ -86,6 +99,8 @@ def test_settings_include_only_allowlisted_run_knobs():
         "gradient_accumulation_steps": "4",
         "llm_scheduler": "OneCycleLR",
         "seed": "7",
+        "profile": "phase1_7b_rslora_r32",
+        "corpus_objective": "phase1_pretrain",
         "use_peft": "True",
         "lora_r": "32",
     }
@@ -96,7 +111,7 @@ def test_emit_creates_nested_output_directory(tmp_path: Path):
     bundle = build_run_bundle(
         _spec(use_peft=False, lora_r=64),
         training={"epochs_done": 1},
-        argv=["igc_main.py", "--profile", "m1_gpt2_smoke"],
+        argv=["igc_main.py", "--profile", "phase1_gpt2_smoke"],
         checkpoint_path="experiments/smoke",
     )
     report_path = emit_run_report(bundle, str(tmp_path / "nested" / "run"))

--- a/tests/modules/train/test_emit_edges.py
+++ b/tests/modules/train/test_emit_edges.py
@@ -28,6 +28,8 @@ def _spec(**overrides):
         "max_train_steps": 120,
         "seq_len": 1024,
         "gradient_accumulation_steps": 4,
+        "early_stopping_patience": 3,
+        "early_stopping_min_delta": 0.005,
         "llm_scheduler": "OneCycleLR",
         "seed": 7,
     }
@@ -97,6 +99,8 @@ def test_settings_include_only_allowlisted_run_knobs():
 
     assert bundle.manifest.settings == {
         "gradient_accumulation_steps": "4",
+        "early_stopping_patience": "3",
+        "early_stopping_min_delta": "0.005",
         "llm_scheduler": "OneCycleLR",
         "seed": "7",
         "profile": "phase1_7b_rslora_r32",

--- a/tests/modules/train/test_launch.py
+++ b/tests/modules/train/test_launch.py
@@ -30,6 +30,8 @@ def test_smoke_is_step_capped_full_ft():
     assert _val(argv, "--corpus_objective") == "phase1_pretrain"
     assert _val(argv, "--weights_role") == "model_x"
     assert _val(argv, "--llm") == "latent"
+    assert _val(argv, "--early_stopping_patience") == "3"
+    assert _val(argv, "--early_stopping_min_delta") == "0.005"
     assert "--use_peft" not in argv and "--num_train_epochs" not in argv
 
 
@@ -78,6 +80,7 @@ def test_main_print_argv_applies_typed_set_overrides(capsys):
     assert _val(argv, "--per_device_train_batch_size") == "12"
     assert _val(argv, "--llm_learning_rate") == "0.0002"
     assert _val(argv, "--max_train_steps") == "25"
+    assert _val(argv, "--early_stopping_patience") == "3"
     assert "--num_train_epochs" not in argv
 
 
@@ -92,6 +95,8 @@ def test_main_prints_public_safe_profile_json(capsys):
     assert payload["phase"] == "phase1_finetune"
     assert payload["weights_role"] == "model_x"
     assert payload["corpus_objective"] == "phase1_pretrain"
+    assert payload["early_stopping_patience"] == 3
+    assert payload["early_stopping_min_delta"] == 0.005
     assert payload["adapter"]["method"] == "full_finetune"
     assert "json_data_dir" not in payload and "output_dir" not in payload
 

--- a/tests/modules/train/test_launch.py
+++ b/tests/modules/train/test_launch.py
@@ -28,6 +28,7 @@ def test_smoke_is_step_capped_full_ft():
     assert _val(argv, "--model_type") == "gpt2"
     assert _val(argv, "--max_train_steps") == "50"
     assert _val(argv, "--corpus_objective") == "phase1_pretrain"
+    assert _val(argv, "--weights_role") == "model_x"
     assert _val(argv, "--llm") == "latent"
     assert "--use_peft" not in argv and "--num_train_epochs" not in argv
 
@@ -89,6 +90,7 @@ def test_main_prints_public_safe_profile_json(capsys):
     assert payload["profile"] == "phase1_7b_full_zero3"
     assert payload["num_workers"] == 2
     assert payload["phase"] == "phase1_finetune"
+    assert payload["weights_role"] == "model_x"
     assert payload["corpus_objective"] == "phase1_pretrain"
     assert payload["adapter"]["method"] == "full_finetune"
     assert "json_data_dir" not in payload and "output_dir" not in payload

--- a/tests/modules/train/test_launch.py
+++ b/tests/modules/train/test_launch.py
@@ -1,9 +1,9 @@
 """Offline tests for profile_to_argv (name -> igc_main.py command line).
 
-Pins that each named profile maps to the right igc_main flags: the smoke caps steps and
-runs full-FT, LoRA profiles carry adapter flags + epochs, the 7B rsLoRA candidate emits
---adapter_method rslora at r32/alpha64, and full-FT profiles turn on the accelerator +
-sharding. Data/output dirs are intentionally NOT baked in. Pure stdlib.
+Pins that each named Phase 1 profile maps to the right igc_main flags: the smoke caps
+steps and runs full-FT, LoRA profiles carry adapter flags + epochs, the 7B rsLoRA
+candidate emits --adapter_method rslora at r32/alpha64, and full-FT profiles turn on
+the accelerator + sharding. Data/output dirs are intentionally NOT baked in. Pure stdlib.
 
 Author:
 Mus mbayramo@stanford.edu
@@ -23,23 +23,26 @@ def _val(argv, flag):
 
 def test_smoke_is_step_capped_full_ft():
     """The GPT-2 smoke caps steps and does not enable PEFT."""
-    argv = profile_to_argv(resolve_profile("m1_gpt2_smoke"))
+    argv = profile_to_argv(resolve_profile("phase1_gpt2_smoke"))
+    assert _val(argv, "--profile") == "phase1_gpt2_smoke"
     assert _val(argv, "--model_type") == "gpt2"
     assert _val(argv, "--max_train_steps") == "50"
+    assert _val(argv, "--corpus_objective") == "phase1_pretrain"
+    assert _val(argv, "--llm") == "latent"
     assert "--use_peft" not in argv and "--num_train_epochs" not in argv
 
 
 def test_3b_lora_has_adapter_flags_and_epochs():
     """The 3B LoRA profile emits PEFT + adapter flags and epoch-based length."""
-    argv = profile_to_argv(resolve_profile("m1_3b_lora"))
+    argv = profile_to_argv(resolve_profile("phase1_3b_lora"))
     assert "--use_peft" in argv
     assert _val(argv, "--lora_r") == "16" and _val(argv, "--adapter_method") == "lora"
     assert _val(argv, "--num_train_epochs") == "3" and "--max_train_steps" not in argv
 
 
 def test_7b_rslora_argv_matches_spec():
-    """m1_7b_rslora_r32 emits the plan's rsLoRA r32/alpha64 adapter flags."""
-    argv = profile_to_argv(resolve_profile("m1_7b_rslora_r32"))
+    """phase1_7b_rslora_r32 emits the plan's rsLoRA r32/alpha64 adapter flags."""
+    argv = profile_to_argv(resolve_profile("phase1_7b_rslora_r32"))
     assert _val(argv, "--model_type") == "Qwen/Qwen2.5-7B-Instruct"
     assert _val(argv, "--adapter_method") == "rslora"
     assert _val(argv, "--lora_r") == "32" and _val(argv, "--lora_alpha") == "64"
@@ -48,21 +51,21 @@ def test_7b_rslora_argv_matches_spec():
 
 def test_full_ft_enables_accelerator_and_sharding():
     """Full fine-tune profiles turn on the accelerator + ZeRO-3 and drop PEFT."""
-    argv = profile_to_argv(resolve_profile("m1_7b_full_zero3"))
+    argv = profile_to_argv(resolve_profile("phase1_7b_full_zero3"))
     assert "--use_accelerator" in argv and _val(argv, "--sharding") == "zero3"
     assert _val(argv, "--mixed_precision") == "bf16" and "--use_peft" not in argv
 
 
 def test_override_flows_into_argv():
     """A resolved override (e.g. batch_size) is reflected in the argv."""
-    argv = profile_to_argv(resolve_profile("m1_7b_lora", batch_size=16))
+    argv = profile_to_argv(resolve_profile("phase1_7b_lora", batch_size=16))
     assert _val(argv, "--per_device_train_batch_size") == "16"
 
 
 def test_main_print_argv_applies_typed_set_overrides(capsys):
     """CLI --set overrides are coerced before printing the igc_main argv."""
     rc = main([
-        "--profile", "m1_3b_lora",
+        "--profile", "phase1_3b_lora",
         "--set", "batch_size=12",
         "--set", "lr=2e-4",
         "--set", "max_steps=25",
@@ -79,12 +82,14 @@ def test_main_print_argv_applies_typed_set_overrides(capsys):
 
 def test_main_prints_public_safe_profile_json(capsys):
     """Without --print-argv, CLI output is a resolved profile JSON payload."""
-    rc = main(["--profile", "m1_7b_full_zero3", "--set", "num_workers=2"])
+    rc = main(["--profile", "phase1_7b_full_zero3", "--set", "num_workers=2"])
     payload = json.loads(capsys.readouterr().out)
 
     assert rc == 0
-    assert payload["profile"] == "m1_7b_full_zero3"
+    assert payload["profile"] == "phase1_7b_full_zero3"
     assert payload["num_workers"] == 2
+    assert payload["phase"] == "phase1_finetune"
+    assert payload["corpus_objective"] == "phase1_pretrain"
     assert payload["adapter"]["method"] == "full_finetune"
     assert "json_data_dir" not in payload and "output_dir" not in payload
 
@@ -92,7 +97,29 @@ def test_main_prints_public_safe_profile_json(capsys):
 def test_main_rejects_unknown_set_override():
     """A typo in --set fails loudly instead of silently changing the command."""
     with pytest.raises(ValueError, match="unknown profile override"):
-        main(["--profile", "m1_3b_lora", "--set", "btch_size=16"])
+        main(["--profile", "phase1_3b_lora", "--set", "btch_size=16"])
+
+
+def test_main_rejects_old_m1_profile_with_rename_hint(capsys):
+    """Old m1_* profile names fail loudly and point to the phase1_* replacement."""
+    with pytest.raises(SystemExit) as exc:
+        main(["--profile", "m1_7b_rslora_r32", "--print-argv"])
+
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "m1_7b_rslora_r32" in err
+    assert "phase1_7b_rslora_r32" in err
+
+
+def test_main_rejects_unknown_profile_with_valid_names(capsys):
+    """Unknown profile errors list valid Phase 1 names instead of argparse choices noise."""
+    with pytest.raises(SystemExit) as exc:
+        main(["--profile", "phase9_magic"])
+
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "unknown profile 'phase9_magic'" in err
+    assert "phase1_gpt2_smoke" in err
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/modules/train/test_profile_local_model.py
+++ b/tests/modules/train/test_profile_local_model.py
@@ -1,6 +1,6 @@
-"""Offline regressions for the env-driven ``m1_local`` profile and seq_len argv.
+"""Offline regressions for the env-driven ``phase1_local`` profile and seq_len argv.
 
-``m1_local`` takes its weights dir from ``$IGC_MODEL_DIR`` at resolve time (no
+``phase1_local`` takes its weights dir from ``$IGC_MODEL_DIR`` at resolve time (no
 node-local path is committed), failing loudly when the variable is unset. The
 launcher argv must emit ``--seq_len`` — the profile field was previously dead,
 freezing chunk length at the build-time default regardless of the profile.
@@ -15,30 +15,30 @@ from igc.modules.train.launch import profile_to_argv
 from igc.modules.train.profiles import resolve_profile
 
 
-def test_m1_local_resolves_model_from_env(monkeypatch):
+def test_phase1_local_resolves_model_from_env(monkeypatch):
     """$IGC_MODEL_DIR expands into the profile's model at resolve time."""
     monkeypatch.setenv("IGC_MODEL_DIR", "/nvme/models/DeepSeek-V4-Flash")
-    profile = resolve_profile("m1_local")
+    profile = resolve_profile("phase1_local")
     assert profile.model == "/nvme/models/DeepSeek-V4-Flash"
 
 
-def test_m1_local_unset_env_raises(monkeypatch):
+def test_phase1_local_unset_env_raises(monkeypatch):
     """An unset IGC_MODEL_DIR is a loud error, not a literal '$IGC_MODEL_DIR'."""
     monkeypatch.delenv("IGC_MODEL_DIR", raising=False)
     with pytest.raises(ValueError, match="IGC_MODEL_DIR"):
-        resolve_profile("m1_local")
+        resolve_profile("phase1_local")
 
 
 def test_env_expansion_applies_after_overrides(monkeypatch):
     """A model override wins and needs no env var."""
     monkeypatch.delenv("IGC_MODEL_DIR", raising=False)
-    profile = resolve_profile("m1_local", model="gpt2")
+    profile = resolve_profile("phase1_local", model="gpt2")
     assert profile.model == "gpt2"
 
 
 def test_argv_emits_profile_seq_len():
     """profile_to_argv forwards seq_len (256 for the gpt2 smoke profile)."""
-    argv = profile_to_argv(resolve_profile("m1_gpt2_smoke"))
+    argv = profile_to_argv(resolve_profile("phase1_gpt2_smoke"))
     assert "--seq_len" in argv
     assert argv[argv.index("--seq_len") + 1] == "256"
 

--- a/tests/modules/train/test_profiles.py
+++ b/tests/modules/train/test_profiles.py
@@ -89,6 +89,7 @@ def test_profile_matrix_matches_plan_contract(
     assert p.precision == precision
     assert p.max_steps == max_steps
     assert p.phase == "phase1_finetune"
+    assert p.weights_role == "model_x"
     assert p.llm_stage == "latent"
     assert p.corpus_objective == "phase1_pretrain"
 
@@ -174,6 +175,7 @@ def test_describe_is_flat_log_safe_dict():
     d = resolve_profile("phase1_7b_rslora_r32").describe()
     assert d["profile"] == "phase1_7b_rslora_r32" and d["use_peft"] is True
     assert d["phase"] == "phase1_finetune"
+    assert d["weights_role"] == "model_x"
     assert d["corpus_objective"] == "phase1_pretrain"
     assert d["adapter"]["method"] == "rslora" and d["adapter"]["r"] == 32
     full = resolve_profile("phase1_7b_full_zero3").describe()

--- a/tests/modules/train/test_profiles.py
+++ b/tests/modules/train/test_profiles.py
@@ -1,4 +1,4 @@
-"""Offline tests for the M1 training profile registry (the run contract).
+"""Offline tests for the Phase 1 training profile registry (the run contract).
 
 Pins the six named profiles, that the 7B rsLoRA candidate resolves to the exact
 LoRA config docs/TRAINING_OPTIMIZATION_PLAN.md specifies, that full-FT profiles carry
@@ -18,42 +18,42 @@ from igc.modules.train.profiles import (
 )
 
 _REGISTERED = [
-    "m1_gpt2_smoke",
-    "m1_3b_lora",
-    "m1_7b_lora",
-    "m1_7b_rslora_r32",
-    "m1_local",
-    "m1_3b_full",
-    "m1_7b_full_zero3",
+    "phase1_gpt2_smoke",
+    "phase1_3b_lora",
+    "phase1_7b_lora",
+    "phase1_7b_rslora_r32",
+    "phase1_local",
+    "phase1_3b_full",
+    "phase1_7b_full_zero3",
 ]
 
 _PROFILE_CASES = [
-    ("m1_gpt2_smoke", "gpt2", False, 8, 1, 5e-5, "none", 256, "no", 50),
+    ("phase1_gpt2_smoke", "gpt2", False, 8, 1, 5e-5, "none", 256, "no", 50),
     (
-        "m1_3b_lora", "Qwen/Qwen2.5-3B-Instruct", True, 8, 2,
+        "phase1_3b_lora", "Qwen/Qwen2.5-3B-Instruct", True, 8, 2,
         1e-4, "none", 1024, "bf16", None,
     ),
     (
-        "m1_7b_lora", "Qwen/Qwen2.5-7B-Instruct", True, 8, 4,
+        "phase1_7b_lora", "Qwen/Qwen2.5-7B-Instruct", True, 8, 4,
         1e-4, "none", 1024, "bf16", None,
     ),
     (
-        "m1_7b_rslora_r32", "Qwen/Qwen2.5-7B-Instruct", True, 8, 4,
+        "phase1_7b_rslora_r32", "Qwen/Qwen2.5-7B-Instruct", True, 8, 4,
         1e-4, "none", 1024, "bf16", None,
     ),
     (
-        "m1_3b_full", "Qwen/Qwen2.5-3B-Instruct", False, 4, 8,
+        "phase1_3b_full", "Qwen/Qwen2.5-3B-Instruct", False, 4, 8,
         2e-5, "zero3", 1024, "bf16", None,
     ),
     (
-        "m1_7b_full_zero3", "Qwen/Qwen2.5-7B-Instruct", False, 2, 16,
+        "phase1_7b_full_zero3", "Qwen/Qwen2.5-7B-Instruct", False, 2, 16,
         1e-5, "zero3", 1024, "bf16", None,
     ),
 ]
 
 
 def test_all_registered_profiles_present():
-    """Every named profile from the plan (plus the env-driven m1_local) is present."""
+    """Every named profile from the plan (plus the env-driven phase1_local) is present."""
     names = profile_names()
     assert names == _REGISTERED
 
@@ -88,11 +88,14 @@ def test_profile_matrix_matches_plan_contract(
     assert p.seq_len == seq_len
     assert p.precision == precision
     assert p.max_steps == max_steps
+    assert p.phase == "phase1_finetune"
+    assert p.llm_stage == "latent"
+    assert p.corpus_objective == "phase1_pretrain"
 
 
 def test_7b_rslora_matches_plan_spec():
-    """m1_7b_rslora_r32 resolves to the plan's exact LoraConfig kwargs."""
-    p = resolve_profile("m1_7b_rslora_r32")
+    """phase1_7b_rslora_r32 resolves to the plan's exact LoraConfig kwargs."""
+    p = resolve_profile("phase1_7b_rslora_r32")
     assert p.model == "Qwen/Qwen2.5-7B-Instruct" and p.use_peft
     kw = apply_lora_kwargs(p)
     assert kw["r"] == 32 and kw["alpha"] == 64 and kw["dropout"] == 0.05
@@ -105,7 +108,7 @@ def test_7b_rslora_matches_plan_spec():
 
 def test_full_ft_profiles_have_no_adapter_and_shard():
     """Full fine-tune profiles disable PEFT, shard with zero3, and refuse LoRA kwargs."""
-    for n in ("m1_3b_full", "m1_7b_full_zero3"):
+    for n in ("phase1_3b_full", "phase1_7b_full_zero3"):
         p = resolve_profile(n)
         assert not p.use_peft and p.adapter is None and p.sharding == "zero3"
         with pytest.raises(ValueError):
@@ -114,25 +117,25 @@ def test_full_ft_profiles_have_no_adapter_and_shard():
 
 def test_smoke_profile_is_cheap_and_capped():
     """The GPT-2 smoke is a small, step-capped full-FT launch check."""
-    p = resolve_profile("m1_gpt2_smoke")
+    p = resolve_profile("phase1_gpt2_smoke")
     assert p.model == "gpt2" and p.max_steps == 50 and not p.use_peft
 
 
 def test_resolve_applies_overrides_and_rejects_typos():
     """Overrides apply; an unknown field raises, and an unknown profile raises."""
-    p = resolve_profile("m1_3b_lora", batch_size=16, lr=2e-4, max_steps=200)
+    p = resolve_profile("phase1_3b_lora", batch_size=16, lr=2e-4, max_steps=200)
     assert p.batch_size == 16 and p.lr == 2e-4 and p.max_steps == 200
     with pytest.raises(ValueError):
-        resolve_profile("m1_3b_lora", btch_size=16)  # typo must not silently no-op
+        resolve_profile("phase1_3b_lora", btch_size=16)  # typo must not silently no-op
     with pytest.raises(KeyError):
         resolve_profile("does_not_exist")
 
 
 def test_resolve_override_does_not_mutate_registered_profile():
     """Overrides return a copy and leave the registered profile unchanged."""
-    base = resolve_profile("m1_3b_lora")
-    changed = resolve_profile("m1_3b_lora", batch_size=16, lr=2e-4, max_steps=200)
-    again = resolve_profile("m1_3b_lora")
+    base = resolve_profile("phase1_3b_lora")
+    changed = resolve_profile("phase1_3b_lora", batch_size=16, lr=2e-4, max_steps=200)
+    again = resolve_profile("phase1_3b_lora")
     assert changed.batch_size == 16 and changed.lr == 2e-4 and changed.max_steps == 200
     assert again is base
     assert again.batch_size == 8 and again.lr == 1e-4 and again.max_steps is None
@@ -140,7 +143,7 @@ def test_resolve_override_does_not_mutate_registered_profile():
 
 def test_peft_false_override_disables_lora_kwargs_even_with_adapter():
     """A use_peft=False override makes a profile behave as a full fine-tune."""
-    p = resolve_profile("m1_3b_lora", use_peft=False)
+    p = resolve_profile("phase1_3b_lora", use_peft=False)
     assert p.adapter is not None
     assert p.describe()["adapter"]["method"] == "full_finetune"
     with pytest.raises(ValueError):
@@ -160,7 +163,7 @@ def test_adapter_init_maps():
 def test_apply_lora_kwargs_preserves_custom_adapter_targets():
     """Custom adapter init and target modules pass through as PEFT kwargs."""
     adapter = AdapterSpec(init="loftq", target_modules=("x_proj",))
-    p = resolve_profile("m1_3b_lora", adapter=adapter)
+    p = resolve_profile("phase1_3b_lora", adapter=adapter)
     kw = apply_lora_kwargs(p)
     assert kw["init_lora_weights"] == "loftq"
     assert kw["target_modules"] == ["x_proj"]
@@ -168,10 +171,12 @@ def test_apply_lora_kwargs_preserves_custom_adapter_targets():
 
 def test_describe_is_flat_log_safe_dict():
     """describe() yields a flat dict suitable for stdout + W&B config."""
-    d = resolve_profile("m1_7b_rslora_r32").describe()
-    assert d["profile"] == "m1_7b_rslora_r32" and d["use_peft"] is True
+    d = resolve_profile("phase1_7b_rslora_r32").describe()
+    assert d["profile"] == "phase1_7b_rslora_r32" and d["use_peft"] is True
+    assert d["phase"] == "phase1_finetune"
+    assert d["corpus_objective"] == "phase1_pretrain"
     assert d["adapter"]["method"] == "rslora" and d["adapter"]["r"] == 32
-    full = resolve_profile("m1_7b_full_zero3").describe()
+    full = resolve_profile("phase1_7b_full_zero3").describe()
     assert full["adapter"]["method"] == "full_finetune" and full["sharding"] == "zero3"
 
 

--- a/tests/modules/train/test_profiles.py
+++ b/tests/modules/train/test_profiles.py
@@ -92,6 +92,8 @@ def test_profile_matrix_matches_plan_contract(
     assert p.weights_role == "model_x"
     assert p.llm_stage == "latent"
     assert p.corpus_objective == "phase1_pretrain"
+    assert p.early_stopping_patience == 3
+    assert p.early_stopping_min_delta == 0.005
 
 
 def test_7b_rslora_matches_plan_spec():
@@ -177,6 +179,8 @@ def test_describe_is_flat_log_safe_dict():
     assert d["phase"] == "phase1_finetune"
     assert d["weights_role"] == "model_x"
     assert d["corpus_objective"] == "phase1_pretrain"
+    assert d["early_stopping_patience"] == 3
+    assert d["early_stopping_min_delta"] == 0.005
     assert d["adapter"]["method"] == "rslora" and d["adapter"]["r"] == 32
     full = resolve_profile("phase1_7b_full_zero3").describe()
     assert full["adapter"]["method"] == "full_finetune" and full["sharding"] == "zero3"

--- a/tests/modules/train/test_report.py
+++ b/tests/modules/train/test_report.py
@@ -20,7 +20,7 @@ def _bundle(arm_method, rank, metrics, *, data="ds-v1", split="held-out-a", step
     """A ResultBundle for one arm with a shared (fair) manifest by default."""
     return ResultBundle(
         manifest=RunManifest(
-            run_id=f"run-{arm_method}-{rank}", profile="m1_7b_lora",
+            run_id=f"run-{arm_method}-{rank}", profile="phase1_7b_lora",
             model="Qwen/Qwen2.5-7B-Instruct", tokenizer="qwen2.5",
             adapter_method=arm_method, adapter_rank=rank,
             data_manifest=data, eval_split=split, max_steps=steps, seq_len=seq,
@@ -89,7 +89,7 @@ def test_enriched_manifest_round_trips(tmp_path: Path) -> None:
     """The comprehensive-capture fields survive write/read."""
     b = ResultBundle(
         manifest=RunManifest(
-            run_id="r1", profile="m1_7b_rslora_r32", model="Qwen/Qwen2.5-7B-Instruct",
+            run_id="r1", profile="phase1_7b_rslora_r32", model="Qwen/Qwen2.5-7B-Instruct",
             argv=["--train", "llm", "--adapter_method", "rslora"],
             started_at="2026-07-01T09:00:00", checkpoint_path="experiments/r1/last.pt",
             environment=capture_environment(),
@@ -134,7 +134,7 @@ def test_from_dict_defaults_missing_optional_collections() -> None:
     bundle = ResultBundle.from_dict({
         "manifest": {
             "run_id": "legacy-r1",
-            "profile": "m1_3b_lora",
+            "profile": "phase1_3b_lora",
             "model": "Qwen/Qwen2.5-3B-Instruct",
         },
         "metrics": {"recall@1": 0.5},

--- a/tests/shared/test_arg_parser_action_repr.py
+++ b/tests/shared/test_arg_parser_action_repr.py
@@ -123,6 +123,41 @@ def test_large_model_loader_flags_parse(monkeypatch):
     assert args.llm_torch_dtype == "bfloat16"
 
 
+def test_onecycle_defaults_follow_llm_learning_rate(monkeypatch):
+    """OneCycleLR defaults must not jump from the profile LR to the old 0.008 LR."""
+    args = _parse(
+        monkeypatch,
+        [
+            "--llm_learning_rate",
+            "0.0001",
+            "--llm_scheduler",
+            "OneCycleLR",
+        ],
+    )
+
+    assert args.max_lr == 0.0001
+    assert args.div_factor == 25.0
+    assert args.max_lr / args.div_factor < args.max_lr
+
+
+def test_onecycle_explicit_max_lr_and_div_factor_are_preserved(monkeypatch):
+    """Explicit scheduler knobs remain expert-overridable."""
+    args = _parse(
+        monkeypatch,
+        [
+            "--llm_learning_rate",
+            "0.0001",
+            "--max_lr",
+            "0.0002",
+            "--div_factor",
+            "10",
+        ],
+    )
+
+    assert args.max_lr == 0.0002
+    assert args.div_factor == 10.0
+
+
 def test_large_model_dtype_rejects_unknown_value(monkeypatch):
     """--llm_torch_dtype stays constrained to supported loader values."""
     with pytest.raises(SystemExit):

--- a/tests/shared/test_arg_parser_action_repr.py
+++ b/tests/shared/test_arg_parser_action_repr.py
@@ -74,6 +74,21 @@ def test_corpus_objective_defaults_legacy_and_phase1_selectable(monkeypatch):
     assert phase1.corpus_objective == "phase1_pretrain"
 
 
+def test_profile_weights_role_metadata_parses(monkeypatch):
+    """Profile launches can record which checkpoint role a run writes."""
+    args = _parse(
+        monkeypatch,
+        [
+            "--profile",
+            "phase1_7b_rslora_r32",
+            "--weights_role",
+            "model_x",
+        ],
+    )
+    assert args.profile == "phase1_7b_rslora_r32"
+    assert args.weights_role == "model_x"
+
+
 def test_rl_sizes_are_ints(monkeypatch):
     """rl batch/buffer sizes parse as ints, not floats."""
     args = _parse(monkeypatch, [])

--- a/tests/test_llm_shared.py
+++ b/tests/test_llm_shared.py
@@ -5,6 +5,7 @@ Author:Mus mbayramo@stanford.edu
 
 import argparse
 import os
+from types import SimpleNamespace
 import tempfile
 import unittest
 
@@ -16,8 +17,36 @@ from igc.modules.shared.llm_shared import (
     from_pretrained_default,
     save_pretrained_default,
     load_pretrained_default,
-    load_igc_tokenizer
+    load_igc_tokenizer,
+    safe_resize_token_embeddings,
 )
+
+
+class _DummyEmbeddings:
+    def __init__(self, num_embeddings):
+        self.num_embeddings = num_embeddings
+
+
+class _DummyModel:
+    def __init__(self, num_embeddings=100, name_or_path="demo/backbone"):
+        self.config = SimpleNamespace(_name_or_path=name_or_path, vocab_size=num_embeddings)
+        self.embeddings = _DummyEmbeddings(num_embeddings)
+        self.resized_to = None
+
+    def get_input_embeddings(self):
+        return self.embeddings
+
+    def resize_token_embeddings(self, size):
+        self.resized_to = size
+
+
+class _DummyTokenizer:
+    def __init__(self, size=100, name_or_path="demo/backbone"):
+        self.size = size
+        self.name_or_path = name_or_path
+
+    def __len__(self):
+        return self.size
 
 
 class TestFromPretrainedDefault(unittest.TestCase):
@@ -120,3 +149,20 @@ class TestFromPretrainedDefault(unittest.TestCase):
         self.assertIsInstance(loaded_tokenizer, GPT2Tokenizer)
         self.assertEqual(loaded_tokenizer.pad_token, loaded_tokenizer.eos_token)
         self.assertEqual(loaded_tokenizer.pad_token_id, loaded_tokenizer.eos_token_id)
+
+    def test_safe_resize_allows_same_backbone_padded_vocab_noop(self):
+        """Model vocab padding above tokenizer length should not trigger a shrink."""
+        model = _DummyModel(num_embeddings=128, name_or_path="vendor/model")
+        tokenizer = _DummyTokenizer(size=120, name_or_path="vendor/model")
+
+        safe_resize_token_embeddings(model, tokenizer)
+
+        self.assertIsNone(model.resized_to)
+
+    def test_safe_resize_rejects_obvious_wrong_tokenizer_shrink(self):
+        """A much smaller tokenizer from another backbone still raises loudly."""
+        model = _DummyModel(num_embeddings=128, name_or_path="vendor/model")
+        tokenizer = _DummyTokenizer(size=32, name_or_path="other/model")
+
+        with self.assertRaisesRegex(ValueError, "Refusing to shrink"):
+            safe_resize_token_embeddings(model, tokenizer)


### PR DESCRIPTION
## Summary
- select Phase 1 checkpoints by validation loss with min_delta and patience
- emit explicit early-stopping knobs through parser/profile/launcher/report settings
- log Phase 1 eval loss/perplexity/token accuracy for model_x selection

## Verification
- PYTHONPATH=/Users/spyroot/dev/igc KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 pytest -q tests/modules/test_validation_metrics.py tests/modules/test_eval_metric_gather.py tests/modules/test_checkpoint_sentinel.py tests/modules/test_resume_validation_accuracy_seed.py tests/modules/test_phase1_metric_keys.py tests/modules/train/test_profiles.py tests/modules/train/test_launch.py tests/modules/train/test_emit.py tests/modules/train/test_emit_edges.py tests/gpu/test_m1_train_step_live.py
- ruff check changed Python files
- bats tests/bats/gb300_launch.bats
- git diff --check

## Notes
- Private Brain/Pro review was attempted, but the task POST flapped with curl connection refusal after a successful readiness probe. No external reviewer was used.
- Mid-epoch 4x eval/save cadence remains documented as the next checkpoint-format gap; this patch preserves the gated distributed save path.