### PR TITLE
Phase 2/3 mock REST contract plumbing

### DIFF
--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -79,6 +79,31 @@ Current M1 state-encoder runs log `train/loss`, `train/lr`, `train/grad_norm`, `
 `epoch_goal_reached_count`. Treat perplexity, tokens/sec, GPU memory, and success-rate curves as
 planned instrumentation unless a later change adds those exact metric keys.
 
+Phase 2/3 mock-plumbing metric names are constants only; no live W&B run is part of that lane.
+`PHASE2_GOAL_EXTRACT_METRIC_KEYS`, defined in `igc/ds/rest_goal_contract.py`, reserves:
+`phase2_goal_extract/train/{loss,perplexity,optimizer_step}`,
+`phase2_goal_extract/eval/{loss,perplexity,token_accuracy,ordered_exact_match_rate,set_match_rate}`,
+`phase2_goal_extract/eval/{precision,recall,f1,top_k_api_accuracy,invalid_api_rate}`,
+`phase2_goal_extract/eval/{missing_required_api_rate,missing_allowed_methods_rate,order_violation_rate}`,
+`phase2_goal_extract/order/{kendall_tau,edit_distance}`,
+`phase2_goal_extract/throughput/{train_tokens_per_sec,train_samples_per_sec,eval_tokens_per_sec,eval_samples_per_sec}`,
+`phase2_goal_extract/data/{avg_num_apis,max_num_apis,mean_sequence_length,padding_ratio}`,
+`phase2_goal_extract/calibration/{log_prob_per_sequence,ece}`, and
+`phase2_goal_extract/test/{latency_sec_p50,latency_sec_p95,memory_peak_mb}`.
+`PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS`, also defined in `igc/ds/rest_goal_contract.py`, reserves:
+`phase3_argument_extract/train/{loss,perplexity,optimizer_step}`,
+`phase3_argument_extract/eval/{loss,perplexity,token_accuracy,call_ordered_exact_match_rate}`,
+`phase3_argument_extract/eval/{call_order_correct_rate,step_exact_match_rate,rest_api_exact_match_rate}`,
+`phase3_argument_extract/eval/{allowed_methods_exact_match_rate,method_exact_match_rate}`,
+`phase3_argument_extract/eval/{arguments_json_parse_rate,arguments_exact_match_rate,invalid_method_rate}`,
+`phase3_argument_extract/eval/{readonly_empty_arguments_rate}`,
+`phase3_argument_extract/order/{kendall_tau,edit_distance}`,
+`phase3_argument_extract/throughput/{train_tokens_per_sec,train_samples_per_sec}`,
+`phase3_argument_extract/throughput/{eval_tokens_per_sec,eval_samples_per_sec}`,
+`phase3_argument_extract/data/{avg_num_calls,avg_arguments_length,mean_sequence_length,padding_ratio}`,
+`phase3_argument_extract/calibration/{log_prob_per_call,ece_method}`, and
+`phase3_argument_extract/test/{latency_sec_p50,latency_sec_p95,memory_peak_mb}`.
+
 To use TensorBoard instead, choose the variable for the launcher you are using:
 `IGC_METRIC_REPORT=tensorboard bash scripts/run_profile.sh` for the profile wrapper, or
 `IGC_REPORT=tensorboard sbatch scripts/train_m1.sbatch` for the sbatch smoke path.

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -80,29 +80,18 @@ Current M1 state-encoder runs log `train/loss`, `train/lr`, `train/grad_norm`, `
 planned instrumentation unless a later change adds those exact metric keys.
 
 Phase 2/3 mock-plumbing metric names are constants only; no live W&B run is part of that lane.
-`PHASE2_GOAL_EXTRACT_METRIC_KEYS`, defined in `igc/ds/rest_goal_contract.py`, reserves:
+`PHASE2_GOAL_EXTRACT_METRIC_KEYS`, re-exported by `igc/ds/rest_goal_contract.py` from the shared
+`PHASE2_WANDB_METRIC_KEYS` registry in `igc/modules/base/metric_keys.py`, currently reserves:
 `phase2_goal_extract/train/{loss,perplexity,optimizer_step}`,
-`phase2_goal_extract/eval/{loss,perplexity,token_accuracy,ordered_exact_match_rate,set_match_rate}`,
-`phase2_goal_extract/eval/{precision,recall,f1,top_k_api_accuracy,invalid_api_rate}`,
-`phase2_goal_extract/eval/{missing_required_api_rate,missing_allowed_methods_rate,order_violation_rate}`,
-`phase2_goal_extract/order/{kendall_tau,edit_distance}`,
-`phase2_goal_extract/throughput/{train_tokens_per_sec,train_samples_per_sec,eval_tokens_per_sec,eval_samples_per_sec}`,
-`phase2_goal_extract/data/{avg_num_apis,max_num_apis,mean_sequence_length,padding_ratio}`,
-`phase2_goal_extract/calibration/{log_prob_per_sequence,ece}`, and
-`phase2_goal_extract/test/{latency_sec_p50,latency_sec_p95,memory_peak_mb}`.
-`PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS`, also defined in `igc/ds/rest_goal_contract.py`, reserves:
+`phase2_goal_extract/eval/{ordered_exact_match_rate,set_match_rate,precision,recall,f1,`
+`missing_allowed_methods_rate}`,
+and `phase2_goal_extract/order/{kendall_tau,edit_distance}`.
+`PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS`, re-exported by `igc/ds/rest_goal_contract.py` from the shared
+`PHASE3_WANDB_METRIC_KEYS` registry in `igc/modules/base/metric_keys.py`, currently reserves:
 `phase3_argument_extract/train/{loss,perplexity,optimizer_step}`,
-`phase3_argument_extract/eval/{loss,perplexity,token_accuracy,call_ordered_exact_match_rate}`,
-`phase3_argument_extract/eval/{call_order_correct_rate,step_exact_match_rate,rest_api_exact_match_rate}`,
-`phase3_argument_extract/eval/{allowed_methods_exact_match_rate,method_exact_match_rate}`,
-`phase3_argument_extract/eval/{arguments_json_parse_rate,arguments_exact_match_rate,invalid_method_rate}`,
-`phase3_argument_extract/eval/{readonly_empty_arguments_rate}`,
-`phase3_argument_extract/order/{kendall_tau,edit_distance}`,
-`phase3_argument_extract/throughput/{train_tokens_per_sec,train_samples_per_sec}`,
-`phase3_argument_extract/throughput/{eval_tokens_per_sec,eval_samples_per_sec}`,
-`phase3_argument_extract/data/{avg_num_calls,avg_arguments_length,mean_sequence_length,padding_ratio}`,
-`phase3_argument_extract/calibration/{log_prob_per_call,ece_method}`, and
-`phase3_argument_extract/test/{latency_sec_p50,latency_sec_p95,memory_peak_mb}`.
+`phase3_argument_extract/eval/{call_ordered_exact_match_rate,method_exact_match_rate,`
+`arguments_exact_match_rate,readonly_empty_arguments_rate}`,
+and `phase3_argument_extract/order/{kendall_tau,edit_distance}`.
 
 To use TensorBoard instead, choose the variable for the launcher you are using:
 `IGC_METRIC_REPORT=tensorboard bash scripts/run_profile.sh` for the profile wrapper, or

--- a/docs/TRAINING.md
+++ b/docs/TRAINING.md
@@ -92,6 +92,30 @@ and `phase2_goal_extract/order/{kendall_tau,edit_distance}`.
 `phase3_argument_extract/eval/{call_ordered_exact_match_rate,method_exact_match_rate,`
 `arguments_exact_match_rate,readonly_empty_arguments_rate}`,
 and `phase3_argument_extract/order/{kendall_tau,edit_distance}`.
+Exact reserved keys:
+
+```text
+phase2_goal_extract/train/loss
+phase2_goal_extract/train/perplexity
+phase2_goal_extract/train/optimizer_step
+phase2_goal_extract/eval/ordered_exact_match_rate
+phase2_goal_extract/eval/set_match_rate
+phase2_goal_extract/eval/precision
+phase2_goal_extract/eval/recall
+phase2_goal_extract/eval/f1
+phase2_goal_extract/eval/missing_allowed_methods_rate
+phase2_goal_extract/order/kendall_tau
+phase2_goal_extract/order/edit_distance
+phase3_argument_extract/train/loss
+phase3_argument_extract/train/perplexity
+phase3_argument_extract/train/optimizer_step
+phase3_argument_extract/eval/call_ordered_exact_match_rate
+phase3_argument_extract/eval/method_exact_match_rate
+phase3_argument_extract/eval/arguments_exact_match_rate
+phase3_argument_extract/eval/readonly_empty_arguments_rate
+phase3_argument_extract/order/kendall_tau
+phase3_argument_extract/order/edit_distance
+```
 
 To use TensorBoard instead, choose the variable for the launcher you are using:
 `IGC_METRIC_REPORT=tensorboard bash scripts/run_profile.sh` for the profile wrapper, or

--- a/igc/ds/rest_goal_contract.py
+++ b/igc/ds/rest_goal_contract.py
@@ -1,0 +1,381 @@
+"""REST-goal dataset contracts for ordered language-model targets.
+
+Used by tests and future dataset builders as the narrow mock-plumbing seam for
+the Phase 2/3 Redfish instruction contracts: text/context to ordered REST APIs,
+then text/API list/context to ordered calls. This module owns row shape,
+canonical prompt/target rendering, and metric-key names; it does not train,
+decode, crawl, or infer labels from text.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+
+MODEL_X = "model_x"
+D0 = "D0"
+D1 = "D1"
+
+PHASE2_GOAL_EXTRACT_METRIC_KEYS = (
+    "phase2_goal_extract/train/loss",
+    "phase2_goal_extract/train/perplexity",
+    "phase2_goal_extract/train/optimizer_step",
+    "phase2_goal_extract/eval/loss",
+    "phase2_goal_extract/eval/perplexity",
+    "phase2_goal_extract/eval/token_accuracy",
+    "phase2_goal_extract/eval/ordered_exact_match_rate",
+    "phase2_goal_extract/eval/set_match_rate",
+    "phase2_goal_extract/eval/precision",
+    "phase2_goal_extract/eval/recall",
+    "phase2_goal_extract/eval/f1",
+    "phase2_goal_extract/eval/top_k_api_accuracy",
+    "phase2_goal_extract/eval/invalid_api_rate",
+    "phase2_goal_extract/eval/missing_required_api_rate",
+    "phase2_goal_extract/eval/missing_allowed_methods_rate",
+    "phase2_goal_extract/eval/order_violation_rate",
+    "phase2_goal_extract/order/kendall_tau",
+    "phase2_goal_extract/order/edit_distance",
+    "phase2_goal_extract/throughput/train_tokens_per_sec",
+    "phase2_goal_extract/throughput/train_samples_per_sec",
+    "phase2_goal_extract/throughput/eval_tokens_per_sec",
+    "phase2_goal_extract/throughput/eval_samples_per_sec",
+    "phase2_goal_extract/data/avg_num_apis",
+    "phase2_goal_extract/data/max_num_apis",
+    "phase2_goal_extract/data/mean_sequence_length",
+    "phase2_goal_extract/data/padding_ratio",
+    "phase2_goal_extract/calibration/log_prob_per_sequence",
+    "phase2_goal_extract/calibration/ece",
+    "phase2_goal_extract/test/latency_sec_p50",
+    "phase2_goal_extract/test/latency_sec_p95",
+    "phase2_goal_extract/test/memory_peak_mb",
+)
+
+PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS = (
+    "phase3_argument_extract/train/loss",
+    "phase3_argument_extract/train/perplexity",
+    "phase3_argument_extract/train/optimizer_step",
+    "phase3_argument_extract/eval/loss",
+    "phase3_argument_extract/eval/perplexity",
+    "phase3_argument_extract/eval/token_accuracy",
+    "phase3_argument_extract/eval/call_ordered_exact_match_rate",
+    "phase3_argument_extract/eval/call_order_correct_rate",
+    "phase3_argument_extract/eval/step_exact_match_rate",
+    "phase3_argument_extract/eval/rest_api_exact_match_rate",
+    "phase3_argument_extract/eval/allowed_methods_exact_match_rate",
+    "phase3_argument_extract/eval/method_exact_match_rate",
+    "phase3_argument_extract/eval/arguments_json_parse_rate",
+    "phase3_argument_extract/eval/arguments_exact_match_rate",
+    "phase3_argument_extract/eval/invalid_method_rate",
+    "phase3_argument_extract/eval/readonly_empty_arguments_rate",
+    "phase3_argument_extract/order/kendall_tau",
+    "phase3_argument_extract/order/edit_distance",
+    "phase3_argument_extract/throughput/train_tokens_per_sec",
+    "phase3_argument_extract/throughput/train_samples_per_sec",
+    "phase3_argument_extract/throughput/eval_tokens_per_sec",
+    "phase3_argument_extract/throughput/eval_samples_per_sec",
+    "phase3_argument_extract/data/avg_num_calls",
+    "phase3_argument_extract/data/avg_arguments_length",
+    "phase3_argument_extract/data/mean_sequence_length",
+    "phase3_argument_extract/data/padding_ratio",
+    "phase3_argument_extract/calibration/log_prob_per_call",
+    "phase3_argument_extract/calibration/ece_method",
+    "phase3_argument_extract/test/latency_sec_p50",
+    "phase3_argument_extract/test/latency_sec_p95",
+    "phase3_argument_extract/test/memory_peak_mb",
+)
+
+
+@dataclass(frozen=True)
+class RedfishContext:
+    """Current Redfish resource/method context for one REST API.
+
+    :param rest_api: concrete Redfish URI supplied by the current discovery context.
+    :param allowed_methods: HTTP methods legal for ``rest_api`` from the same method map.
+    :param json: full Redfish JSON resource body observed for ``rest_api``.
+    """
+
+    rest_api: str  # Concrete Redfish URI used as a legal REST target.
+    allowed_methods: Sequence[str]  # HTTP methods legal on this URI in the current context.
+    json: Mapping[str, Any]  # Full Redfish JSON body paired with this URI.
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to the locked field names used by the Phase 2/3 rows."""
+        return {
+            "rest_api": self.rest_api,                 # One concrete Redfish URI.
+            "allowed_methods": list(self.allowed_methods),  # Legal methods for this URI.
+            "json": dict(self.json),                   # Resource body supplied as context.
+        }
+
+
+@dataclass(frozen=True)
+class RenderedContractExample:
+    """Prompt/target split for causal-LM fine-tuning examples.
+
+    :param prompt: rendered ``x`` context, excluding the target completion.
+    :param target_json: canonical JSON string rendered from ``y_true``.
+    :param target_char_start: character offset where ``y_true`` begins in ``full_text``.
+    """
+
+    prompt: str  # Rendered input context only.
+    target_json: str  # Canonical serialized target completion.
+    target_char_start: int  # Boundary used by tokenizers to mask prompt tokens later.
+
+    @property
+    def full_text(self) -> str:
+        """Return the text shown to a causal LM before tokenization."""
+        return self.prompt + self.target_json
+
+
+def _canonical_json(value: Mapping[str, Any] | Sequence[Any]) -> str:
+    """Render deterministic JSON for training labels and golden tests."""
+    return json.dumps(value, indent=2, sort_keys=True)
+
+
+def _contexts_by_api(contexts: Sequence[RedfishContext]) -> dict[str, RedfishContext]:
+    """Index contexts by ``rest_api`` and reject ambiguous duplicates."""
+    by_api: dict[str, RedfishContext] = {}
+    for context in contexts:
+        if context.rest_api in by_api:
+            raise ValueError(f"duplicate rest_api in context: {context.rest_api}")
+        by_api[context.rest_api] = context
+    return by_api
+
+
+def _require_context(rest_api_list: Sequence[str], by_api: Mapping[str, RedfishContext]) -> None:
+    """Reject labels that name APIs absent from the current context."""
+    missing = [rest_api for rest_api in rest_api_list if rest_api not in by_api]
+    if missing:
+        raise ValueError(f"rest_api not present in current context: {missing}")
+
+
+def _allowed_methods_map(contexts: Sequence[RedfishContext]) -> dict[str, list[str]]:
+    """Build the locked ``allowed_methods`` map from current context rows."""
+    return {
+        context.rest_api: [method.upper() for method in context.allowed_methods]
+        for context in contexts
+    }
+
+
+def build_d1_rest_api_list_row(
+    *,
+    text: str,
+    contexts: Sequence[RedfishContext],
+    rest_api_list: Sequence[str],
+    order_evidence: str = "explicit_then",
+) -> dict[str, Any]:
+    """Build one mock ``D1`` row for text-to-ordered-REST-API training.
+
+    :param text: operator sentence.
+    :param contexts: current Redfish JSON/method context.
+    :param rest_api_list: target REST APIs in operator-stated order.
+    :param order_evidence: label describing why order should be evaluated strictly.
+    :return: JSON-compatible Phase 2 row with locked field names.
+    """
+    by_api = _contexts_by_api(contexts)
+    _require_context(rest_api_list, by_api)
+    return {
+        "phase": 2,                         # Phase 2: text -> ordered rest_api_list.
+        "dataset": D1,                      # D1 is the accepted Phase 2 dataset name.
+        "source_dataset": D0,               # D0 is the Phase 1 JSON reconstruction source.
+        "model_x": MODEL_X,                 # model_x creates/reviews D1 after Phase 1.
+        "task": "text_to_ordered_rest_api_list",  # Contract name from the phase workflow.
+        "x": {
+            "text": text,                   # Operator sentence shown to the model.
+            "json": [dict(context.json) for context in contexts],  # Current resource bodies.
+            "allowed_methods": _allowed_methods_map(contexts),  # Method legality context.
+        },
+        "y_true": {
+            "rest_api_list": list(rest_api_list),  # Ordered API label, never sorted.
+            "order_evidence": order_evidence,     # Whether strict order evidence is explicit.
+        },
+        "validation": {
+            "text_source": "mock_fixture",         # Tiny offline fixture, not real D1 generation.
+            "review_judged": False,                # Real review waits for model_x checkpoint.
+            "all_rest_api_present": True,          # All labels are present in current context.
+            "extra_rest_api_present": False,       # The mock row carries only requested APIs.
+            "order_preserved": True,               # The label keeps the caller-provided order.
+        },
+    }
+
+
+def _default_method(allowed_methods: Sequence[str]) -> str:
+    """Pick the safe default method from the context method set."""
+    normalized = [method.upper() for method in allowed_methods]
+    if "GET" in normalized:
+        return "GET"
+    if normalized:
+        return normalized[0]
+    return "GET"
+
+
+def build_ordered_call_row(
+    *,
+    text: str,
+    contexts: Sequence[RedfishContext],
+    rest_api_list: Sequence[str],
+    method_by_api: Mapping[str, str] | None = None,
+    arguments_by_api: Mapping[str, Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build one mock Phase 3 row for ordered method/argument extraction.
+
+    :param text: operator sentence.
+    :param contexts: current Redfish JSON/method context.
+    :param rest_api_list: ordered REST APIs emitted by Phase 2.
+    :param method_by_api: optional explicit method labels by API.
+    :param arguments_by_api: optional explicit argument labels by API.
+    :return: JSON-compatible Phase 3 row with ordered calls.
+    """
+    method_by_api = method_by_api or {}
+    arguments_by_api = arguments_by_api or {}
+    by_api = _contexts_by_api(contexts)
+    _require_context(rest_api_list, by_api)
+
+    calls: list[dict[str, Any]] = []
+    for rest_api in rest_api_list:
+        context = by_api[rest_api]
+        allowed_methods = [method.upper() for method in context.allowed_methods]
+        method = method_by_api.get(rest_api, _default_method(allowed_methods)).upper()
+        if method not in allowed_methods:
+            raise ValueError(f"method {method} is not in allowed_methods for {rest_api}")
+        explicit_arguments = dict(arguments_by_api.get(rest_api) or {})
+        arguments = {} if method in ("GET", "HEAD") else explicit_arguments
+        calls.append({
+            "rest_api": rest_api,             # Ordered REST API copied from rest_api_list.
+            "allowed_methods": allowed_methods,  # Legal methods for this API.
+            "method": method,                 # Selected method label for the call.
+            "arguments": arguments,           # Explicit body/action args; never inferred.
+        })
+
+    return {
+        "phase": 3,                           # Phase 3: ordered APIs -> ordered calls.
+        "source_dataset": D1,                 # Phase 3 starts from accepted D1 rows.
+        "model_x": MODEL_X,                   # model_x is the Phase 1 checkpoint lineage.
+        "task": "text_and_rest_api_list_to_calls",  # Contract name from the workflow.
+        "x": {
+            "text": text,                     # Operator sentence shown to Phase 3.
+            "rest_api_list": list(rest_api_list),  # Ordered API input from Phase 2.
+            "json": [dict(context.json) for context in contexts],  # Current resource bodies.
+            "allowed_methods": _allowed_methods_map(contexts),  # Method legality context.
+        },
+        "y_true": {
+            "calls": calls,                   # Ordered call labels with methods and args.
+        },
+    }
+
+
+def render_rest_api_list_example(row: Mapping[str, Any]) -> RenderedContractExample:
+    """Render a Phase 2 row into prompt and target JSON text.
+
+    :param row: row from :func:`build_d1_rest_api_list_row`.
+    :return: rendered prompt/target split.
+    """
+    x = row["x"]
+    target = {"rest_api_list": list(row["y_true"]["rest_api_list"])}
+    prompt = (
+        "### Operator Text\n"
+        f"{x['text']}\n\n"
+        "### Current Redfish JSON\n"
+        f"{_canonical_json(x['json'])}\n\n"
+        "### Allowed Methods\n"
+        f"{_canonical_json(x['allowed_methods'])}\n\n"
+        "### Ordered REST API List\n"
+    )
+    return RenderedContractExample(
+        prompt=prompt,
+        target_json=_canonical_json(target),
+        target_char_start=len(prompt),
+    )
+
+
+def render_ordered_call_example(row: Mapping[str, Any]) -> RenderedContractExample:
+    """Render a Phase 3 row into prompt and target JSON text.
+
+    :param row: row from :func:`build_ordered_call_row`.
+    :return: rendered prompt/target split.
+    """
+    x = row["x"]
+    target = {"calls": list(row["y_true"]["calls"])}
+    prompt = (
+        "### Operator Text\n"
+        f"{x['text']}\n\n"
+        "### Ordered REST API List\n"
+        f"{_canonical_json(x['rest_api_list'])}\n\n"
+        "### Current Redfish JSON\n"
+        f"{_canonical_json(x['json'])}\n\n"
+        "### Allowed Methods\n"
+        f"{_canonical_json(x['allowed_methods'])}\n\n"
+        "### Ordered REST Calls\n"
+    )
+    return RenderedContractExample(
+        prompt=prompt,
+        target_json=_canonical_json(target),
+        target_char_start=len(prompt),
+    )
+
+
+def parse_rest_api_list_y_pred(y_pred: Mapping[str, Any] | str) -> list[str]:
+    """Parse Phase 2 model output into an ordered ``rest_api_list``.
+
+    :param y_pred: model output as a mapping or JSON string.
+    :return: ordered REST API list.
+    """
+    if isinstance(y_pred, str):
+        y_pred = json.loads(y_pred)
+    value = y_pred.get("y_pred", y_pred)
+    rest_api_list = value.get("rest_api_list")
+    if not isinstance(rest_api_list, list):
+        raise ValueError("y_pred.rest_api_list must be a list")
+    return [str(rest_api) for rest_api in rest_api_list]
+
+
+def parse_ordered_calls_y_pred(y_pred: Mapping[str, Any] | str) -> list[dict[str, Any]]:
+    """Parse Phase 3 model output into ordered call dictionaries.
+
+    :param y_pred: model output as a mapping or JSON string.
+    :return: ordered calls with ``rest_api``, ``allowed_methods``, ``method``, and ``arguments``.
+    """
+    if isinstance(y_pred, str):
+        y_pred = json.loads(y_pred)
+    value = y_pred.get("y_pred", y_pred)
+    calls = value.get("calls")
+    if not isinstance(calls, list):
+        raise ValueError("y_pred.calls must be a list")
+    parsed: list[dict[str, Any]] = []
+    for call in calls:
+        if not isinstance(call, Mapping):
+            raise ValueError("each y_pred.calls item must be an object")
+        missing = [
+            field
+            for field in ("rest_api", "allowed_methods", "method", "arguments")
+            if field not in call
+        ]
+        if missing:
+            raise ValueError(f"y_pred.calls item missing required field(s): {missing}")
+        if not isinstance(call["allowed_methods"], list):
+            raise ValueError("y_pred.calls.allowed_methods must be a list")
+        parsed.append({
+            "rest_api": str(call["rest_api"]),
+            "allowed_methods": [str(method).upper() for method in call["allowed_methods"]],
+            "method": str(call["method"]).upper(),
+            "arguments": dict(call.get("arguments") or {}),
+        })
+    return parsed
+
+
+def inference_ordered_goals_json(row: Mapping[str, Any]) -> dict[str, Any]:
+    """Build the combined inference JSON handoff from a Phase 3 row.
+
+    :param row: row from :func:`build_ordered_call_row`.
+    :return: ``{"text": ..., "ordered_goals": [...]}``.
+    """
+    return {
+        "text": str(row["x"]["text"]),        # Operator sentence tied to the call sequence.
+        "ordered_goals": list(row["y_true"]["calls"]),  # Ordered calls for the RL handoff.
+    }
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/igc/ds/rest_goal_contract.py
+++ b/igc/ds/rest_goal_contract.py
@@ -3,8 +3,8 @@
 Used by tests and future dataset builders as the narrow mock-plumbing seam for
 the Phase 2/3 Redfish instruction contracts: text/context to ordered REST APIs,
 then text/API list/context to ordered calls. This module owns row shape,
-canonical prompt/target rendering, and metric-key names; it does not train,
-decode, crawl, or infer labels from text.
+canonical prompt/target rendering, and re-exports shared metric-key names; it
+does not train, decode, crawl, or infer labels from text.
 
 Author:
 Mus mbayramo@stanford.edu
@@ -15,78 +15,18 @@ import json
 from dataclasses import dataclass
 from typing import Any, Mapping, Sequence
 
+from igc.modules.base.metric_keys import (
+    PHASE2_WANDB_METRIC_KEYS,
+    PHASE3_WANDB_METRIC_KEYS,
+)
+
 
 MODEL_X = "model_x"
 D0 = "D0"
 D1 = "D1"
 
-PHASE2_GOAL_EXTRACT_METRIC_KEYS = (
-    "phase2_goal_extract/train/loss",
-    "phase2_goal_extract/train/perplexity",
-    "phase2_goal_extract/train/optimizer_step",
-    "phase2_goal_extract/eval/loss",
-    "phase2_goal_extract/eval/perplexity",
-    "phase2_goal_extract/eval/token_accuracy",
-    "phase2_goal_extract/eval/ordered_exact_match_rate",
-    "phase2_goal_extract/eval/set_match_rate",
-    "phase2_goal_extract/eval/precision",
-    "phase2_goal_extract/eval/recall",
-    "phase2_goal_extract/eval/f1",
-    "phase2_goal_extract/eval/top_k_api_accuracy",
-    "phase2_goal_extract/eval/invalid_api_rate",
-    "phase2_goal_extract/eval/missing_required_api_rate",
-    "phase2_goal_extract/eval/missing_allowed_methods_rate",
-    "phase2_goal_extract/eval/order_violation_rate",
-    "phase2_goal_extract/order/kendall_tau",
-    "phase2_goal_extract/order/edit_distance",
-    "phase2_goal_extract/throughput/train_tokens_per_sec",
-    "phase2_goal_extract/throughput/train_samples_per_sec",
-    "phase2_goal_extract/throughput/eval_tokens_per_sec",
-    "phase2_goal_extract/throughput/eval_samples_per_sec",
-    "phase2_goal_extract/data/avg_num_apis",
-    "phase2_goal_extract/data/max_num_apis",
-    "phase2_goal_extract/data/mean_sequence_length",
-    "phase2_goal_extract/data/padding_ratio",
-    "phase2_goal_extract/calibration/log_prob_per_sequence",
-    "phase2_goal_extract/calibration/ece",
-    "phase2_goal_extract/test/latency_sec_p50",
-    "phase2_goal_extract/test/latency_sec_p95",
-    "phase2_goal_extract/test/memory_peak_mb",
-)
-
-PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS = (
-    "phase3_argument_extract/train/loss",
-    "phase3_argument_extract/train/perplexity",
-    "phase3_argument_extract/train/optimizer_step",
-    "phase3_argument_extract/eval/loss",
-    "phase3_argument_extract/eval/perplexity",
-    "phase3_argument_extract/eval/token_accuracy",
-    "phase3_argument_extract/eval/call_ordered_exact_match_rate",
-    "phase3_argument_extract/eval/call_order_correct_rate",
-    "phase3_argument_extract/eval/step_exact_match_rate",
-    "phase3_argument_extract/eval/rest_api_exact_match_rate",
-    "phase3_argument_extract/eval/allowed_methods_exact_match_rate",
-    "phase3_argument_extract/eval/method_exact_match_rate",
-    "phase3_argument_extract/eval/arguments_json_parse_rate",
-    "phase3_argument_extract/eval/arguments_exact_match_rate",
-    "phase3_argument_extract/eval/invalid_method_rate",
-    "phase3_argument_extract/eval/readonly_empty_arguments_rate",
-    "phase3_argument_extract/order/kendall_tau",
-    "phase3_argument_extract/order/edit_distance",
-    "phase3_argument_extract/throughput/train_tokens_per_sec",
-    "phase3_argument_extract/throughput/train_samples_per_sec",
-    "phase3_argument_extract/throughput/eval_tokens_per_sec",
-    "phase3_argument_extract/throughput/eval_samples_per_sec",
-    "phase3_argument_extract/data/avg_num_calls",
-    "phase3_argument_extract/data/avg_arguments_length",
-    "phase3_argument_extract/data/mean_sequence_length",
-    "phase3_argument_extract/data/padding_ratio",
-    "phase3_argument_extract/calibration/log_prob_per_call",
-    "phase3_argument_extract/calibration/ece_method",
-    "phase3_argument_extract/test/latency_sec_p50",
-    "phase3_argument_extract/test/latency_sec_p95",
-    "phase3_argument_extract/test/memory_peak_mb",
-)
+PHASE2_GOAL_EXTRACT_METRIC_KEYS = PHASE2_WANDB_METRIC_KEYS
+PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS = PHASE3_WANDB_METRIC_KEYS
 
 
 @dataclass(frozen=True)

--- a/igc/ds/rest_goal_contract.py
+++ b/igc/ds/rest_goal_contract.py
@@ -314,11 +314,14 @@ def parse_ordered_calls_y_pred(y_pred: Mapping[str, Any] | str) -> list[dict[str
             )
         if not isinstance(call["arguments"], Mapping):
             raise ValueError("y_pred.calls.arguments must be an object")
+        arguments = dict(call["arguments"])
+        if method in ("GET", "HEAD") and arguments:
+            raise ValueError("read-only y_pred.calls.arguments must be empty")
         parsed.append({
             "rest_api": call["rest_api"],
             "allowed_methods": allowed_methods,
             "method": method,
-            "arguments": dict(call["arguments"]),
+            "arguments": arguments,
         })
     return parsed
 

--- a/igc/ds/rest_goal_contract.py
+++ b/igc/ds/rest_goal_contract.py
@@ -269,7 +269,9 @@ def parse_rest_api_list_y_pred(y_pred: Mapping[str, Any] | str) -> list[str]:
     rest_api_list = value.get("rest_api_list")
     if not isinstance(rest_api_list, list):
         raise ValueError("y_pred.rest_api_list must be a list")
-    return [str(rest_api) for rest_api in rest_api_list]
+    if not all(isinstance(rest_api, str) for rest_api in rest_api_list):
+        raise ValueError("each y_pred.rest_api_list item must be a string")
+    return list(rest_api_list)
 
 
 def parse_ordered_calls_y_pred(y_pred: Mapping[str, Any] | str) -> list[dict[str, Any]]:
@@ -295,10 +297,16 @@ def parse_ordered_calls_y_pred(y_pred: Mapping[str, Any] | str) -> list[dict[str
         ]
         if missing:
             raise ValueError(f"y_pred.calls item missing required field(s): {missing}")
+        if not isinstance(call["rest_api"], str):
+            raise ValueError("y_pred.calls.rest_api must be a string")
         if not isinstance(call["allowed_methods"], list):
             raise ValueError("y_pred.calls.allowed_methods must be a list")
-        allowed_methods = [str(method).upper() for method in call["allowed_methods"]]
-        method = str(call["method"]).upper()
+        if not all(isinstance(method, str) for method in call["allowed_methods"]):
+            raise ValueError("each y_pred.calls.allowed_methods item must be a string")
+        if not isinstance(call["method"], str):
+            raise ValueError("y_pred.calls.method must be a string")
+        allowed_methods = [method.upper() for method in call["allowed_methods"]]
+        method = call["method"].upper()
         if method not in allowed_methods:
             raise ValueError(
                 f"y_pred.calls.method {method} is not in allowed_methods "
@@ -307,7 +315,7 @@ def parse_ordered_calls_y_pred(y_pred: Mapping[str, Any] | str) -> list[dict[str
         if not isinstance(call["arguments"], Mapping):
             raise ValueError("y_pred.calls.arguments must be an object")
         parsed.append({
-            "rest_api": str(call["rest_api"]),
+            "rest_api": call["rest_api"],
             "allowed_methods": allowed_methods,
             "method": method,
             "arguments": dict(call["arguments"]),

--- a/igc/ds/rest_goal_contract.py
+++ b/igc/ds/rest_goal_contract.py
@@ -297,11 +297,20 @@ def parse_ordered_calls_y_pred(y_pred: Mapping[str, Any] | str) -> list[dict[str
             raise ValueError(f"y_pred.calls item missing required field(s): {missing}")
         if not isinstance(call["allowed_methods"], list):
             raise ValueError("y_pred.calls.allowed_methods must be a list")
+        allowed_methods = [str(method).upper() for method in call["allowed_methods"]]
+        method = str(call["method"]).upper()
+        if method not in allowed_methods:
+            raise ValueError(
+                f"y_pred.calls.method {method} is not in allowed_methods "
+                f"for {call['rest_api']}"
+            )
+        if not isinstance(call["arguments"], Mapping):
+            raise ValueError("y_pred.calls.arguments must be an object")
         parsed.append({
             "rest_api": str(call["rest_api"]),
-            "allowed_methods": [str(method).upper() for method in call["allowed_methods"]],
-            "method": str(call["method"]).upper(),
-            "arguments": dict(call.get("arguments") or {}),
+            "allowed_methods": allowed_methods,
+            "method": method,
+            "arguments": dict(call["arguments"]),
         })
     return parsed
 

--- a/igc/ds/rest_goal_contract.py
+++ b/igc/ds/rest_goal_contract.py
@@ -265,7 +265,11 @@ def parse_rest_api_list_y_pred(y_pred: Mapping[str, Any] | str) -> list[str]:
     """
     if isinstance(y_pred, str):
         y_pred = json.loads(y_pred)
+    if not isinstance(y_pred, Mapping):
+        raise ValueError("y_pred must be an object")
     value = y_pred.get("y_pred", y_pred)
+    if not isinstance(value, Mapping):
+        raise ValueError("y_pred.y_pred must be an object")
     rest_api_list = value.get("rest_api_list")
     if not isinstance(rest_api_list, list):
         raise ValueError("y_pred.rest_api_list must be a list")
@@ -282,7 +286,11 @@ def parse_ordered_calls_y_pred(y_pred: Mapping[str, Any] | str) -> list[dict[str
     """
     if isinstance(y_pred, str):
         y_pred = json.loads(y_pred)
+    if not isinstance(y_pred, Mapping):
+        raise ValueError("y_pred must be an object")
     value = y_pred.get("y_pred", y_pred)
+    if not isinstance(value, Mapping):
+        raise ValueError("y_pred.y_pred must be an object")
     calls = value.get("calls")
     if not isinstance(calls, list):
         raise ValueError("y_pred.calls must be a list")

--- a/igc/ds/rest_goal_contract.py
+++ b/igc/ds/rest_goal_contract.py
@@ -122,7 +122,7 @@ def build_d1_rest_api_list_row(
         "dataset": D1,                      # D1 is the accepted Phase 2 dataset name.
         "source_dataset": D0,               # D0 is the Phase 1 JSON reconstruction source.
         "model_x": MODEL_X,                 # model_x creates/reviews D1 after Phase 1.
-        "task": "text_to_ordered_rest_api_list",  # Contract name from the phase workflow.
+        "task": "text_to_rest_api_list",    # Contract name from the phase workflow.
         "x": {
             "text": text,                   # Operator sentence shown to the model.
             "json": [dict(context.json) for context in contexts],  # Current resource bodies.
@@ -326,15 +326,15 @@ def parse_ordered_calls_y_pred(y_pred: Mapping[str, Any] | str) -> list[dict[str
     return parsed
 
 
-def inference_ordered_goals_json(row: Mapping[str, Any]) -> dict[str, Any]:
+def inference_target_calls_json(row: Mapping[str, Any]) -> dict[str, Any]:
     """Build the combined inference JSON handoff from a Phase 3 row.
 
     :param row: row from :func:`build_ordered_call_row`.
-    :return: ``{"text": ..., "ordered_goals": [...]}``.
+    :return: ``{"text": ..., "target_calls": [...]}``.
     """
     return {
         "text": str(row["x"]["text"]),        # Operator sentence tied to the call sequence.
-        "ordered_goals": list(row["y_true"]["calls"]),  # Ordered calls for the RL handoff.
+        "target_calls": list(row["y_true"]["calls"]),  # Ordered calls for the RL handoff.
     }
 
 

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -122,13 +122,23 @@ def test_d1_row_does_not_leak_extra_context_into_target_list() -> None:
 
 def test_phase23_rows_pin_locked_field_names() -> None:
     """Phase 2/3 rows expose only the locked contract field names."""
+    body = {"@odata.id": "/redfish/v1/Systems", "Name": "Systems"}
     context = _context(
         "/redfish/v1/Systems",
         ("GET", "HEAD"),
-        {"@odata.id": "/redfish/v1/Systems", "Name": "Systems"},
+        body,
     )
 
-    assert set(context.to_dict()) == {"rest_api", "allowed_methods", "json"}
+    serialized = context.to_dict()
+
+    assert set(serialized) == {"rest_api", "allowed_methods", "json"}
+    assert serialized == {
+        "rest_api": "/redfish/v1/Systems",
+        "allowed_methods": ["GET", "HEAD"],
+        "json": {"@odata.id": "/redfish/v1/Systems", "Name": "Systems"},
+    }
+    assert serialized["allowed_methods"] is not context.allowed_methods
+    assert serialized["json"] is not body
 
     phase2 = build_d1_rest_api_list_row(
         text="list systems",
@@ -433,6 +443,28 @@ def test_phase3_default_method_prefers_get_over_mutating_methods() -> None:
     }
 
 
+def test_phase3_default_method_uses_first_non_get_method_when_needed() -> None:
+    """POST-only rows default to POST without synthesizing request arguments."""
+    reset = _context(
+        "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+        ("POST",),
+        {"@odata.id": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset"},
+    )
+
+    row = build_ordered_call_row(
+        text="reset the system",
+        contexts=(reset,),
+        rest_api_list=("/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",),
+    )
+
+    assert row["y_true"]["calls"][0] == {
+        "rest_api": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+        "allowed_methods": ["POST"],
+        "method": "POST",
+        "arguments": {},
+    }
+
+
 def test_phase3_mixed_calls_preserve_order_case_and_per_api_arguments() -> None:
     """Mixed read/write calls keep order, normalize methods, and isolate arguments."""
     virtual_media = _context(
@@ -500,6 +532,18 @@ def test_rows_reject_missing_and_duplicate_contexts() -> None:
 
     with pytest.raises(ValueError, match="not present"):
         build_d1_rest_api_list_row(
+            text="list chassis",
+            contexts=(context,),
+            rest_api_list=("/redfish/v1/Chassis",),
+        )
+    with pytest.raises(ValueError, match="duplicate rest_api"):
+        build_d1_rest_api_list_row(
+            text="list systems",
+            contexts=(context, context),
+            rest_api_list=("/redfish/v1/Systems",),
+        )
+    with pytest.raises(ValueError, match="not present"):
+        build_ordered_call_row(
             text="list chassis",
             contexts=(context,),
             rest_api_list=("/redfish/v1/Chassis",),
@@ -768,6 +812,9 @@ def test_y_pred_parsers_preserve_order_and_report_bad_contracts() -> None:
     assert parse_rest_api_list_y_pred({
         "y_pred": {"rest_api_list": ["/redfish/v1/B", "/redfish/v1/A"]},
     }) == ["/redfish/v1/B", "/redfish/v1/A"]
+    assert parse_rest_api_list_y_pred({
+        "rest_api_list": ["/redfish/v1/Systems", "/redfish/v1/Managers"],
+    }) == ["/redfish/v1/Systems", "/redfish/v1/Managers"]
     calls = [{
         "rest_api": "/redfish/v1/Systems",
         "allowed_methods": ["get", "head"],

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -641,6 +641,14 @@ def test_y_pred_parsers_preserve_order_and_report_bad_contracts() -> None:
         })
 
 
+def test_rest_api_list_parser_rejects_non_string_items() -> None:
+    """Phase 2 y_pred parsing rejects non-string REST API labels."""
+    with pytest.raises(ValueError, match="rest_api_list item"):
+        parse_rest_api_list_y_pred({
+            "y_pred": {"rest_api_list": ["/redfish/v1/Systems", 42]},
+        })
+
+
 def test_ordered_calls_parser_preserves_multiple_call_order() -> None:
     """Phase 3 y_pred parsing keeps the model-emitted call sequence intact."""
     calls = [
@@ -659,6 +667,37 @@ def test_ordered_calls_parser_preserves_multiple_call_order() -> None:
     ]
 
     assert parse_ordered_calls_y_pred({"calls": calls}) == calls
+
+
+def test_ordered_calls_parser_rejects_non_string_contract_fields() -> None:
+    """Phase 3 y_pred parsing rejects non-string REST API, method, and allowed methods."""
+    with pytest.raises(ValueError, match="rest_api"):
+        parse_ordered_calls_y_pred({
+            "calls": [{
+                "rest_api": 42,
+                "allowed_methods": ["GET"],
+                "method": "GET",
+                "arguments": {},
+            }],
+        })
+    with pytest.raises(ValueError, match="allowed_methods"):
+        parse_ordered_calls_y_pred({
+            "calls": [{
+                "rest_api": "/redfish/v1/Systems",
+                "allowed_methods": ["GET", 42],
+                "method": "GET",
+                "arguments": {},
+            }],
+        })
+    with pytest.raises(ValueError, match="method"):
+        parse_ordered_calls_y_pred({
+            "calls": [{
+                "rest_api": "/redfish/v1/Systems",
+                "allowed_methods": ["GET"],
+                "method": 42,
+                "arguments": {},
+            }],
+        })
 
 
 def test_ordered_calls_parser_rejects_invalid_method_and_arguments_shape() -> None:

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -39,6 +39,13 @@ def _context(rest_api: str, allowed_methods: tuple[str, ...], body: dict) -> Red
     return RedfishContext(rest_api=rest_api, allowed_methods=allowed_methods, json=body)
 
 
+def test_phase23_locked_name_constants_use_literal_contract_values() -> None:
+    """Locked Phase 2/3 names stay literal, not only internally self-consistent."""
+    assert MODEL_X == "model_x"
+    assert D0 == "D0"
+    assert D1 == "D1"
+
+
 def test_d1_row_preserves_operator_order_independent_of_context_order() -> None:
     """The label order follows the operator-stated order, not JSON context order."""
     systems = _context(

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -232,6 +232,33 @@ def test_phase3_mutation_arguments_must_be_supplied_explicitly() -> None:
     }
 
 
+def test_phase3_patch_does_not_infer_top_level_get_scalars() -> None:
+    """PATCH rows do not turn arbitrary top-level GET values into arguments."""
+    system = _context(
+        "/redfish/v1/Systems/1",
+        ("GET", "PATCH"),
+        {
+            "@odata.id": "/redfish/v1/Systems/1",
+            "PowerState": "On",
+            "Name": "System",
+        },
+    )
+
+    row = build_ordered_call_row(
+        text="set the system power state",
+        contexts=(system,),
+        rest_api_list=("/redfish/v1/Systems/1",),
+        method_by_api={"/redfish/v1/Systems/1": "PATCH"},
+    )
+
+    assert row["y_true"]["calls"][0] == {
+        "rest_api": "/redfish/v1/Systems/1",
+        "allowed_methods": ["GET", "PATCH"],
+        "method": "PATCH",
+        "arguments": {},
+    }
+
+
 def test_rows_reject_missing_and_duplicate_contexts() -> None:
     """Rows fail fast when labels cannot be resolved to one current context."""
     context = _context(

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -730,6 +730,39 @@ def test_inference_json_uses_target_calls_shape() -> None:
     }
 
 
+def test_inference_target_calls_json_preserves_mutation_arguments() -> None:
+    """The inference handoff keeps explicit non-GET arguments unchanged."""
+    context = _context(
+        "/redfish/v1/Systems/1/Bios/Settings",
+        ("GET", "PATCH"),
+        {
+            "@odata.id": "/redfish/v1/Systems/1/Bios/Settings",
+            "Attributes": {"BootMode": "LegacyBios"},
+        },
+    )
+    row = build_ordered_call_row(
+        text="set bios boot mode to Uefi",
+        contexts=(context,),
+        rest_api_list=("/redfish/v1/Systems/1/Bios/Settings",),
+        method_by_api={"/redfish/v1/Systems/1/Bios/Settings": "patch"},
+        arguments_by_api={
+            "/redfish/v1/Systems/1/Bios/Settings": {
+                "Attributes": {"BootMode": "Uefi"},
+            },
+        },
+    )
+
+    assert inference_target_calls_json(row) == {
+        "text": "set bios boot mode to Uefi",
+        "target_calls": [{
+            "rest_api": "/redfish/v1/Systems/1/Bios/Settings",
+            "allowed_methods": ["GET", "PATCH"],
+            "method": "PATCH",
+            "arguments": {"Attributes": {"BootMode": "Uefi"}},
+        }],
+    }
+
+
 def test_y_pred_parsers_preserve_order_and_report_bad_contracts() -> None:
     """Parsed y_pred JSON preserves order and rejects malformed call objects clearly."""
     assert parse_rest_api_list_y_pred({
@@ -774,6 +807,23 @@ def test_y_pred_parsers_preserve_order_and_report_bad_contracts() -> None:
                 "method": "GET",
             }],
         })
+
+
+def test_ordered_calls_parser_preserves_mutation_arguments_and_normalizes_method() -> None:
+    """Phase 3 y_pred parsing keeps PATCH arguments and normalizes method case."""
+    calls = [{
+        "rest_api": "/redfish/v1/Systems/1/Bios/Settings",
+        "allowed_methods": ["get", "patch"],
+        "method": "patch",
+        "arguments": {"Attributes": {"BootMode": "Uefi"}},
+    }]
+
+    assert parse_ordered_calls_y_pred({"y_pred": {"calls": calls}}) == [{
+        "rest_api": "/redfish/v1/Systems/1/Bios/Settings",
+        "allowed_methods": ["GET", "PATCH"],
+        "method": "PATCH",
+        "arguments": {"Attributes": {"BootMode": "Uefi"}},
+    }]
 
 
 def test_rest_api_list_parser_rejects_non_string_items() -> None:

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -722,6 +722,14 @@ def test_rest_api_list_parser_rejects_non_string_items() -> None:
         })
 
 
+def test_rest_api_list_parser_rejects_non_list_target() -> None:
+    """Phase 2 y_pred parsing rejects scalar REST API labels."""
+    with pytest.raises(ValueError, match="rest_api_list must be a list"):
+        parse_rest_api_list_y_pred({
+            "y_pred": {"rest_api_list": "/redfish/v1/Systems"},
+        })
+
+
 def test_rest_api_list_parser_rejects_non_object_top_level_json() -> None:
     """Phase 2 y_pred parsing rejects JSON that is not an object."""
     for y_pred in ('["/redfish/v1/Systems"]', '"not an object"'):
@@ -787,6 +795,27 @@ def test_ordered_calls_parser_rejects_non_string_contract_fields() -> None:
         })
 
 
+def test_ordered_calls_parser_rejects_non_list_calls_and_items() -> None:
+    """Phase 3 y_pred parsing rejects malformed calls containers and items."""
+    with pytest.raises(ValueError, match="calls must be a list"):
+        parse_ordered_calls_y_pred({"calls": "not a list"})
+    with pytest.raises(ValueError, match="calls item must be an object"):
+        parse_ordered_calls_y_pred({"calls": ["not an object"]})
+
+
+def test_ordered_calls_parser_rejects_non_list_allowed_methods() -> None:
+    """Phase 3 y_pred parsing rejects scalar allowed_methods values."""
+    with pytest.raises(ValueError, match="allowed_methods must be a list"):
+        parse_ordered_calls_y_pred({
+            "calls": [{
+                "rest_api": "/redfish/v1/Systems",
+                "allowed_methods": "GET",
+                "method": "GET",
+                "arguments": {},
+            }],
+        })
+
+
 def test_ordered_calls_parser_rejects_non_object_top_level_json() -> None:
     """Phase 3 y_pred parsing rejects JSON that is not an object."""
     for y_pred in ("[]", "42"):
@@ -839,12 +868,41 @@ def test_ordered_calls_parser_rejects_readonly_arguments() -> None:
 
 def test_wandb_metric_keys_are_stage_scoped_and_not_m3_names() -> None:
     """Phase 2/3 contract constants reuse the shared W&B metric registry."""
+    expected_phase2 = (
+        "phase2_goal_extract/train/loss",
+        "phase2_goal_extract/train/perplexity",
+        "phase2_goal_extract/train/optimizer_step",
+        "phase2_goal_extract/eval/ordered_exact_match_rate",
+        "phase2_goal_extract/eval/set_match_rate",
+        "phase2_goal_extract/eval/precision",
+        "phase2_goal_extract/eval/recall",
+        "phase2_goal_extract/eval/f1",
+        "phase2_goal_extract/eval/missing_allowed_methods_rate",
+        "phase2_goal_extract/order/kendall_tau",
+        "phase2_goal_extract/order/edit_distance",
+    )
+    expected_phase3 = (
+        "phase3_argument_extract/train/loss",
+        "phase3_argument_extract/train/perplexity",
+        "phase3_argument_extract/train/optimizer_step",
+        "phase3_argument_extract/eval/call_ordered_exact_match_rate",
+        "phase3_argument_extract/eval/method_exact_match_rate",
+        "phase3_argument_extract/eval/arguments_exact_match_rate",
+        "phase3_argument_extract/eval/readonly_empty_arguments_rate",
+        "phase3_argument_extract/order/kendall_tau",
+        "phase3_argument_extract/order/edit_distance",
+    )
+
     assert PHASE2_GOAL_EXTRACT_METRIC_KEYS == PHASE2_WANDB_METRIC_KEYS
     assert PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS == PHASE3_WANDB_METRIC_KEYS
+    assert PHASE2_GOAL_EXTRACT_METRIC_KEYS == expected_phase2
+    assert PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS == expected_phase3
     assert (
         PHASE2_GOAL_EXTRACT_METRIC_KEYS + PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS
         == PHASE23_WANDB_METRIC_KEYS
     )
+    assert len(PHASE2_GOAL_EXTRACT_METRIC_KEYS) == len(set(PHASE2_GOAL_EXTRACT_METRIC_KEYS))
+    assert len(PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS) == len(set(PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS))
     assert (
         "phase2_goal_extract/eval/ordered_exact_match_rate"
         in PHASE2_GOAL_EXTRACT_METRIC_KEYS
@@ -877,6 +935,10 @@ def test_training_docs_pin_phase23_metric_constants() -> None:
     assert "phase2_goal_extract/order/{kendall_tau,edit_distance}" in training_doc
     assert "phase3_argument_extract/eval/{call_ordered_exact_match_rate" in training_doc
     assert "phase3_argument_extract/order/{kendall_tau,edit_distance}" in training_doc
+    for metric_key in PHASE2_GOAL_EXTRACT_METRIC_KEYS:
+        assert metric_key in training_doc
+    for metric_key in PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS:
+        assert metric_key in training_doc
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -288,6 +288,34 @@ def test_phase3_patch_does_not_infer_top_level_get_scalars() -> None:
     }
 
 
+def test_phase3_post_does_not_infer_action_arguments_from_get_scalars() -> None:
+    """POST rows do not turn observed action metadata into arguments."""
+    action_target = _context(
+        "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+        ("POST",),
+        {
+            "@odata.id": "/redfish/v1/Systems/1",
+            "ResetType": "GracefulRestart",
+        },
+    )
+
+    row = build_ordered_call_row(
+        text="reset the system",
+        contexts=(action_target,),
+        rest_api_list=("/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",),
+        method_by_api={
+            "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset": "POST",
+        },
+    )
+
+    assert row["y_true"]["calls"][0] == {
+        "rest_api": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+        "allowed_methods": ["POST"],
+        "method": "POST",
+        "arguments": {},
+    }
+
+
 def test_rows_reject_missing_and_duplicate_contexts() -> None:
     """Rows fail fast when labels cannot be resolved to one current context."""
     context = _context(

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -62,6 +62,7 @@ def test_d1_row_preserves_operator_order_independent_of_context_order() -> None:
     assert row["dataset"] == D1
     assert row["source_dataset"] == D0
     assert row["model_x"] == MODEL_X
+    assert row["x"]["text"] == "check the task queue, then list the systems"
     assert row["x"]["json"] == [systems.json, tasks.json]
     assert row["y_true"]["rest_api_list"] == [
         "/redfish/v1/TaskService/Tasks",
@@ -184,6 +185,21 @@ def test_phase3_get_calls_preserve_order_and_keep_arguments_empty() -> None:
     )
 
     assert row["phase"] == 3
+    assert row["x"]["text"] == "check task state, then inspect system power"
+    assert row["x"]["json"] == [
+        {
+            "@odata.id": "/redfish/v1/Systems/1",
+            "PowerState": "On",
+        },
+        {
+            "@odata.id": "/redfish/v1/TaskService/Tasks",
+            "Members@odata.count": 0,
+        },
+    ]
+    assert row["x"]["allowed_methods"] == {
+        "/redfish/v1/Systems/1": ["GET", "HEAD"],
+        "/redfish/v1/TaskService/Tasks": ["GET", "HEAD"],
+    }
     assert row["x"]["rest_api_list"] == [
         "/redfish/v1/TaskService/Tasks",
         "/redfish/v1/Systems/1",
@@ -408,6 +424,63 @@ def test_phase3_default_method_prefers_get_over_mutating_methods() -> None:
         "method": "GET",
         "arguments": {},
     }
+
+
+def test_phase3_mixed_calls_preserve_order_case_and_per_api_arguments() -> None:
+    """Mixed read/write calls keep order, normalize methods, and isolate arguments."""
+    virtual_media = _context(
+        "/redfish/v1/Managers/1/VirtualMedia/CD",
+        ("get", "head"),
+        {
+            "@odata.id": "/redfish/v1/Managers/1/VirtualMedia/CD",
+            "Image": "old.iso",
+        },
+    )
+    bios_settings = _context(
+        "/redfish/v1/Systems/1/Bios/Settings",
+        ("get", "patch"),
+        {
+            "@odata.id": "/redfish/v1/Systems/1/Bios/Settings",
+            "Attributes": {"BootMode": "LegacyBios"},
+        },
+    )
+
+    row = build_ordered_call_row(
+        text="inspect virtual media, then set bios boot mode to Uefi",
+        contexts=(bios_settings, virtual_media),
+        rest_api_list=(
+            "/redfish/v1/Managers/1/VirtualMedia/CD",
+            "/redfish/v1/Systems/1/Bios/Settings",
+        ),
+        method_by_api={"/redfish/v1/Systems/1/Bios/Settings": "patch"},
+        arguments_by_api={
+            "/redfish/v1/Systems/1/Bios/Settings": {
+                "Attributes": {"BootMode": "Uefi"},
+            },
+            "/redfish/v1/Managers/1/VirtualMedia/CD": {"Image": "old.iso"},
+        },
+    )
+
+    assert row["x"]["text"] == "inspect virtual media, then set bios boot mode to Uefi"
+    assert row["x"]["json"] == [bios_settings.json, virtual_media.json]
+    assert row["x"]["allowed_methods"] == {
+        "/redfish/v1/Systems/1/Bios/Settings": ["GET", "PATCH"],
+        "/redfish/v1/Managers/1/VirtualMedia/CD": ["GET", "HEAD"],
+    }
+    assert row["y_true"]["calls"] == [
+        {
+            "rest_api": "/redfish/v1/Managers/1/VirtualMedia/CD",
+            "allowed_methods": ["GET", "HEAD"],
+            "method": "GET",
+            "arguments": {},
+        },
+        {
+            "rest_api": "/redfish/v1/Systems/1/Bios/Settings",
+            "allowed_methods": ["GET", "PATCH"],
+            "method": "PATCH",
+            "arguments": {"Attributes": {"BootMode": "Uefi"}},
+        },
+    ]
 
 
 def test_rows_reject_missing_and_duplicate_contexts() -> None:

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -359,6 +359,45 @@ def test_rendered_examples_have_prompt_target_boundary_and_canonical_json() -> N
     assert "### Ordered REST Calls" in rendered3.prompt
 
 
+def test_rendered_phase3_patch_example_keeps_explicit_arguments() -> None:
+    """Rendered Phase 3 labels preserve explicit non-GET arguments."""
+    context = _context(
+        "/redfish/v1/Systems/1/Bios/Settings",
+        ("GET", "PATCH"),
+        {
+            "@odata.id": "/redfish/v1/Systems/1/Bios/Settings",
+            "Attributes": {"BootMode": "Uefi"},
+        },
+    )
+    row = build_ordered_call_row(
+        text="set bios boot mode to Uefi",
+        contexts=(context,),
+        rest_api_list=("/redfish/v1/Systems/1/Bios/Settings",),
+        method_by_api={"/redfish/v1/Systems/1/Bios/Settings": "PATCH"},
+        arguments_by_api={
+            "/redfish/v1/Systems/1/Bios/Settings": {
+                "Attributes": {"BootMode": "Uefi"},
+            },
+        },
+    )
+
+    rendered = render_ordered_call_example(row)
+
+    assert rendered.target_char_start == len(rendered.prompt)
+    assert json.loads(rendered.target_json) == {
+        "calls": [{
+            "rest_api": "/redfish/v1/Systems/1/Bios/Settings",
+            "allowed_methods": ["GET", "PATCH"],
+            "method": "PATCH",
+            "arguments": {"Attributes": {"BootMode": "Uefi"}},
+        }],
+    }
+    assert '"PATCH"' in rendered.target_json
+    assert '"Attributes": {' in rendered.target_json
+    assert "### Ordered REST Calls" in rendered.prompt
+    assert "/redfish/v1/Systems/1/Bios/Settings" in rendered.prompt
+
+
 def test_inference_json_uses_ordered_goals_shape() -> None:
     """The combined inference handoff uses ordered_goals with Phase 3 call fields."""
     context = _context(

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -27,6 +27,11 @@ from igc.ds.rest_goal_contract import (
     render_ordered_call_example,
     render_rest_api_list_example,
 )
+from igc.modules.base.metric_keys import (
+    PHASE2_WANDB_METRIC_KEYS,
+    PHASE3_WANDB_METRIC_KEYS,
+    PHASE23_WANDB_METRIC_KEYS,
+)
 
 
 def _context(rest_api: str, allowed_methods: tuple[str, ...], body: dict) -> RedfishContext:
@@ -249,6 +254,30 @@ def test_rows_reject_missing_and_duplicate_contexts() -> None:
         )
 
 
+def test_empty_ordered_rows_are_supported_for_noop_context() -> None:
+    """Empty mock rows encode no selected REST goals without inventing context."""
+    phase2 = build_d1_rest_api_list_row(
+        text="nothing to do",
+        contexts=(),
+        rest_api_list=(),
+        order_evidence="empty_request",
+    )
+    phase3 = build_ordered_call_row(
+        text="nothing to do",
+        contexts=(),
+        rest_api_list=(),
+    )
+
+    assert phase2["x"]["json"] == []
+    assert phase2["x"]["allowed_methods"] == {}
+    assert phase2["y_true"]["rest_api_list"] == []
+    assert phase2["y_true"]["order_evidence"] == "empty_request"
+    assert phase3["x"]["rest_api_list"] == []
+    assert phase3["x"]["json"] == []
+    assert phase3["x"]["allowed_methods"] == {}
+    assert phase3["y_true"]["calls"] == []
+
+
 def test_phase3_rejects_methods_outside_allowed_methods() -> None:
     """The selected method must be present in allowed_methods, including empty sets."""
     read_only = _context(
@@ -377,6 +406,22 @@ def test_y_pred_parsers_preserve_order_and_report_bad_contracts() -> None:
                 }],
             },
         })
+    with pytest.raises(ValueError, match="method"):
+        parse_ordered_calls_y_pred({
+            "calls": [{
+                "rest_api": "/redfish/v1/Systems",
+                "allowed_methods": ["GET"],
+                "arguments": {},
+            }],
+        })
+    with pytest.raises(ValueError, match="arguments"):
+        parse_ordered_calls_y_pred({
+            "calls": [{
+                "rest_api": "/redfish/v1/Systems",
+                "allowed_methods": ["GET"],
+                "method": "GET",
+            }],
+        })
 
 
 def test_ordered_calls_parser_preserves_multiple_call_order() -> None:
@@ -400,11 +445,26 @@ def test_ordered_calls_parser_preserves_multiple_call_order() -> None:
 
 
 def test_wandb_metric_keys_are_stage_scoped_and_not_m3_names() -> None:
-    """Phase 2/3 metric constants use dedicated W&B namespaces."""
-    assert "phase2_goal_extract/eval/ordered_exact_match_rate" in PHASE2_GOAL_EXTRACT_METRIC_KEYS
+    """Phase 2/3 contract constants reuse the shared W&B metric registry."""
+    assert PHASE2_GOAL_EXTRACT_METRIC_KEYS == PHASE2_WANDB_METRIC_KEYS
+    assert PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS == PHASE3_WANDB_METRIC_KEYS
+    assert (
+        PHASE2_GOAL_EXTRACT_METRIC_KEYS + PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS
+        == PHASE23_WANDB_METRIC_KEYS
+    )
+    assert (
+        "phase2_goal_extract/eval/ordered_exact_match_rate"
+        in PHASE2_GOAL_EXTRACT_METRIC_KEYS
+    )
     assert "phase2_goal_extract/eval/set_match_rate" in PHASE2_GOAL_EXTRACT_METRIC_KEYS
-    assert "phase3_argument_extract/eval/readonly_empty_arguments_rate" in PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS
-    assert "phase3_argument_extract/eval/arguments_exact_match_rate" in PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS
+    assert (
+        "phase3_argument_extract/eval/readonly_empty_arguments_rate"
+        in PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS
+    )
+    assert (
+        "phase3_argument_extract/eval/arguments_exact_match_rate"
+        in PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS
+    )
     assert all(k.startswith("phase2_goal_extract/") for k in PHASE2_GOAL_EXTRACT_METRIC_KEYS)
     assert all(k.startswith("phase3_argument_extract/") for k in PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS)
     assert not any(k.startswith("m3_") for k in PHASE2_GOAL_EXTRACT_METRIC_KEYS)
@@ -418,10 +478,12 @@ def test_training_docs_pin_phase23_metric_constants() -> None:
 
     assert "PHASE2_GOAL_EXTRACT_METRIC_KEYS" in training_doc
     assert "PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS" in training_doc
-    assert "phase2_goal_extract/eval/{loss,perplexity,token_accuracy" in training_doc
-    assert "phase2_goal_extract/test/{latency_sec_p50,latency_sec_p95" in training_doc
-    assert "phase3_argument_extract/eval/{allowed_methods_exact_match_rate" in training_doc
-    assert "phase3_argument_extract/data/{avg_num_calls,avg_arguments_length" in training_doc
+    assert "PHASE2_WANDB_METRIC_KEYS" in training_doc
+    assert "PHASE3_WANDB_METRIC_KEYS" in training_doc
+    assert "phase2_goal_extract/eval/{ordered_exact_match_rate,set_match_rate" in training_doc
+    assert "phase2_goal_extract/order/{kendall_tau,edit_distance}" in training_doc
+    assert "phase3_argument_extract/eval/{call_ordered_exact_match_rate" in training_doc
+    assert "phase3_argument_extract/order/{kendall_tau,edit_distance}" in training_doc
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -1,0 +1,300 @@
+"""Offline tests for the ordered REST-goal dataset contracts.
+
+These tests pin the Phase 2/3 mock-plumbing rows without training a model,
+running W&B, touching captured corpora, or inventing a regex extractor.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import json
+
+import pytest
+
+from igc.ds.rest_goal_contract import (
+    D0,
+    D1,
+    MODEL_X,
+    PHASE2_GOAL_EXTRACT_METRIC_KEYS,
+    PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS,
+    RedfishContext,
+    build_d1_rest_api_list_row,
+    build_ordered_call_row,
+    inference_ordered_goals_json,
+    parse_ordered_calls_y_pred,
+    parse_rest_api_list_y_pred,
+    render_ordered_call_example,
+    render_rest_api_list_example,
+)
+
+
+def _context(rest_api: str, allowed_methods: tuple[str, ...], body: dict) -> RedfishContext:
+    """Build one tiny Redfish context row for contract tests."""
+    return RedfishContext(rest_api=rest_api, allowed_methods=allowed_methods, json=body)
+
+
+def test_d1_row_preserves_operator_order_independent_of_context_order() -> None:
+    """The label order follows the operator-stated order, not JSON context order."""
+    systems = _context(
+        "/redfish/v1/Systems",
+        ("GET", "HEAD"),
+        {"@odata.id": "/redfish/v1/Systems", "Name": "Systems"},
+    )
+    tasks = _context(
+        "/redfish/v1/TaskService/Tasks",
+        ("GET", "HEAD"),
+        {"@odata.id": "/redfish/v1/TaskService/Tasks", "Name": "Tasks"},
+    )
+
+    row = build_d1_rest_api_list_row(
+        text="check the task queue, then list the systems",
+        contexts=(systems, tasks),
+        rest_api_list=("/redfish/v1/TaskService/Tasks", "/redfish/v1/Systems"),
+    )
+
+    assert row["phase"] == 2
+    assert row["dataset"] == D1
+    assert row["source_dataset"] == D0
+    assert row["model_x"] == MODEL_X
+    assert row["x"]["json"] == [systems.json, tasks.json]
+    assert row["y_true"]["rest_api_list"] == [
+        "/redfish/v1/TaskService/Tasks",
+        "/redfish/v1/Systems",
+    ]
+    assert row["x"]["allowed_methods"] == {
+        "/redfish/v1/Systems": ["GET", "HEAD"],
+        "/redfish/v1/TaskService/Tasks": ["GET", "HEAD"],
+    }
+    assert row["validation"] == {
+        "text_source": "mock_fixture",
+        "review_judged": False,
+        "all_rest_api_present": True,
+        "extra_rest_api_present": False,
+        "order_preserved": True,
+    }
+
+
+def test_phase3_get_calls_preserve_order_and_keep_arguments_empty() -> None:
+    """Read-only GET calls keep ordered rest_api rows and never copy scalar JSON values."""
+    row = build_ordered_call_row(
+        text="check task state, then inspect system power",
+        contexts=(
+            _context(
+                "/redfish/v1/Systems/1",
+                ("GET", "HEAD"),
+                {
+                    "@odata.id": "/redfish/v1/Systems/1",
+                    "PowerState": "On",
+                },
+            ),
+            _context(
+                "/redfish/v1/TaskService/Tasks",
+                ("GET", "HEAD"),
+                {
+                    "@odata.id": "/redfish/v1/TaskService/Tasks",
+                    "Members@odata.count": 0,
+                },
+            ),
+        ),
+        rest_api_list=("/redfish/v1/TaskService/Tasks", "/redfish/v1/Systems/1"),
+    )
+
+    assert row["phase"] == 3
+    assert row["x"]["rest_api_list"] == [
+        "/redfish/v1/TaskService/Tasks",
+        "/redfish/v1/Systems/1",
+    ]
+    assert row["y_true"]["calls"] == [
+        {
+            "rest_api": "/redfish/v1/TaskService/Tasks",
+            "allowed_methods": ["GET", "HEAD"],
+            "method": "GET",
+            "arguments": {},
+        },
+        {
+            "rest_api": "/redfish/v1/Systems/1",
+            "allowed_methods": ["GET", "HEAD"],
+            "method": "GET",
+            "arguments": {},
+        },
+    ]
+
+
+def test_phase3_mutation_arguments_must_be_supplied_explicitly() -> None:
+    """PATCH rows do not infer arguments from arbitrary scalar values in GET JSON."""
+    settings = _context(
+        "/redfish/v1/Systems/1/Bios/Settings",
+        ("GET", "PATCH"),
+        {
+            "@odata.id": "/redfish/v1/Systems/1/Bios/Settings",
+            "Attributes": {"BootMode": "Uefi"},
+        },
+    )
+
+    without_arguments = build_ordered_call_row(
+        text="set bios boot mode",
+        contexts=(settings,),
+        rest_api_list=("/redfish/v1/Systems/1/Bios/Settings",),
+        method_by_api={"/redfish/v1/Systems/1/Bios/Settings": "PATCH"},
+    )
+    with_arguments = build_ordered_call_row(
+        text="set bios boot mode to Uefi",
+        contexts=(settings,),
+        rest_api_list=("/redfish/v1/Systems/1/Bios/Settings",),
+        method_by_api={"/redfish/v1/Systems/1/Bios/Settings": "PATCH"},
+        arguments_by_api={
+            "/redfish/v1/Systems/1/Bios/Settings": {
+                "Attributes": {"BootMode": "Uefi"},
+            },
+        },
+    )
+
+    assert without_arguments["y_true"]["calls"][0]["arguments"] == {}
+    assert with_arguments["y_true"]["calls"][0]["arguments"] == {
+        "Attributes": {"BootMode": "Uefi"},
+    }
+
+
+def test_rows_reject_missing_and_duplicate_contexts() -> None:
+    """Rows fail fast when labels cannot be resolved to one current context."""
+    context = _context(
+        "/redfish/v1/Systems",
+        ("GET", "HEAD"),
+        {"@odata.id": "/redfish/v1/Systems"},
+    )
+
+    with pytest.raises(ValueError, match="not present"):
+        build_d1_rest_api_list_row(
+            text="list chassis",
+            contexts=(context,),
+            rest_api_list=("/redfish/v1/Chassis",),
+        )
+    with pytest.raises(ValueError, match="duplicate rest_api"):
+        build_ordered_call_row(
+            text="list systems twice",
+            contexts=(context, context),
+            rest_api_list=("/redfish/v1/Systems",),
+        )
+
+
+def test_phase3_rejects_methods_outside_allowed_methods() -> None:
+    """The selected method must be present in allowed_methods, including empty sets."""
+    read_only = _context(
+        "/redfish/v1/Systems",
+        ("GET", "HEAD"),
+        {"@odata.id": "/redfish/v1/Systems"},
+    )
+    no_methods = _context(
+        "/redfish/v1/Managers",
+        (),
+        {"@odata.id": "/redfish/v1/Managers"},
+    )
+
+    with pytest.raises(ValueError, match="not in allowed_methods"):
+        build_ordered_call_row(
+            text="delete systems",
+            contexts=(read_only,),
+            rest_api_list=("/redfish/v1/Systems",),
+            method_by_api={"/redfish/v1/Systems": "DELETE"},
+        )
+    with pytest.raises(ValueError, match="not in allowed_methods"):
+        build_ordered_call_row(
+            text="list managers",
+            contexts=(no_methods,),
+            rest_api_list=("/redfish/v1/Managers",),
+        )
+
+
+def test_rendered_examples_have_prompt_target_boundary_and_canonical_json() -> None:
+    """Rendered rows separate x prompt from the y_true JSON completion."""
+    context = _context(
+        "/redfish/v1/Systems",
+        ("GET", "HEAD"),
+        {"@odata.id": "/redfish/v1/Systems"},
+    )
+    phase2 = build_d1_rest_api_list_row(
+        text="list systems",
+        contexts=(context,),
+        rest_api_list=("/redfish/v1/Systems",),
+    )
+    phase3 = build_ordered_call_row(
+        text="list systems",
+        contexts=(context,),
+        rest_api_list=("/redfish/v1/Systems",),
+    )
+
+    rendered2 = render_rest_api_list_example(phase2)
+    rendered3 = render_ordered_call_example(phase3)
+
+    assert rendered2.target_char_start == len(rendered2.prompt)
+    assert json.loads(rendered2.target_json) == {"rest_api_list": ["/redfish/v1/Systems"]}
+    assert "### Ordered REST API List" in rendered2.prompt
+    assert rendered2.full_text == rendered2.prompt + rendered2.target_json
+    assert json.loads(rendered3.target_json) == {
+        "calls": phase3["y_true"]["calls"],
+    }
+    assert "### Ordered REST Calls" in rendered3.prompt
+
+
+def test_inference_json_uses_ordered_goals_shape() -> None:
+    """The combined inference handoff uses ordered_goals with Phase 3 call fields."""
+    context = _context(
+        "/redfish/v1/TaskService/Tasks",
+        ("GET", "HEAD"),
+        {"@odata.id": "/redfish/v1/TaskService/Tasks"},
+    )
+    row = build_ordered_call_row(
+        text="check task queue",
+        contexts=(context,),
+        rest_api_list=("/redfish/v1/TaskService/Tasks",),
+    )
+
+    assert inference_ordered_goals_json(row) == {
+        "text": "check task queue",
+        "ordered_goals": row["y_true"]["calls"],
+    }
+
+
+def test_y_pred_parsers_preserve_order_and_report_bad_contracts() -> None:
+    """Parsed y_pred JSON preserves order and rejects malformed call objects clearly."""
+    assert parse_rest_api_list_y_pred({
+        "y_pred": {"rest_api_list": ["/redfish/v1/B", "/redfish/v1/A"]},
+    }) == ["/redfish/v1/B", "/redfish/v1/A"]
+    calls = [{
+        "rest_api": "/redfish/v1/Systems",
+        "allowed_methods": ["get", "head"],
+        "method": "get",
+        "arguments": {},
+    }]
+
+    assert parse_ordered_calls_y_pred(json.dumps({"y_pred": {"calls": calls}})) == [{
+        "rest_api": "/redfish/v1/Systems",
+        "allowed_methods": ["GET", "HEAD"],
+        "method": "GET",
+        "arguments": {},
+    }]
+    with pytest.raises(ValueError, match="rest_api"):
+        parse_ordered_calls_y_pred({
+            "y_pred": {
+                "calls": [{
+                    "allowed_methods": ["GET"],
+                    "method": "GET",
+                    "arguments": {},
+                }],
+            },
+        })
+
+
+def test_wandb_metric_keys_are_stage_scoped_and_not_m3_names() -> None:
+    """Phase 2/3 metric constants use dedicated W&B namespaces."""
+    assert "phase2_goal_extract/eval/ordered_exact_match_rate" in PHASE2_GOAL_EXTRACT_METRIC_KEYS
+    assert "phase2_goal_extract/eval/set_match_rate" in PHASE2_GOAL_EXTRACT_METRIC_KEYS
+    assert "phase3_argument_extract/eval/readonly_empty_arguments_rate" in PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS
+    assert "phase3_argument_extract/eval/arguments_exact_match_rate" in PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS
+    assert all(k.startswith("phase2_goal_extract/") for k in PHASE2_GOAL_EXTRACT_METRIC_KEYS)
+    assert all(k.startswith("phase3_argument_extract/") for k in PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS)
+    assert not any(k.startswith("m3_") for k in PHASE2_GOAL_EXTRACT_METRIC_KEYS)
+    assert not any(k.startswith("m3_") for k in PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS)
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -656,6 +656,61 @@ def test_rendered_phase3_patch_example_keeps_explicit_arguments() -> None:
     assert "/redfish/v1/Systems/1/Bios/Settings" in rendered.prompt
 
 
+def test_rendered_and_inference_outputs_preserve_multi_item_order() -> None:
+    """Model-facing targets keep multi-item Phase 2/3 order unchanged."""
+    systems = _context(
+        "/redfish/v1/Systems",
+        ("GET", "HEAD"),
+        {"@odata.id": "/redfish/v1/Systems"},
+    )
+    tasks = _context(
+        "/redfish/v1/TaskService/Tasks",
+        ("GET", "HEAD"),
+        {"@odata.id": "/redfish/v1/TaskService/Tasks"},
+    )
+
+    phase2 = build_d1_rest_api_list_row(
+        text="check tasks, then list systems",
+        contexts=(systems, tasks),
+        rest_api_list=("/redfish/v1/TaskService/Tasks", "/redfish/v1/Systems"),
+    )
+    phase3 = build_ordered_call_row(
+        text="check tasks, then list systems",
+        contexts=(systems, tasks),
+        rest_api_list=("/redfish/v1/TaskService/Tasks", "/redfish/v1/Systems"),
+    )
+
+    assert json.loads(render_rest_api_list_example(phase2).target_json) == {
+        "rest_api_list": [
+            "/redfish/v1/TaskService/Tasks",
+            "/redfish/v1/Systems",
+        ],
+    }
+    assert json.loads(render_ordered_call_example(phase3).target_json) == {
+        "calls": [
+            {
+                "rest_api": "/redfish/v1/TaskService/Tasks",
+                "allowed_methods": ["GET", "HEAD"],
+                "method": "GET",
+                "arguments": {},
+            },
+            {
+                "rest_api": "/redfish/v1/Systems",
+                "allowed_methods": ["GET", "HEAD"],
+                "method": "GET",
+                "arguments": {},
+            },
+        ],
+    }
+    assert [
+        call["rest_api"]
+        for call in inference_target_calls_json(phase3)["target_calls"]
+    ] == [
+        "/redfish/v1/TaskService/Tasks",
+        "/redfish/v1/Systems",
+    ]
+
+
 def test_inference_json_uses_target_calls_shape() -> None:
     """The combined inference handoff uses target_calls with Phase 3 call fields."""
     context = _context(

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -80,6 +80,38 @@ def test_d1_row_preserves_operator_order_independent_of_context_order() -> None:
     }
 
 
+def test_d1_row_does_not_leak_extra_context_into_target_list() -> None:
+    """Extra current context stays in x and never becomes an unrequested target."""
+    systems = _context(
+        "/redfish/v1/Systems",
+        ("GET", "HEAD"),
+        {"@odata.id": "/redfish/v1/Systems", "Name": "Systems"},
+    )
+    tasks = _context(
+        "/redfish/v1/TaskService/Tasks",
+        ("GET", "HEAD"),
+        {"@odata.id": "/redfish/v1/TaskService/Tasks", "Name": "Tasks"},
+    )
+    chassis = _context(
+        "/redfish/v1/Chassis",
+        ("GET", "HEAD"),
+        {"@odata.id": "/redfish/v1/Chassis", "Name": "Chassis"},
+    )
+
+    row = build_d1_rest_api_list_row(
+        text="check the task queue, then list systems",
+        contexts=(systems, tasks, chassis),
+        rest_api_list=("/redfish/v1/TaskService/Tasks", "/redfish/v1/Systems"),
+    )
+
+    assert row["x"]["json"] == [systems.json, tasks.json, chassis.json]
+    assert row["y_true"]["rest_api_list"] == [
+        "/redfish/v1/TaskService/Tasks",
+        "/redfish/v1/Systems",
+    ]
+    assert "/redfish/v1/Chassis" not in row["y_true"]["rest_api_list"]
+
+
 def test_phase23_rows_pin_locked_field_names() -> None:
     """Phase 2/3 rows expose only the locked contract field names."""
     context = _context(
@@ -312,6 +344,68 @@ def test_phase3_post_does_not_infer_action_arguments_from_get_scalars() -> None:
         "rest_api": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
         "allowed_methods": ["POST"],
         "method": "POST",
+        "arguments": {},
+    }
+
+
+def test_phase3_ignores_unselected_method_and_argument_labels() -> None:
+    """Phase 3 emits exactly one call per ordered rest_api_list entry."""
+    system = _context(
+        "/redfish/v1/Systems/1",
+        ("GET", "HEAD"),
+        {"@odata.id": "/redfish/v1/Systems/1"},
+    )
+    reset = _context(
+        "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+        ("POST",),
+        {"@odata.id": "/redfish/v1/Systems/1"},
+    )
+
+    row = build_ordered_call_row(
+        text="inspect the system",
+        contexts=(system, reset),
+        rest_api_list=("/redfish/v1/Systems/1",),
+        method_by_api={
+            "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset": "POST",
+        },
+        arguments_by_api={
+            "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset": {
+                "ResetType": "GracefulRestart",
+            },
+        },
+    )
+
+    assert row["x"]["rest_api_list"] == ["/redfish/v1/Systems/1"]
+    assert row["y_true"]["calls"] == [{
+        "rest_api": "/redfish/v1/Systems/1",
+        "allowed_methods": ["GET", "HEAD"],
+        "method": "GET",
+        "arguments": {},
+    }]
+
+
+def test_phase3_default_method_prefers_get_over_mutating_methods() -> None:
+    """Default Phase 3 labels prefer read-only GET even if PATCH appears first."""
+    system = _context(
+        "/redfish/v1/Systems/1",
+        ("PATCH", "GET"),
+        {
+            "@odata.id": "/redfish/v1/Systems/1",
+            "PowerState": "On",
+        },
+    )
+
+    row = build_ordered_call_row(
+        text="inspect system power",
+        contexts=(system,),
+        rest_api_list=("/redfish/v1/Systems/1",),
+        arguments_by_api={"/redfish/v1/Systems/1": {"PowerState": "On"}},
+    )
+
+    assert row["y_true"]["calls"][0] == {
+        "rest_api": "/redfish/v1/Systems/1",
+        "allowed_methods": ["PATCH", "GET"],
+        "method": "GET",
         "arguments": {},
     }
 
@@ -565,6 +659,28 @@ def test_ordered_calls_parser_preserves_multiple_call_order() -> None:
     ]
 
     assert parse_ordered_calls_y_pred({"calls": calls}) == calls
+
+
+def test_ordered_calls_parser_rejects_invalid_method_and_arguments_shape() -> None:
+    """Phase 3 y_pred parsing rejects invalid method and argument contracts."""
+    with pytest.raises(ValueError, match="not in allowed_methods"):
+        parse_ordered_calls_y_pred({
+            "calls": [{
+                "rest_api": "/redfish/v1/Systems",
+                "allowed_methods": ["GET", "HEAD"],
+                "method": "PATCH",
+                "arguments": {},
+            }],
+        })
+    with pytest.raises(ValueError, match="arguments"):
+        parse_ordered_calls_y_pred({
+            "calls": [{
+                "rest_api": "/redfish/v1/Systems",
+                "allowed_methods": ["GET", "HEAD"],
+                "method": "GET",
+                "arguments": ["PowerState", "On"],
+            }],
+        })
 
 
 def test_wandb_metric_keys_are_stage_scoped_and_not_m3_names() -> None:

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -722,6 +722,20 @@ def test_ordered_calls_parser_rejects_invalid_method_and_arguments_shape() -> No
         })
 
 
+def test_ordered_calls_parser_rejects_readonly_arguments() -> None:
+    """Phase 3 y_pred parsing rejects non-empty GET/HEAD argument objects."""
+    for method in ("GET", "HEAD"):
+        with pytest.raises(ValueError, match="read-only"):
+            parse_ordered_calls_y_pred({
+                "calls": [{
+                    "rest_api": "/redfish/v1/Systems",
+                    "allowed_methods": ["GET", "HEAD", "PATCH"],
+                    "method": method,
+                    "arguments": {"PowerState": "On"},
+                }],
+            })
+
+
 def test_wandb_metric_keys_are_stage_scoped_and_not_m3_names() -> None:
     """Phase 2/3 contract constants reuse the shared W&B metric registry."""
     assert PHASE2_GOAL_EXTRACT_METRIC_KEYS == PHASE2_WANDB_METRIC_KEYS

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -8,6 +8,7 @@ Mus mbayramo@stanford.edu
 """
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -71,6 +72,50 @@ def test_d1_row_preserves_operator_order_independent_of_context_order() -> None:
         "all_rest_api_present": True,
         "extra_rest_api_present": False,
         "order_preserved": True,
+    }
+
+
+def test_phase23_rows_pin_locked_field_names() -> None:
+    """Phase 2/3 rows expose only the locked contract field names."""
+    context = _context(
+        "/redfish/v1/Systems",
+        ("GET", "HEAD"),
+        {"@odata.id": "/redfish/v1/Systems", "Name": "Systems"},
+    )
+
+    assert set(context.to_dict()) == {"rest_api", "allowed_methods", "json"}
+
+    phase2 = build_d1_rest_api_list_row(
+        text="list systems",
+        contexts=(context,),
+        rest_api_list=("/redfish/v1/Systems",),
+    )
+    phase3 = build_ordered_call_row(
+        text="list systems",
+        contexts=(context,),
+        rest_api_list=("/redfish/v1/Systems",),
+    )
+
+    assert set(phase2) == {
+        "phase",
+        "dataset",
+        "source_dataset",
+        "model_x",
+        "task",
+        "x",
+        "y_true",
+        "validation",
+    }
+    assert set(phase2["x"]) == {"text", "json", "allowed_methods"}
+    assert set(phase2["y_true"]) == {"rest_api_list", "order_evidence"}
+    assert set(phase3) == {"phase", "source_dataset", "model_x", "task", "x", "y_true"}
+    assert set(phase3["x"]) == {"text", "rest_api_list", "json", "allowed_methods"}
+    assert set(phase3["y_true"]) == {"calls"}
+    assert set(phase3["y_true"]["calls"][0]) == {
+        "rest_api",
+        "allowed_methods",
+        "method",
+        "arguments",
     }
 
 
@@ -295,6 +340,19 @@ def test_wandb_metric_keys_are_stage_scoped_and_not_m3_names() -> None:
     assert all(k.startswith("phase3_argument_extract/") for k in PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS)
     assert not any(k.startswith("m3_") for k in PHASE2_GOAL_EXTRACT_METRIC_KEYS)
     assert not any(k.startswith("m3_") for k in PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS)
+
+
+def test_training_docs_pin_phase23_metric_constants() -> None:
+    """Training docs name the Phase 2/3 constants and representative key groups."""
+    docs_path = Path(__file__).resolve().parents[2] / "docs" / "TRAINING.md"
+    training_doc = docs_path.read_text(encoding="utf-8")
+
+    assert "PHASE2_GOAL_EXTRACT_METRIC_KEYS" in training_doc
+    assert "PHASE3_ARGUMENT_EXTRACT_METRIC_KEYS" in training_doc
+    assert "phase2_goal_extract/eval/{loss,perplexity,token_accuracy" in training_doc
+    assert "phase2_goal_extract/test/{latency_sec_p50,latency_sec_p95" in training_doc
+    assert "phase3_argument_extract/eval/{allowed_methods_exact_match_rate" in training_doc
+    assert "phase3_argument_extract/data/{avg_num_calls,avg_arguments_length" in training_doc
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -21,7 +21,7 @@ from igc.ds.rest_goal_contract import (
     RedfishContext,
     build_d1_rest_api_list_row,
     build_ordered_call_row,
-    inference_ordered_goals_json,
+    inference_target_calls_json,
     parse_ordered_calls_y_pred,
     parse_rest_api_list_y_pred,
     render_ordered_call_example,
@@ -143,7 +143,7 @@ def test_phase23_rows_pin_locked_field_names() -> None:
         "y_true",
         "validation",
     }
-    assert phase2["task"] == "text_to_ordered_rest_api_list"
+    assert phase2["task"] == "text_to_rest_api_list"
     assert set(phase2["x"]) == {"text", "json", "allowed_methods"}
     assert set(phase2["y_true"]) == {"rest_api_list", "order_evidence"}
     assert set(phase3) == {"phase", "source_dataset", "model_x", "task", "x", "y_true"}
@@ -576,8 +576,8 @@ def test_rendered_phase3_patch_example_keeps_explicit_arguments() -> None:
     assert "/redfish/v1/Systems/1/Bios/Settings" in rendered.prompt
 
 
-def test_inference_json_uses_ordered_goals_shape() -> None:
-    """The combined inference handoff uses ordered_goals with Phase 3 call fields."""
+def test_inference_json_uses_target_calls_shape() -> None:
+    """The combined inference handoff uses target_calls with Phase 3 call fields."""
     context = _context(
         "/redfish/v1/TaskService/Tasks",
         ("GET", "HEAD"),
@@ -589,9 +589,9 @@ def test_inference_json_uses_ordered_goals_shape() -> None:
         rest_api_list=("/redfish/v1/TaskService/Tasks",),
     )
 
-    assert inference_ordered_goals_json(row) == {
+    assert inference_target_calls_json(row) == {
         "text": "check task queue",
-        "ordered_goals": row["y_true"]["calls"],
+        "target_calls": row["y_true"]["calls"],
     }
 
 

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -649,6 +649,20 @@ def test_rest_api_list_parser_rejects_non_string_items() -> None:
         })
 
 
+def test_rest_api_list_parser_rejects_non_object_top_level_json() -> None:
+    """Phase 2 y_pred parsing rejects JSON that is not an object."""
+    for y_pred in ('["/redfish/v1/Systems"]', '"not an object"'):
+        with pytest.raises(ValueError, match="y_pred must be an object"):
+            parse_rest_api_list_y_pred(y_pred)
+
+
+def test_rest_api_list_parser_rejects_non_object_y_pred_envelope() -> None:
+    """Phase 2 y_pred parsing rejects a malformed y_pred envelope value."""
+    for y_pred in ({"y_pred": ["/redfish/v1/Systems"]}, {"y_pred": "not an object"}):
+        with pytest.raises(ValueError, match="y_pred.y_pred must be an object"):
+            parse_rest_api_list_y_pred(y_pred)
+
+
 def test_ordered_calls_parser_preserves_multiple_call_order() -> None:
     """Phase 3 y_pred parsing keeps the model-emitted call sequence intact."""
     calls = [
@@ -698,6 +712,20 @@ def test_ordered_calls_parser_rejects_non_string_contract_fields() -> None:
                 "arguments": {},
             }],
         })
+
+
+def test_ordered_calls_parser_rejects_non_object_top_level_json() -> None:
+    """Phase 3 y_pred parsing rejects JSON that is not an object."""
+    for y_pred in ("[]", "42"):
+        with pytest.raises(ValueError, match="y_pred must be an object"):
+            parse_ordered_calls_y_pred(y_pred)
+
+
+def test_ordered_calls_parser_rejects_non_object_y_pred_envelope() -> None:
+    """Phase 3 y_pred parsing rejects a malformed y_pred envelope value."""
+    for y_pred in ({"y_pred": []}, {"y_pred": 42}):
+        with pytest.raises(ValueError, match="y_pred.y_pred must be an object"):
+            parse_ordered_calls_y_pred(y_pred)
 
 
 def test_ordered_calls_parser_rejects_invalid_method_and_arguments_shape() -> None:

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -111,9 +111,11 @@ def test_phase23_rows_pin_locked_field_names() -> None:
         "y_true",
         "validation",
     }
+    assert phase2["task"] == "text_to_ordered_rest_api_list"
     assert set(phase2["x"]) == {"text", "json", "allowed_methods"}
     assert set(phase2["y_true"]) == {"rest_api_list", "order_evidence"}
     assert set(phase3) == {"phase", "source_dataset", "model_x", "task", "x", "y_true"}
+    assert phase3["task"] == "text_and_rest_api_list_to_calls"
     assert set(phase3["x"]) == {"text", "rest_api_list", "json", "allowed_methods"}
     assert set(phase3["y_true"]) == {"calls"}
     assert set(phase3["y_true"]["calls"][0]) == {
@@ -193,6 +195,33 @@ def test_phase3_get_calls_discard_supplied_arguments() -> None:
         "rest_api": "/redfish/v1/Systems/1",
         "allowed_methods": ["GET", "PATCH"],
         "method": "GET",
+        "arguments": {},
+    }
+
+
+def test_phase3_head_calls_discard_supplied_arguments() -> None:
+    """Read-only HEAD labels keep arguments empty like GET labels."""
+    row = build_ordered_call_row(
+        text="check system headers",
+        contexts=(
+            _context(
+                "/redfish/v1/Systems/1",
+                ("GET", "HEAD"),
+                {
+                    "@odata.id": "/redfish/v1/Systems/1",
+                    "PowerState": "On",
+                },
+            ),
+        ),
+        rest_api_list=("/redfish/v1/Systems/1",),
+        method_by_api={"/redfish/v1/Systems/1": "HEAD"},
+        arguments_by_api={"/redfish/v1/Systems/1": {"PowerState": "On"}},
+    )
+
+    assert row["y_true"]["calls"][0] == {
+        "rest_api": "/redfish/v1/Systems/1",
+        "allowed_methods": ["GET", "HEAD"],
+        "method": "HEAD",
         "arguments": {},
     }
 

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -272,9 +272,31 @@ def test_rendered_examples_have_prompt_target_boundary_and_canonical_json() -> N
     rendered3 = render_ordered_call_example(phase3)
 
     assert rendered2.target_char_start == len(rendered2.prompt)
+    assert rendered2.target_json == (
+        "{\n"
+        '  "rest_api_list": [\n'
+        '    "/redfish/v1/Systems"\n'
+        "  ]\n"
+        "}"
+    )
     assert json.loads(rendered2.target_json) == {"rest_api_list": ["/redfish/v1/Systems"]}
     assert "### Ordered REST API List" in rendered2.prompt
     assert rendered2.full_text == rendered2.prompt + rendered2.target_json
+    assert rendered3.target_json == (
+        "{\n"
+        '  "calls": [\n'
+        "    {\n"
+        '      "allowed_methods": [\n'
+        '        "GET",\n'
+        '        "HEAD"\n'
+        "      ],\n"
+        '      "arguments": {},\n'
+        '      "method": "GET",\n'
+        '      "rest_api": "/redfish/v1/Systems"\n'
+        "    }\n"
+        "  ]\n"
+        "}"
+    )
     assert json.loads(rendered3.target_json) == {
         "calls": phase3["y_true"]["calls"],
     }
@@ -328,6 +350,26 @@ def test_y_pred_parsers_preserve_order_and_report_bad_contracts() -> None:
                 }],
             },
         })
+
+
+def test_ordered_calls_parser_preserves_multiple_call_order() -> None:
+    """Phase 3 y_pred parsing keeps the model-emitted call sequence intact."""
+    calls = [
+        {
+            "rest_api": "/redfish/v1/TaskService/Tasks",
+            "allowed_methods": ["GET", "HEAD"],
+            "method": "GET",
+            "arguments": {},
+        },
+        {
+            "rest_api": "/redfish/v1/Systems",
+            "allowed_methods": ["GET", "HEAD"],
+            "method": "GET",
+            "arguments": {},
+        },
+    ]
+
+    assert parse_ordered_calls_y_pred({"calls": calls}) == calls
 
 
 def test_wandb_metric_keys_are_stage_scoped_and_not_m3_names() -> None:

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -165,6 +165,33 @@ def test_phase3_get_calls_preserve_order_and_keep_arguments_empty() -> None:
     ]
 
 
+def test_phase3_get_calls_discard_supplied_arguments() -> None:
+    """Read-only GET labels keep arguments empty even if caller supplies body-like data."""
+    row = build_ordered_call_row(
+        text="inspect system power",
+        contexts=(
+            _context(
+                "/redfish/v1/Systems/1",
+                ("GET", "PATCH"),
+                {
+                    "@odata.id": "/redfish/v1/Systems/1",
+                    "PowerState": "On",
+                },
+            ),
+        ),
+        rest_api_list=("/redfish/v1/Systems/1",),
+        method_by_api={"/redfish/v1/Systems/1": "GET"},
+        arguments_by_api={"/redfish/v1/Systems/1": {"PowerState": "On"}},
+    )
+
+    assert row["y_true"]["calls"][0] == {
+        "rest_api": "/redfish/v1/Systems/1",
+        "allowed_methods": ["GET", "PATCH"],
+        "method": "GET",
+        "arguments": {},
+    }
+
+
 def test_phase3_mutation_arguments_must_be_supplied_explicitly() -> None:
     """PATCH rows do not infer arguments from arbitrary scalar values in GET JSON."""
     settings = _context(


### PR DESCRIPTION
## Summary

Adds the offline Phase 2/3 mock-plumbing contract surface for REST goal extraction and ordered method/argument extraction.

- Adds tiny-fixture row builders, canonical renderers, y_pred parsers, and inference handoff JSON for `rest_api_list` and `target_calls`.
- Pins locked contract names including `model_x`, `D0`, `D1`, `x`, `y_true`, `y_pred`, `rest_api`, `rest_api_list`, `allowed_methods`, `method`, `arguments`, and `json`.
- Documents and re-exports reserved W&B metric key constants for `phase2_goal_extract/*` and `phase3_argument_extract/*`.

## Validation

- `/Users/spyroot/miniconda3/condabin/conda run -n igc-dev python -m pytest -q tests/ds/test_rest_goal_contract.py tests/modules/test_argument_decoder.py tests/modules/test_goal_extractor_encoder.py` aborted on this Mac before pytest output with `Abort trap: 6`.
- `/Users/spyroot/miniconda3/condabin/conda run -n igc-dev env PYTHONDONTWRITEBYTECODE=1 KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1 python -m pytest -q -p no:cacheprovider tests/ds/test_rest_goal_contract.py tests/modules/test_argument_decoder.py tests/modules/test_goal_extractor_encoder.py` passed: 55 passed, 1 existing warning.
- `/Users/spyroot/miniconda3/condabin/conda run -n igc-dev python -m ruff check igc/ds/rest_goal_contract.py tests/ds/test_rest_goal_contract.py` passed.
- `git diff --check`, `git diff --cached --check`, and `git diff --check origin/main..HEAD` passed.

## Boundaries

This is offline mock-plumbing only. Real `D1` generation and real Phase 2/3 training remain blocked until the Phase 1 `model_x` checkpoint is accepted.