### PR TITLE
Add Phase 2 labelled-request plumbing with hardened judge parsing

### DIFF
--- a/configs/phase2_labelled_requests.yaml
+++ b/configs/phase2_labelled_requests.yaml
@@ -1,0 +1,88 @@
+version: phase2_labelled_requests.v1
+dataset_name: phase2_labelled_requests
+
+sample_widths:
+  - 1
+  - 2
+  - 3
+
+wandb:
+  namespace: phase2_labelled_requests
+  project: igc
+  run_group: phase2_labelled_requests_offline_plumbing
+
+model_x:
+  id: phase1_redfish_model_x
+  artifact_sha: fixture-model-x-sha256
+  artifact_source: approved_model_store_placeholder
+
+judge:
+  route:
+    name: private_pro_judge
+    transport: configured_private_runtime
+    endpoint_env: PHASE2_PRO_JUDGE_ENDPOINT
+  model: private_pro
+  profile: max_reasoning
+
+generation:
+  draft_human_request:
+    temperature: 0.2
+    top_p: 0.9
+    max_tokens: 256
+  pro_judge_set_match:
+    temperature: 0.0
+    top_p: 1.0
+    max_tokens: 512
+
+acceptance_thresholds:
+  pro_accept_rate_min: 0.95
+  rest_api_set_match_rate_min: 0.98
+  empty_set_match_rate_min: 1.0
+  nonsense_rate_max: 0.02
+  invalid_json_rate_max: 0.01
+
+prompts:
+  draft_human_request:
+    version: phase2_labelled_requests.prompt.draft.v1
+    template: |
+      You generate one natural operator request for the dataset {dataset_name}.
+      The request must ask for all and only the sampled REST API records.
+      Do not include endpoint URLs in the request text.
+      Do not invent actions, arguments, hosts, credentials, or ordering language.
+      If there are multiple records, use a natural compound request.
+
+      Sample width: {sample_width}
+      REST API records:
+      {records_json}
+
+      Return JSON only with this shape:
+      {{
+        "text": "natural operator request"
+      }}
+  pro_judge_set_match:
+    version: phase2_labelled_requests.prompt.judge.v1
+    template: |
+      You judge whether drafted operator text maps back to the same unordered
+      REST API set for the dataset {dataset_name}. Empty set equals empty set.
+      Order is not the primary objective unless the text explicitly carries
+      ordering language such as "then", "before", "after", or numbered steps.
+
+      Draft text:
+      {draft_text}
+
+      Expected REST API set:
+      {rest_api_list_json}
+
+      Allowed methods by REST API:
+      {allowed_methods_json}
+
+      REST API records:
+      {records_json}
+
+      Return JSON only with this shape:
+      {{
+        "accepted": true,
+        "rest_api_list": ["/redfish/v1/example"],
+        "nonsense": false,
+        "reason": "short evidence-backed reason"
+      }}

--- a/docs/phase_2.md
+++ b/docs/phase_2.md
@@ -1,211 +1,177 @@
-# Phase 2: Ordered REST Goal Extraction
+# Phase 2: Labelled Request Dataset
 
-Phase 2 builds and trains `D1`, the dataset for extracting Redfish REST goals from an operator
-sentence. `model_x` must already have completed Phase 1 Redfish JSON pretraining.
+Phase 2 builds `phase2_labelled_requests`, the dataset name defined by
+`configs/phase2_labelled_requests.yaml` in this repository. The dataset adds the
+missing human request text label for one, two, or three Redfish REST API records
+that already carry paths, allowed HTTP methods, and JSON bodies.
 
-Names are fixed as follows:
+`model_x`, produced by Phase 1 Redfish JSON pretraining, drafts the missing
+operator text. The private Pro judge, selected by the `judge` section in
+`configs/phase2_labelled_requests.yaml`, decides whether that text maps back to
+the same unordered REST API set. Empty set equals empty set. Order is recorded
+only as secondary evidence when the text explicitly says things like "then",
+"before", "after", or uses numbered steps.
 
-- `D0`: Phase 1 JSON reconstruction data.
-- `D1`: Phase 2 text-to-ordered-REST-goal data.
-- `model_x`: the Phase 1 Redfish-tuned LLM.
-- `x`: the input context shown to the model.
-- `y_true`: the exact target label stored in the dataset.
-- `y_pred`: the model output during inference or evaluation.
-- `rest_api`: one concrete Redfish URI.
-- `rest_api_list`: ordered list of concrete Redfish URIs.
-- `allowed_methods`: methods from the same discovery run's `rest_api_map.npy`.
-- `json`: full Redfish JSON resource body.
+## Config Contract
 
-Phase 2 output is ordered. If the operator sentence says "check tasks, then check systems", the
-target order is tasks first and systems second. If the sentence has no explicit order, the dataset
-builder still stores a deterministic order and marks that order as weak evidence so evaluation can
-separate exact-order accuracy from set-recall.
+`configs/phase2_labelled_requests.yaml`, added by the Phase 2 labelled-request
+plumbing step, is the single runtime source for:
 
-## D1 Build Input
+- prompt templates and prompt spec versions under `prompts`;
+- `model_x` identifiers and the model artifact SHA under `model_x`;
+- private judge route metadata, judge model, and judge profile under `judge`;
+- generation settings under `generation`;
+- sample widths `1`, `2`, and `3` under `sample_widths`;
+- W&B namespace metadata under `wandb`;
+- acceptance thresholds under `acceptance_thresholds`.
 
-To build one `D1` row, sample one, two, or three Redfish records from `D0` or the same captured
-corpus. Each sampled record must carry its `rest_api`, full `json`, and `allowed_methods`.
-The following block is an intermediate synthetic-text generation request, not the final stored row:
-`x` is the sampled Redfish context, and `y_pred.text` is the draft operator sentence.
+Runtime code must load this YAML spec. Prompt text, model IDs, judge route names,
+generation temperatures, token limits, W&B namespaces, and acceptance thresholds
+must not be embedded directly in dataset-builder code.
+
+## Build Input
+
+One build item samples `k in {1, 2, 3}` records from the Redfish corpus. Each
+record has this minimum shape:
 
 ```json
 {
-  "x": {
-    "task": "produce_human_text_for_ordered_rest_api_list",
-    "json": [
-      {
-        "@odata.context": "/redfish/v1/$metadata#TaskCollection.TaskCollection",
-        "@odata.id": "/redfish/v1/TaskService/Tasks",
-        "@odata.type": "#TaskCollection.TaskCollection",
-        "Description": "Collection of Tasks",
-        "Members": [],
-        "Members@odata.count": 0,
-        "Name": "Task Collection"
-      },
-      {
-        "@odata.context": "/redfish/v1/$metadata#ComputerSystemCollection.ComputerSystemCollection",
-        "@odata.id": "/redfish/v1/Systems",
-        "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
-        "Description": "Collection of Computer Systems",
-        "Members": [
-          {
-            "@odata.id": "/redfish/v1/Systems/System.Embedded.1"
-          }
-        ],
-        "Members@odata.count": 1,
-        "Name": "Computer System Collection"
-      }
-    ],
-    "allowed_methods": {
-      "/redfish/v1/TaskService/Tasks": [
-        "GET",
-        "HEAD"
-      ],
-      "/redfish/v1/Systems": [
-        "GET",
-        "HEAD"
-      ]
-    },
-    "rest_api_list": [
-      "/redfish/v1/TaskService/Tasks",
-      "/redfish/v1/Systems"
-    ]
+  "rest_api": "/redfish/v1/Systems",
+  "allowed_methods": ["GET", "HEAD"],
+  "json": {
+    "@odata.id": "/redfish/v1/Systems",
+    "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+    "Members": [],
+    "Members@odata.count": 0,
+    "Name": "Computer System Collection"
   },
-  "y_pred": {
-    "text": "check the task queue, then list the available computer systems"
-  }
+  "vendor": "fixture",
+  "source_corpus": "unit_fixture"
 }
 ```
 
-`y_pred.text` is only a draft. If `model_x` emits junk text, that text must not enter `D1`. It must
-be cleaned or rejected.
+The sampled records are rendered into the YAML `draft_human_request` prompt. A
+later approved run can send that prompt to `model_x`; offline unit tests use only
+fixtures and do not call a model.
 
-## Review Cleanup And Judge
+## Draft And Judge
 
-The generated text should be passed through a review/judge step with the same `json`,
-`allowed_methods`, and ordered `rest_api_list`. The reviewer has two jobs:
+`model_x` should return JSON containing the drafted text:
 
-1. rewrite the text into a natural operator sentence if needed;
-2. judge whether the sentence asks for all and only the sampled `rest_api_list`, in the intended
-   order when the sentence contains ordering language.
+```json
+{
+  "text": "check the available computer systems"
+}
+```
 
-Accepted output becomes the final `D1` row. Rejected output is not used for fine-tuning.
+The draft text, sampled records, allowed methods, and expected REST API set are
+then rendered into the YAML `pro_judge_set_match` prompt. The private Pro judge
+returns JSON with the judged REST API set:
 
-## Final D1 Row
+```json
+{
+  "accepted": true,
+  "rest_api_list": ["/redfish/v1/Systems"],
+  "nonsense": false,
+  "reason": "The request asks for the sampled Systems collection only."
+}
+```
 
-This is the row used to fine-tune text-to-REST-goal extraction:
+The offline parser accepts a row only when the judge JSON parses, the judge did
+not mark the draft as nonsense, and the judged REST API set equals the expected
+set after ignoring order. If the expected and judged sets are both empty, the
+row counts as an empty-set match.
+
+## Final Row
+
+An accepted row stores the text label with the sampled REST API evidence:
 
 ```json
 {
   "phase": 2,
-  "dataset": "D1",
-  "task": "text_to_ordered_rest_api_list",
+  "dataset": "phase2_labelled_requests",
+  "task": "text_to_rest_api_set",
   "x": {
-    "text": "check the task queue, then list the available computer systems",
-    "json": [
+    "text": "check the available computer systems",
+    "records": [
       {
-        "@odata.context": "/redfish/v1/$metadata#TaskCollection.TaskCollection",
-        "@odata.id": "/redfish/v1/TaskService/Tasks",
-        "@odata.type": "#TaskCollection.TaskCollection",
-        "Description": "Collection of Tasks",
-        "Members": [],
-        "Members@odata.count": 0,
-        "Name": "Task Collection"
-      },
-      {
-        "@odata.context": "/redfish/v1/$metadata#ComputerSystemCollection.ComputerSystemCollection",
-        "@odata.id": "/redfish/v1/Systems",
-        "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
-        "Description": "Collection of Computer Systems",
-        "Members": [
-          {
-            "@odata.id": "/redfish/v1/Systems/System.Embedded.1"
-          }
-        ],
-        "Members@odata.count": 1,
-        "Name": "Computer System Collection"
+        "rest_api": "/redfish/v1/Systems",
+        "allowed_methods": ["GET", "HEAD"],
+        "json": {
+          "@odata.id": "/redfish/v1/Systems",
+          "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+          "Members": [],
+          "Members@odata.count": 0,
+          "Name": "Computer System Collection"
+        }
       }
-    ],
-    "allowed_methods": {
-      "/redfish/v1/TaskService/Tasks": [
-        "GET",
-        "HEAD"
-      ],
-      "/redfish/v1/Systems": [
-        "GET",
-        "HEAD"
-      ]
-    }
+    ]
   },
   "y_true": {
-    "rest_api_list": [
-      "/redfish/v1/TaskService/Tasks",
-      "/redfish/v1/Systems"
-    ],
-    "order_evidence": "explicit_then"
+    "rest_api_set": ["/redfish/v1/Systems"],
+    "order_evidence": "none"
   },
   "validation": {
-    "text_source": "model_x_then_review",
-    "review_judged": true,
-    "all_rest_api_present": true,
-    "extra_rest_api_present": false,
-    "order_preserved": true
+    "text_source": "model_x_then_private_pro_judge",
+    "pro_judged": true,
+    "rest_api_set_match": true,
+    "empty_set_match": false,
+    "nonsense": false,
+    "invalid_json": false
   }
 }
 ```
 
-## Fine-Tuning Target
+The row may preserve a deterministic list order for storage, but Phase 2
+acceptance is set-based unless the text itself carries explicit ordering
+language. Phase 3 argument extraction remains a separate phase and consumes
+accepted request labels only after a downstream contract chooses how to preserve
+or infer call order.
 
-The rendered training target is canonical JSON:
+## Metrics
 
-```json
-{
-  "rest_api_list": [
-    "/redfish/v1/TaskService/Tasks",
-    "/redfish/v1/Systems"
-  ]
-}
-```
+`PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS`, defined in
+`igc/modules/base/metric_keys.py`, records the metric keys used by the offline
+builder seam. The canonical namespace comes from `wandb.namespace` in
+`configs/phase2_labelled_requests.yaml` and is `phase2_labelled_requests`.
 
-Cross-entropy is computed on the target JSON tokens. Evaluation parses `y_pred`, reads
-`y_pred.rest_api_list`, and reports both ordered exact match and set match.
+Required keys:
 
-## Phase 2 W&B Metrics
+- `phase2_labelled_requests/build/draft_total`
+- `phase2_labelled_requests/build/accepted_total`
+- `phase2_labelled_requests/build/rejected_total`
+- `phase2_labelled_requests/eval/nonsense_rate`
+- `phase2_labelled_requests/eval/invalid_json_rate`
+- `phase2_labelled_requests/eval/pro_accept_rate`
+- `phase2_labelled_requests/eval/rest_api_set_match_rate`
+- `phase2_labelled_requests/eval/empty_set_match_rate`
+- `phase2_labelled_requests/sample_width/k`
+- `phase2_labelled_requests/vendor/source_corpus`
+- `phase2_labelled_requests/spec/prompt_spec_version`
+- `phase2_labelled_requests/model/model_x_artifact_sha`
+- `phase2_labelled_requests/judge/model`
+- `phase2_labelled_requests/judge/profile`
 
-- `phase2_goal_extract/train/loss`
-- `phase2_goal_extract/train/perplexity`
-- `phase2_goal_extract/train/optimizer_step`
-- `phase2_goal_extract/eval/loss`
-- `phase2_goal_extract/eval/perplexity`
-- `phase2_goal_extract/eval/token_accuracy`
-- `phase2_goal_extract/eval/ordered_exact_match_rate`
-- `phase2_goal_extract/eval/set_match_rate`
-- `phase2_goal_extract/eval/precision`
-- `phase2_goal_extract/eval/recall`
-- `phase2_goal_extract/eval/f1`
-- `phase2_goal_extract/eval/top_k_api_accuracy`
-- `phase2_goal_extract/eval/invalid_api_rate`
-- `phase2_goal_extract/eval/missing_required_api_rate`
-- `phase2_goal_extract/eval/missing_allowed_methods_rate`
-- `phase2_goal_extract/eval/order_violation_rate`
-- `phase2_goal_extract/order/kendall_tau`
-- `phase2_goal_extract/order/edit_distance`
-- `phase2_goal_extract/throughput/train_tokens_per_sec`
-- `phase2_goal_extract/throughput/train_samples_per_sec`
-- `phase2_goal_extract/throughput/eval_tokens_per_sec`
-- `phase2_goal_extract/throughput/eval_samples_per_sec`
-- `phase2_goal_extract/data/avg_num_apis`
-- `phase2_goal_extract/data/max_num_apis`
-- `phase2_goal_extract/data/mean_sequence_length`
-- `phase2_goal_extract/data/padding_ratio`
-- `phase2_goal_extract/calibration/log_prob_per_sequence`
-- `phase2_goal_extract/calibration/ece`
-- `phase2_goal_extract/test/latency_sec_p50`
-- `phase2_goal_extract/test/latency_sec_p95`
-- `phase2_goal_extract/test/memory_peak_mb`
+These keys can be emitted by offline counters without opening a live W&B run.
 
-When Phase 2 moves beyond mock plumbing, its acceptance gate must mirror Phase 1: approved full
-corpora, readable W&B plots, checkpoint/report storage, and reviewed Git LFS artifact metadata.
+## Acceptance Gate
+
+The offline plumbing is accepted when focused pytest coverage proves:
+
+- sample widths `k=1`, `k=2`, and `k=3` are supported;
+- prompt specs load from YAML and render sampled record payloads;
+- REST API set comparison is unordered;
+- empty set equals empty set;
+- Pro judge JSON parsing handles accepted, rejected, nonsense, and invalid JSON
+  outcomes;
+- nonsense, invalid JSON, Pro accept, REST API set match, and empty-set match
+  counters emit the required keys;
+- Phase 3 argument extraction remains outside this builder.
+
+A later approved run can point the YAML route metadata at the fine-tuned
+`model_x` artifact and private Pro judge. That run is outside the local CPU
+plumbing gate and must not be simulated with live GPU inference, live W&B, live
+Redfish crawls, model downloads, or cluster jobs.
 
 Author:
 Mus mbayramo@stanford.edu

--- a/igc/ds/phase2_labelled_requests.py
+++ b/igc/ds/phase2_labelled_requests.py
@@ -370,10 +370,30 @@ def parse_pro_judge_result(
             raw=raw,
         )
 
-    rest_api_list = _string_tuple(
-        decoded.get("rest_api_list", decoded.get("rest_api_set", ())),
-        "rest_api_list",
-    )
+    if "rest_api_list" in decoded:
+        rest_api_value = decoded["rest_api_list"]
+        rest_api_field = "rest_api_list"
+    elif "rest_api_set" in decoded:
+        rest_api_value = decoded["rest_api_set"]
+        rest_api_field = "rest_api_set"
+    else:
+        rest_api_value = []
+        rest_api_field = "rest_api_list"
+
+    try:
+        rest_api_list = _string_tuple(rest_api_value, rest_api_field)
+    except Phase2LabelledRequestsSpecError as exc:
+        return ProJudgeResult(
+            valid_json=False,
+            accepted=False,
+            pro_accept=False,
+            rest_api_set_match=False,
+            empty_set_match=False,
+            nonsense=False,
+            invalid_json=True,
+            reason=str(exc),
+            raw=raw,
+        )
     computed_set_match = rest_api_sets_equal(expected_rest_apis, rest_api_list)
     judge_set_match = decoded.get("rest_api_set_match")
     rest_api_set_match = (
@@ -464,8 +484,6 @@ def _float_mapping(raw: Mapping[str, Any], context: str) -> dict[str, float]:
 
 def _string_tuple(value: Any, context: str) -> tuple[str, ...]:
     """Return a tuple of strings from a JSON list field."""
-    if value is None:
-        return ()
     if not isinstance(value, list):
         raise Phase2LabelledRequestsSpecError(f"{context} must be a list")
     if not all(isinstance(item, str) for item in value):

--- a/igc/ds/phase2_labelled_requests.py
+++ b/igc/ds/phase2_labelled_requests.py
@@ -1,0 +1,481 @@
+"""Offline plumbing for the Phase 2 labelled request dataset.
+
+The builder samples Redfish REST API records, renders configured prompts, and
+parses configured judge responses. This module is deliberately pure: it does not
+call models, W&B, GPUs, Redfish hosts, or private runtime endpoints.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import random
+from typing import Any, Mapping, Sequence
+
+import yaml
+
+from igc.modules.base.metric_keys import phase_metric
+
+
+class Phase2LabelledRequestsSpecError(ValueError):
+    """Raised when the Phase 2 labelled request YAML spec is invalid."""
+
+
+_TOP_LEVEL_KEYS = {
+    "version",
+    "dataset_name",
+    "sample_widths",
+    "wandb",
+    "model_x",
+    "judge",
+    "generation",
+    "acceptance_thresholds",
+    "prompts",
+}
+_PHASE2_SAMPLE_WIDTHS = (1, 2, 3)
+
+
+@dataclass(frozen=True)
+class PromptSpec:
+    """One prompt template loaded from ``configs/phase2_labelled_requests.yaml``."""
+
+    name: str
+    version: str
+    template: str
+
+
+@dataclass(frozen=True)
+class Phase2LabelledRequestsSpec:
+    """Normalized runtime spec loaded from ``configs/phase2_labelled_requests.yaml``."""
+
+    path: Path
+    version: str
+    dataset_name: str
+    sample_widths: tuple[int, ...]
+    wandb: dict[str, Any]
+    model_x: dict[str, Any]
+    judge: dict[str, Any]
+    generation: dict[str, Any]
+    acceptance_thresholds: dict[str, float]
+    prompts: dict[str, PromptSpec]
+
+
+@dataclass(frozen=True)
+class Phase2RestApiRecord:
+    """One Redfish REST API record available to the labelled-request builder."""
+
+    rest_api: str
+    allowed_methods: tuple[str, ...]
+    json_body: Mapping[str, Any]
+    vendor: str = ""
+    source_corpus: str = ""
+
+    def __post_init__(self) -> None:
+        """Normalize method storage while preserving public record data."""
+        if not self.rest_api:
+            raise ValueError("rest_api must be non-empty")
+        object.__setattr__(self, "allowed_methods", tuple(self.allowed_methods))
+
+    def to_prompt_dict(self) -> dict[str, Any]:
+        """Return the public-safe record shape used by configured prompts."""
+        return {
+            "rest_api": self.rest_api,
+            "allowed_methods": list(self.allowed_methods),
+            "json": dict(self.json_body),
+            "vendor": self.vendor,
+            "source_corpus": self.source_corpus,
+        }
+
+
+@dataclass(frozen=True)
+class Phase2RequestSample:
+    """A sampled set of one to three REST API records."""
+
+    records: tuple[Phase2RestApiRecord, ...]
+
+    @property
+    def sample_width(self) -> int:
+        """Return the number of sampled REST API records."""
+        return len(self.records)
+
+    @property
+    def rest_api_list(self) -> tuple[str, ...]:
+        """Return sampled REST APIs in deterministic stored order."""
+        return tuple(record.rest_api for record in self.records)
+
+    @property
+    def allowed_methods_by_rest_api(self) -> dict[str, list[str]]:
+        """Return allowed HTTP methods keyed by REST API."""
+        return {
+            record.rest_api: list(record.allowed_methods)
+            for record in self.records
+        }
+
+    def to_prompt_payload(self) -> list[dict[str, Any]]:
+        """Return the sampled record payload for prompt rendering."""
+        return [record.to_prompt_dict() for record in self.records]
+
+
+@dataclass(frozen=True)
+class ProJudgeResult:
+    """Parsed private-judge decision for one drafted request label."""
+
+    valid_json: bool
+    accepted: bool
+    pro_accept: bool
+    rest_api_set_match: bool
+    empty_set_match: bool
+    nonsense: bool
+    invalid_json: bool
+    rest_api_list: tuple[str, ...] = ()
+    reason: str = ""
+    raw: str = ""
+
+
+@dataclass
+class Phase2LabelledRequestCounters:
+    """Offline counters for Phase 2 labelled request generation metrics."""
+
+    draft_total: int = 0
+    accepted_total: int = 0
+    rejected_total: int = 0
+    nonsense_total: int = 0
+    invalid_json_total: int = 0
+    pro_accept_total: int = 0
+    rest_api_set_match_total: int = 0
+    empty_set_match_total: int = 0
+    last_sample_width: int = 0
+    last_vendor: str = ""
+    last_source_corpus: str = ""
+
+    def record_outcome(
+        self,
+        result: ProJudgeResult,
+        *,
+        sample_width: int,
+        vendor: str,
+        source_corpus: str,
+        spec: Phase2LabelledRequestsSpec,
+    ) -> None:
+        """Record one draft/judge outcome without opening a live metrics run."""
+        if sample_width not in spec.sample_widths:
+            raise ValueError(f"sample width must be one of {spec.sample_widths}")
+
+        self.draft_total += 1
+        self.last_sample_width = sample_width
+        self.last_vendor = vendor
+        self.last_source_corpus = source_corpus
+
+        if result.accepted:
+            self.accepted_total += 1
+        else:
+            self.rejected_total += 1
+        if result.nonsense:
+            self.nonsense_total += 1
+        if result.invalid_json:
+            self.invalid_json_total += 1
+        if result.pro_accept:
+            self.pro_accept_total += 1
+        if result.rest_api_set_match:
+            self.rest_api_set_match_total += 1
+        if result.empty_set_match:
+            self.empty_set_match_total += 1
+
+    def to_wandb_metrics(self, spec: Phase2LabelledRequestsSpec) -> dict[str, Any]:
+        """Return metric-key/value pairs suitable for an offline W&B logger seam."""
+        namespace = _required_string(spec.wandb, "namespace", context="wandb")
+        source_value = (
+            f"{self.last_vendor}/{self.last_source_corpus}"
+            if self.last_vendor or self.last_source_corpus else ""
+        )
+        return {
+            phase_metric(namespace, "build", "draft_total"): self.draft_total,
+            phase_metric(namespace, "build", "accepted_total"): self.accepted_total,
+            phase_metric(namespace, "build", "rejected_total"): self.rejected_total,
+            phase_metric(namespace, "eval", "nonsense_rate"): self._rate(self.nonsense_total),
+            phase_metric(namespace, "eval", "invalid_json_rate"): self._rate(
+                self.invalid_json_total
+            ),
+            phase_metric(namespace, "eval", "pro_accept_rate"): self._rate(
+                self.pro_accept_total
+            ),
+            phase_metric(namespace, "eval", "rest_api_set_match_rate"): self._rate(
+                self.rest_api_set_match_total
+            ),
+            phase_metric(namespace, "eval", "empty_set_match_rate"): self._rate(
+                self.empty_set_match_total
+            ),
+            phase_metric(namespace, "sample_width", "k"): self.last_sample_width,
+            phase_metric(namespace, "vendor", "source_corpus"): source_value,
+            phase_metric(namespace, "spec", "prompt_spec_version"): spec.version,
+            phase_metric(namespace, "model", "model_x_artifact_sha"): _required_string(
+                spec.model_x, "artifact_sha", context="model_x"
+            ),
+            phase_metric(namespace, "judge", "model"): _required_string(
+                spec.judge, "model", context="judge"
+            ),
+            phase_metric(namespace, "judge", "profile"): _required_string(
+                spec.judge, "profile", context="judge"
+            ),
+        }
+
+    def _rate(self, numerator: int) -> float:
+        """Return a stable zero-safe rate over drafted examples."""
+        if self.draft_total == 0:
+            return 0.0
+        return numerator / self.draft_total
+
+
+def load_phase2_labelled_requests_spec(
+    path: str | Path,
+) -> Phase2LabelledRequestsSpec:
+    """Load and validate the Phase 2 labelled request YAML spec."""
+    spec_path = Path(path)
+    try:
+        raw = yaml.safe_load(spec_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise Phase2LabelledRequestsSpecError(
+            f"cannot read Phase 2 labelled request spec {spec_path}: {exc}"
+        ) from exc
+    except yaml.YAMLError as exc:
+        raise Phase2LabelledRequestsSpecError(
+            f"cannot parse YAML in Phase 2 labelled request spec {spec_path}: {exc}"
+        ) from exc
+
+    if not isinstance(raw, dict):
+        raise Phase2LabelledRequestsSpecError("Phase 2 spec must be a YAML mapping")
+
+    unknown = sorted(set(raw) - _TOP_LEVEL_KEYS)
+    if unknown:
+        raise Phase2LabelledRequestsSpecError(
+            f"unknown top-level keys: {', '.join(unknown)}"
+        )
+
+    version = _required_string(raw, "version")
+    dataset_name = _required_string(raw, "dataset_name")
+    sample_widths = _sample_widths(raw.get("sample_widths"))
+    prompts = _prompt_specs(_mapping(raw, "prompts", required=True))
+
+    return Phase2LabelledRequestsSpec(
+        path=spec_path,
+        version=version,
+        dataset_name=dataset_name,
+        sample_widths=sample_widths,
+        wandb=_mapping(raw, "wandb", required=True),
+        model_x=_mapping(raw, "model_x", required=True),
+        judge=_mapping(raw, "judge", required=True),
+        generation=_mapping(raw, "generation", required=True),
+        acceptance_thresholds=_float_mapping(
+            _mapping(raw, "acceptance_thresholds", required=True),
+            "acceptance_thresholds",
+        ),
+        prompts=prompts,
+    )
+
+
+def sample_rest_api_records(
+    records: Sequence[Phase2RestApiRecord],
+    *,
+    k: int,
+    rng: random.Random,
+    allowed_widths: Sequence[int],
+) -> Phase2RequestSample:
+    """Sample ``k`` REST API records without replacement."""
+    allowed = tuple(allowed_widths)
+    if k not in allowed:
+        raise ValueError(f"sample width must be one of {allowed}")
+    if len(records) < k:
+        raise ValueError("not enough records to sample requested width")
+    return Phase2RequestSample(tuple(rng.sample(list(records), k)))
+
+
+def render_phase2_prompt(
+    spec: Phase2LabelledRequestsSpec,
+    prompt_name: str,
+    sample: Phase2RequestSample,
+    *,
+    draft_text: str = "",
+) -> str:
+    """Render a configured Phase 2 prompt for one sampled record set."""
+    try:
+        prompt = spec.prompts[prompt_name]
+    except KeyError as exc:
+        raise Phase2LabelledRequestsSpecError(
+            f"unknown prompt in Phase 2 spec: {prompt_name}"
+        ) from exc
+
+    variables = {
+        "dataset_name": spec.dataset_name,
+        "prompt_spec_version": prompt.version,
+        "sample_width": sample.sample_width,
+        "records_json": _json(sample.to_prompt_payload()),
+        "rest_api_list_json": _json(list(sample.rest_api_list)),
+        "allowed_methods_json": _json(sample.allowed_methods_by_rest_api),
+        "draft_text": draft_text,
+        "judge_model": _required_string(spec.judge, "model", context="judge"),
+        "judge_profile": _required_string(spec.judge, "profile", context="judge"),
+        "model_x_id": _required_string(spec.model_x, "id", context="model_x"),
+    }
+    try:
+        return prompt.template.format(**variables)
+    except KeyError as exc:
+        missing = exc.args[0]
+        raise Phase2LabelledRequestsSpecError(
+            f"prompt {prompt_name} references unknown variable {missing}"
+        ) from exc
+
+
+def rest_api_sets_equal(
+    expected_rest_apis: Sequence[str],
+    actual_rest_apis: Sequence[str],
+) -> bool:
+    """Return unordered REST API set equality; empty set equals empty set."""
+    return frozenset(expected_rest_apis) == frozenset(actual_rest_apis)
+
+
+def parse_pro_judge_result(
+    raw: str,
+    *,
+    expected_rest_apis: Sequence[str],
+) -> ProJudgeResult:
+    """Parse a private Pro judge JSON response for one drafted label."""
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return ProJudgeResult(
+            valid_json=False,
+            accepted=False,
+            pro_accept=False,
+            rest_api_set_match=False,
+            empty_set_match=False,
+            nonsense=False,
+            invalid_json=True,
+            reason=str(exc),
+            raw=raw,
+        )
+
+    if not isinstance(decoded, Mapping):
+        return ProJudgeResult(
+            valid_json=False,
+            accepted=False,
+            pro_accept=False,
+            rest_api_set_match=False,
+            empty_set_match=False,
+            nonsense=False,
+            invalid_json=True,
+            reason="judge response must be a JSON object",
+            raw=raw,
+        )
+
+    rest_api_list = _string_tuple(
+        decoded.get("rest_api_list", decoded.get("rest_api_set", ())),
+        "rest_api_list",
+    )
+    computed_set_match = rest_api_sets_equal(expected_rest_apis, rest_api_list)
+    judge_set_match = decoded.get("rest_api_set_match")
+    rest_api_set_match = (
+        computed_set_match if not isinstance(judge_set_match, bool)
+        else judge_set_match and computed_set_match
+    )
+    empty_set_match = not expected_rest_apis and not rest_api_list
+    nonsense = bool(decoded.get("nonsense", False))
+    requested_accept = bool(decoded.get("accepted", decoded.get("accept", False)))
+    pro_accept = requested_accept and rest_api_set_match and not nonsense
+
+    return ProJudgeResult(
+        valid_json=True,
+        accepted=pro_accept,
+        pro_accept=pro_accept,
+        rest_api_set_match=rest_api_set_match,
+        empty_set_match=empty_set_match,
+        nonsense=nonsense,
+        invalid_json=False,
+        rest_api_list=rest_api_list,
+        reason=str(decoded.get("reason", "")),
+        raw=raw,
+    )
+
+
+def _mapping(raw: Mapping[str, Any], key: str, *, required: bool = False) -> dict[str, Any]:
+    """Return a YAML mapping field as a dict."""
+    value = raw.get(key)
+    if value is None:
+        if required:
+            raise Phase2LabelledRequestsSpecError(f"missing required field: {key}")
+        return {}
+    if not isinstance(value, Mapping):
+        raise Phase2LabelledRequestsSpecError(f"{key} must be a mapping")
+    return dict(value)
+
+
+def _required_string(
+    raw: Mapping[str, Any],
+    key: str,
+    *,
+    context: str | None = None,
+) -> str:
+    """Return a non-empty string field from a mapping."""
+    value = raw.get(key)
+    if not isinstance(value, str) or not value:
+        prefix = f"{context}." if context else ""
+        raise Phase2LabelledRequestsSpecError(f"{prefix}{key} must be a non-empty string")
+    return value
+
+
+def _sample_widths(value: Any) -> tuple[int, ...]:
+    """Validate configured sample widths."""
+    if not isinstance(value, list) or not value:
+        raise Phase2LabelledRequestsSpecError("sample_widths must be a non-empty list")
+    widths = tuple(value)
+    if widths != _PHASE2_SAMPLE_WIDTHS:
+        raise Phase2LabelledRequestsSpecError(
+            f"sample_widths must be {list(_PHASE2_SAMPLE_WIDTHS)}"
+        )
+    return widths
+
+
+def _prompt_specs(raw: Mapping[str, Any]) -> dict[str, PromptSpec]:
+    """Normalize prompt specs from the YAML mapping."""
+    prompts: dict[str, PromptSpec] = {}
+    for name, value in raw.items():
+        if not isinstance(value, Mapping):
+            raise Phase2LabelledRequestsSpecError(f"prompt {name} must be a mapping")
+        prompt = dict(value)
+        prompts[name] = PromptSpec(
+            name=name,
+            version=_required_string(prompt, "version", context=f"prompts.{name}"),
+            template=_required_string(prompt, "template", context=f"prompts.{name}"),
+        )
+    return prompts
+
+
+def _float_mapping(raw: Mapping[str, Any], context: str) -> dict[str, float]:
+    """Return a mapping whose values are numeric thresholds."""
+    out: dict[str, float] = {}
+    for key, value in raw.items():
+        if not isinstance(value, (int, float)):
+            raise Phase2LabelledRequestsSpecError(f"{context}.{key} must be numeric")
+        out[str(key)] = float(value)
+    return out
+
+
+def _string_tuple(value: Any, context: str) -> tuple[str, ...]:
+    """Return a tuple of strings from a JSON list field."""
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise Phase2LabelledRequestsSpecError(f"{context} must be a list")
+    if not all(isinstance(item, str) for item in value):
+        raise Phase2LabelledRequestsSpecError(f"{context} entries must be strings")
+    return tuple(value)
+
+
+def _json(value: Any) -> str:
+    """Return stable pretty JSON for prompt variables."""
+    return json.dumps(value, indent=2, sort_keys=True)
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/igc/ds/phase2_labelled_requests.py
+++ b/igc/ds/phase2_labelled_requests.py
@@ -377,8 +377,20 @@ def parse_pro_judge_result(
         rest_api_value = decoded["rest_api_set"]
         rest_api_field = "rest_api_set"
     else:
-        rest_api_value = []
-        rest_api_field = "rest_api_list"
+        # A judge response with NEITHER field is malformed output, not an empty
+        # set: silently substituting [] would let a bare {"accepted": true}
+        # accept a hard-negative row with no REST API evidence at all.
+        return ProJudgeResult(
+            valid_json=False,
+            accepted=False,
+            pro_accept=False,
+            rest_api_set_match=False,
+            empty_set_match=False,
+            nonsense=False,
+            invalid_json=True,
+            reason="missing rest_api_list or rest_api_set field",
+            raw=raw,
+        )
 
     try:
         rest_api_list = _string_tuple(rest_api_value, rest_api_field)

--- a/igc/modules/base/metric_keys.py
+++ b/igc/modules/base/metric_keys.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 PHASE1_PRETRAIN = "phase1_pretrain"
 PHASE2_GOAL_EXTRACT = "phase2_goal_extract"
+PHASE2_LABELLED_REQUESTS = "phase2_labelled_requests"
 PHASE3_ARGUMENT_EXTRACT = "phase3_argument_extract"
 
 
@@ -54,6 +55,23 @@ PHASE2_WANDB_METRIC_KEYS = (
     phase_metric(PHASE2_GOAL_EXTRACT, "eval", "missing_allowed_methods_rate"),
     phase_metric(PHASE2_GOAL_EXTRACT, "order", "kendall_tau"),
     phase_metric(PHASE2_GOAL_EXTRACT, "order", "edit_distance"),
+)
+
+PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS = (
+    phase_metric(PHASE2_LABELLED_REQUESTS, "build", "draft_total"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "build", "accepted_total"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "build", "rejected_total"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "nonsense_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "invalid_json_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "pro_accept_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "rest_api_set_match_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "empty_set_match_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "sample_width", "k"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "vendor", "source_corpus"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "spec", "prompt_spec_version"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "model", "model_x_artifact_sha"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "judge", "model"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "judge", "profile"),
 )
 
 PHASE3_WANDB_METRIC_KEYS = (

--- a/tests/ds/test_phase2_labelled_requests.py
+++ b/tests/ds/test_phase2_labelled_requests.py
@@ -188,6 +188,27 @@ def test_pro_judge_result_parser_counts_malformed_rest_api_fields_as_invalid(
     assert field_name in result.reason
 
 
+def test_pro_judge_result_parser_counts_missing_rest_api_field_as_invalid() -> None:
+    """A judge response with neither rest_api_list nor rest_api_set is invalid.
+
+    Regression: the parser used to substitute an empty list, so a bare
+    {"accepted": true} could accept a hard-negative row (expected []) with no
+    REST API evidence from the judge at all.
+    """
+    result = parse_pro_judge_result(
+        json.dumps({"accepted": True, "nonsense": False}),
+        expected_rest_apis=[],
+    )
+    assert not result.valid_json
+    assert result.invalid_json
+    assert not result.accepted
+    assert not result.pro_accept
+    assert not result.rest_api_set_match
+    assert not result.empty_set_match
+    assert result.rest_api_list == ()
+    assert "rest_api_list or rest_api_set" in result.reason
+
+
 def test_nonsense_invalid_and_acceptance_counters_emit_phase2_metrics() -> None:
     """Counters produce W&B-safe keys without opening a live W&B run."""
     spec = load_phase2_labelled_requests_spec(CONFIG_PATH)

--- a/tests/ds/test_phase2_labelled_requests.py
+++ b/tests/ds/test_phase2_labelled_requests.py
@@ -1,0 +1,219 @@
+"""Offline tests for Phase 2 labelled request dataset plumbing.
+
+The tests pin the dataset-builder contract without model calls, W&B writes, GPU
+work, or live Redfish traffic.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+
+import pytest
+
+from igc.ds.phase2_labelled_requests import (
+    Phase2LabelledRequestCounters,
+    Phase2RestApiRecord,
+    load_phase2_labelled_requests_spec,
+    parse_pro_judge_result,
+    render_phase2_prompt,
+    rest_api_sets_equal,
+    sample_rest_api_records,
+)
+from igc.modules.base.metric_keys import phase_metric
+
+
+CONFIG_PATH = Path(__file__).parents[2] / "configs" / "phase2_labelled_requests.yaml"
+
+
+def _record(index: int, vendor: str = "dell") -> Phase2RestApiRecord:
+    """Build a small public-safe Redfish record fixture."""
+    rest_api = f"/redfish/v1/Systems/{index}"
+    return Phase2RestApiRecord(
+        rest_api=rest_api,
+        allowed_methods=("GET", "HEAD"),
+        json_body={
+            "@odata.id": rest_api,
+            "@odata.type": "#ComputerSystem.v1_20_0.ComputerSystem",
+            "Name": f"System {index}",
+        },
+        vendor=vendor,
+        source_corpus="unit_fixture",
+    )
+
+
+def test_prompt_spec_loading_uses_yaml_contract() -> None:
+    """The runtime spec comes from the YAML file under configs."""
+    spec = load_phase2_labelled_requests_spec(CONFIG_PATH)
+
+    assert spec.dataset_name == "phase2_labelled_requests"
+    assert spec.sample_widths == (1, 2, 3)
+    assert spec.wandb["namespace"] == "phase2_labelled_requests"
+    assert spec.model_x["artifact_sha"] == "fixture-model-x-sha256"
+    assert spec.judge["profile"] == "max_reasoning"
+    assert "draft_human_request" in spec.prompts
+    assert "pro_judge_set_match" in spec.prompts
+    assert spec.acceptance_thresholds["rest_api_set_match_rate_min"] == 0.98
+
+    sample = sample_rest_api_records(
+        [_record(1), _record(2)],
+        k=2,
+        rng=random.Random(3),
+        allowed_widths=spec.sample_widths,
+    )
+    prompt = render_phase2_prompt(spec, "draft_human_request", sample)
+
+    assert "/redfish/v1/Systems/1" in prompt
+    assert "/redfish/v1/Systems/2" in prompt
+    assert "fixture-model-x-sha256" not in prompt
+
+
+def test_sampling_supports_only_configured_widths_one_two_and_three() -> None:
+    """The builder samples one, two, or three REST API records without replacement."""
+    spec = load_phase2_labelled_requests_spec(CONFIG_PATH)
+    records = [_record(1), _record(2), _record(3), _record(4)]
+
+    for width in spec.sample_widths:
+        sample = sample_rest_api_records(
+            records,
+            k=width,
+            rng=random.Random(width),
+            allowed_widths=spec.sample_widths,
+        )
+        assert len(sample.records) == width
+        assert len(set(sample.rest_api_list)) == width
+        assert sample.sample_width == width
+
+    with pytest.raises(ValueError, match="sample width"):
+        sample_rest_api_records(
+            records,
+            k=4,
+            rng=random.Random(4),
+            allowed_widths=spec.sample_widths,
+        )
+
+
+def test_rest_api_set_comparison_is_unordered_and_empty_sets_match() -> None:
+    """Phase 2 judges REST API set equality, with empty set equal to empty set."""
+    assert rest_api_sets_equal(
+        ["/redfish/v1/Systems", "/redfish/v1/TaskService/Tasks"],
+        ["/redfish/v1/TaskService/Tasks", "/redfish/v1/Systems"],
+    )
+    assert rest_api_sets_equal([], [])
+    assert not rest_api_sets_equal(["/redfish/v1/Systems"], [])
+    assert not rest_api_sets_equal(["/redfish/v1/Systems"], ["/redfish/v1/Chassis"])
+
+
+def test_pro_judge_result_parser_handles_accept_reject_empty_and_invalid_json() -> None:
+    """Private judge output parsing is deterministic and side-effect free."""
+    accepted = parse_pro_judge_result(
+        json.dumps({
+            "accepted": True,
+            "rest_api_list": ["/redfish/v1/Systems", "/redfish/v1/Managers"],
+            "nonsense": False,
+            "reason": "The request names both resources.",
+        }),
+        expected_rest_apis=["/redfish/v1/Managers", "/redfish/v1/Systems"],
+    )
+    assert accepted.valid_json
+    assert accepted.accepted
+    assert accepted.pro_accept
+    assert accepted.rest_api_set_match
+    assert not accepted.empty_set_match
+
+    empty = parse_pro_judge_result(
+        json.dumps({
+            "accepted": True,
+            "rest_api_list": [],
+            "nonsense": False,
+        }),
+        expected_rest_apis=[],
+    )
+    assert empty.empty_set_match
+    assert empty.rest_api_set_match
+
+    nonsense = parse_pro_judge_result(
+        json.dumps({
+            "accepted": False,
+            "rest_api_list": [],
+            "nonsense": True,
+            "reason": "Draft text is not a request.",
+        }),
+        expected_rest_apis=["/redfish/v1/Systems"],
+    )
+    assert nonsense.valid_json
+    assert nonsense.nonsense
+    assert not nonsense.accepted
+
+    invalid = parse_pro_judge_result("{not json", expected_rest_apis=["/redfish/v1/Systems"])
+    assert invalid.invalid_json
+    assert not invalid.accepted
+    assert not invalid.pro_accept
+
+
+def test_nonsense_invalid_and_acceptance_counters_emit_phase2_metrics() -> None:
+    """Counters produce W&B-safe keys without opening a live W&B run."""
+    spec = load_phase2_labelled_requests_spec(CONFIG_PATH)
+    counters = Phase2LabelledRequestCounters()
+    accepted = parse_pro_judge_result(
+        json.dumps({
+            "accepted": True,
+            "rest_api_list": ["/redfish/v1/Systems"],
+            "nonsense": False,
+        }),
+        expected_rest_apis=["/redfish/v1/Systems"],
+    )
+    nonsense = parse_pro_judge_result(
+        json.dumps({
+            "accepted": False,
+            "rest_api_list": [],
+            "nonsense": True,
+        }),
+        expected_rest_apis=["/redfish/v1/Managers"],
+    )
+    invalid = parse_pro_judge_result("{bad", expected_rest_apis=["/redfish/v1/Chassis"])
+
+    counters.record_outcome(
+        accepted,
+        sample_width=1,
+        vendor="dell",
+        source_corpus="unit_fixture",
+        spec=spec,
+    )
+    counters.record_outcome(
+        nonsense,
+        sample_width=2,
+        vendor="hpe",
+        source_corpus="unit_fixture",
+        spec=spec,
+    )
+    counters.record_outcome(
+        invalid,
+        sample_width=3,
+        vendor="supermicro",
+        source_corpus="unit_fixture",
+        spec=spec,
+    )
+
+    metrics = counters.to_wandb_metrics(spec)
+    namespace = spec.wandb["namespace"]
+
+    assert metrics[phase_metric(namespace, "build", "draft_total")] == 3
+    assert metrics[phase_metric(namespace, "build", "accepted_total")] == 1
+    assert metrics[phase_metric(namespace, "build", "rejected_total")] == 2
+    assert metrics[phase_metric(namespace, "eval", "nonsense_rate")] == pytest.approx(1 / 3)
+    assert metrics[phase_metric(namespace, "eval", "invalid_json_rate")] == pytest.approx(1 / 3)
+    assert metrics[phase_metric(namespace, "eval", "pro_accept_rate")] == pytest.approx(1 / 3)
+    assert metrics[phase_metric(namespace, "eval", "rest_api_set_match_rate")] == pytest.approx(1 / 3)
+    assert metrics[phase_metric(namespace, "sample_width", "k")] == 3
+    assert metrics[phase_metric(namespace, "vendor", "source_corpus")] == (
+        "supermicro/unit_fixture"
+    )
+    assert metrics[phase_metric(namespace, "spec", "prompt_spec_version")] == spec.version
+    assert metrics[phase_metric(namespace, "model", "model_x_artifact_sha")] == (
+        "fixture-model-x-sha256"
+    )
+    assert metrics[phase_metric(namespace, "judge", "profile")] == "max_reasoning"

--- a/tests/ds/test_phase2_labelled_requests.py
+++ b/tests/ds/test_phase2_labelled_requests.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import random
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -152,6 +153,39 @@ def test_pro_judge_result_parser_handles_accept_reject_empty_and_invalid_json() 
     assert invalid.invalid_json
     assert not invalid.accepted
     assert not invalid.pro_accept
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value"),
+    (
+        ("rest_api_list", "/redfish/v1/Systems"),
+        ("rest_api_list", ["/redfish/v1/Systems", 7]),
+        ("rest_api_list", None),
+        ("rest_api_set", "/redfish/v1/Systems"),
+        ("rest_api_set", ["/redfish/v1/Systems", 7]),
+        ("rest_api_set", None),
+    ),
+)
+def test_pro_judge_result_parser_counts_malformed_rest_api_fields_as_invalid(
+    field_name: str,
+    field_value: Any,
+) -> None:
+    """Malformed judge fields are counted as invalid output, not raised errors."""
+    result = parse_pro_judge_result(
+        json.dumps({
+            "accepted": True,
+            field_name: field_value,
+            "nonsense": False,
+        }),
+        expected_rest_apis=[],
+    )
+    assert not result.valid_json
+    assert result.invalid_json
+    assert not result.accepted
+    assert not result.pro_accept
+    assert not result.rest_api_set_match
+    assert result.rest_api_list == ()
+    assert field_name in result.reason
 
 
 def test_nonsense_invalid_and_acceptance_counters_emit_phase2_metrics() -> None:

--- a/tests/modules/test_phase2_labelled_request_metric_keys.py
+++ b/tests/modules/test_phase2_labelled_request_metric_keys.py
@@ -1,0 +1,39 @@
+"""Metric keys for Phase 2 labelled request dataset generation.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from igc.modules.base.metric_keys import (
+    PHASE2_LABELLED_REQUESTS,
+    PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS,
+    phase_metric,
+)
+
+
+def test_phase2_labelled_request_registry_keeps_required_metric_names() -> None:
+    """The offline builder has stable W&B key names for counters and metadata."""
+    keys = set(PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS)
+
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "build", "draft_total") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "build", "accepted_total") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "build", "rejected_total") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "nonsense_rate") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "invalid_json_rate") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "pro_accept_rate") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "rest_api_set_match_rate") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "empty_set_match_rate") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "sample_width", "k") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "vendor", "source_corpus") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "spec", "prompt_spec_version") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "model", "model_x_artifact_sha") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "judge", "model") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "judge", "profile") in keys
+
+
+def test_phase2_labelled_request_registry_uses_canonical_namespace() -> None:
+    """New Phase 2 labelled request keys use the canonical namespace only."""
+    assert PHASE2_LABELLED_REQUESTS == "phase2_labelled_requests"
+    assert all(
+        key.startswith("phase2_labelled_requests/")
+        for key in PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS
+    )


### PR DESCRIPTION
Adds `igc/ds/phase2_labelled_requests.py`: Phase 2 labelled-request dataset plumbing (D1 rows pairing drafted request text with the sampled REST API set) plus Phase 2 metric keys in the `phase2_goal_extraction` namespace.

Second commit hardens the judge-output parser: malformed judge `rest_api_list`/`rest_api_set` fields and explicit JSON `null` are counted as invalid judge output instead of raising `Phase2LabelledRequestsSpecError` or being accepted as an empty set, so offline dataset generation keeps going and reports invalid-output counts.

Gate: offline suite green in a clean worktree at head 2af49bf — 739 passed, 29 deselected, 8 xfailed; ruff clean on changed files.

Supersedes branch `codex/phase2-labelled-requests` (same base commit rebased; this branch adds the parser hardening).