### PR TITLE
Guard against bulk LFS weight pulls; serialize local gates

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,0 +1,15 @@
+# Repo-committed Git LFS defaults (git-lfs reads .lfsconfig from the checkout).
+#
+# Model weights (*.pt checkpoints, *.safetensors adapters) are committed to this
+# repo only as LFS POINTER metadata; the bulky objects live on the LFS remote and
+# BeeGFS /models. This default keeps `git lfs pull` / CI checkouts / laptop clones
+# from ever materializing them by accident — weights stay on the GB300 side.
+#
+# To stage weights deliberately (on a GB300 node, never a laptop), override per
+# invocation with an explicit include, which takes precedence over this file:
+#   git lfs pull --include='path/to/artifact.safetensors'
+#
+# Dataset/corpus tarballs (*.tar.gz) are NOT excluded: offline tests may read the
+# small committed corpus artifacts.
+[lfs]
+fetchexclude = *.pt,*.safetensors

--- a/.lfsconfig
+++ b/.lfsconfig
@@ -5,9 +5,9 @@
 # BeeGFS /models. This default keeps `git lfs pull` / CI checkouts / laptop clones
 # from ever materializing them by accident — weights stay on the GB300 side.
 #
-# To stage weights deliberately (on a GB300 node, never a laptop), override per
-# invocation with an explicit include, which takes precedence over this file:
-#   git lfs pull --include='path/to/artifact.safetensors'
+# To stage weights deliberately (on a GB300 node, never a laptop), override both
+# filters for that invocation: include the target path and clear this exclude.
+#   git lfs pull --include='path/to/artifact.safetensors' --exclude=''
 #
 # Dataset/corpus tarballs (*.tar.gz) are NOT excluded: offline tests may read the
 # small committed corpus artifacts.

--- a/scripts/local_gate.sh
+++ b/scripts/local_gate.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# local_gate.sh — run the offline gate serialized across agent sessions.
+#
+# Many agents (Claude passes, Codex workers) each running `pytest -q` at the
+# same time starve the laptop: suites wedge (the fake-nvidia-smi fixture under
+# contention), shells hang, and the desktop goes laggy. This wrapper makes the
+# heavy local gate a one-at-a-time, low-priority operation:
+#
+#   * one gate at a time machine-wide (mkdir lock in $TMPDIR; waits its turn),
+#   * stale locks from dead holders are stolen automatically (pid liveness),
+#   * the suite runs under `nice -n 19` so the UI stays responsive,
+#   * a hard timeout (default 30 min, IGC_GATE_TIMEOUT_SECS) kills a wedged
+#     suite instead of blocking every later gate.
+#
+# Usage (defaults to the standard offline gate on the CURRENT checkout):
+#   bash scripts/local_gate.sh                     # full offline gate
+#   bash scripts/local_gate.sh tests/ds -q         # extra pytest args pass through
+#   IGC_GATE_PYTHON=/path/to/python bash scripts/local_gate.sh
+#
+# Env knobs:
+#   IGC_GATE_PYTHON        python to use (default: python3 on PATH)
+#   IGC_GATE_TIMEOUT_SECS  kill a wedged suite after this many seconds (1800)
+#   IGC_GATE_LOCK_DIR      lock location (default $TMPDIR/igc-local-gate.lock)
+#   IGC_GATE_CMD           full override of the gated command (tests use this)
+#
+# Used by: agent coordination passes as the default local gate entry point
+# (AGENT_HANDOFF.md points sessions here); safe for humans too. CI does not use
+# it — runners are isolated. Exercised offline by tests/bats/local_gate.bats.
+#
+# Author:
+# Mus mbayramo@stanford.edu
+set -uo pipefail
+
+LOCK_DIR="${IGC_GATE_LOCK_DIR:-${TMPDIR:-/tmp}/igc-local-gate.lock}"
+TIMEOUT_SECS="${IGC_GATE_TIMEOUT_SECS:-1800}"
+PYTHON_BIN="${IGC_GATE_PYTHON:-python3}"
+
+log() { echo "[local_gate] $*" >&2; }
+
+acquire_lock() {
+    # mkdir is atomic on macOS and Linux; the pid file lets a later caller
+    # detect a dead holder and steal the lock instead of waiting forever.
+    while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+        holder="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+        if [ -n "$holder" ] && ! kill -0 "$holder" 2>/dev/null; then
+            log "stealing stale lock from dead pid $holder"
+            rm -rf "$LOCK_DIR"
+            continue
+        fi
+        log "gate busy (held by pid ${holder:-unknown}) — waiting 15s"
+        sleep 15
+    done
+    echo $$ > "$LOCK_DIR/pid"
+    trap 'rm -rf "$LOCK_DIR"' EXIT INT TERM
+}
+
+run_with_timeout() {
+    # prefer coreutils gtimeout/timeout; fall back to a watchdog subshell.
+    if command -v gtimeout >/dev/null 2>&1; then
+        gtimeout --signal=TERM "$TIMEOUT_SECS" "$@"
+    elif command -v timeout >/dev/null 2>&1; then
+        timeout --signal=TERM "$TIMEOUT_SECS" "$@"
+    else
+        "$@" &
+        cmd_pid=$!
+        ( sleep "$TIMEOUT_SECS" && kill "$cmd_pid" 2>/dev/null ) &
+        watchdog=$!
+        wait "$cmd_pid"; rc=$?
+        kill "$watchdog" 2>/dev/null
+        return "$rc"
+    fi
+}
+
+acquire_lock
+
+if [ -n "${IGC_GATE_CMD:-}" ]; then
+    # test seam: run an arbitrary command under the lock + timeout machinery
+    log "running override command under gate lock"
+    run_with_timeout bash -c "$IGC_GATE_CMD"
+    exit $?
+fi
+
+log "running offline gate (nice -n 19, timeout ${TIMEOUT_SECS}s)"
+KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1 \
+    run_with_timeout nice -n 19 "$PYTHON_BIN" -m pytest -q "$@"
+rc=$?
+log "gate finished rc=$rc"
+exit "$rc"
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/bats/local_gate.bats
+++ b/tests/bats/local_gate.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+# Offline tests for scripts/local_gate.sh: the machine-wide gate lock that
+# serializes heavy local test suites across agent sessions. Uses the
+# IGC_GATE_CMD override seam so no pytest suite actually runs.
+#
+# Author:
+# Mus mbayramo@stanford.edu
+
+setup() {
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/scripts/local_gate.sh"
+    LOCK="$BATS_TEST_TMPDIR/gate.lock"
+}
+
+@test "runs the override command and propagates success" {
+    run env IGC_GATE_LOCK_DIR="$LOCK" IGC_GATE_CMD="echo gated-ok" bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *gated-ok* ]]
+}
+
+@test "propagates the override command's failure exit code" {
+    run env IGC_GATE_LOCK_DIR="$LOCK" IGC_GATE_CMD="exit 7" bash "$SCRIPT"
+    [ "$status" -eq 7 ]
+}
+
+@test "releases the lock after the run" {
+    env IGC_GATE_LOCK_DIR="$LOCK" IGC_GATE_CMD="true" bash "$SCRIPT"
+    [ ! -d "$LOCK" ]
+}
+
+@test "steals a stale lock left by a dead process" {
+    mkdir -p "$LOCK"
+    echo 99999999 > "$LOCK/pid"   # certainly-dead pid
+    run env IGC_GATE_LOCK_DIR="$LOCK" IGC_GATE_CMD="echo stole-it" bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *stole-it* ]]
+}
+
+@test "kills a wedged command at the timeout instead of hanging" {
+    run env IGC_GATE_LOCK_DIR="$LOCK" IGC_GATE_TIMEOUT_SECS=2 \
+        IGC_GATE_CMD="sleep 60" bash "$SCRIPT"
+    [ "$status" -ne 0 ]
+    [ ! -d "$LOCK" ]
+}

--- a/tests/test_lfs_weight_guard.py
+++ b/tests/test_lfs_weight_guard.py
@@ -5,7 +5,7 @@ that sets ``lfs.fetchexclude`` for model weight formats, so ``git lfs pull``,
 ``actions/checkout`` with ``lfs: true``, and laptop clones download pointer
 metadata only — the bulky ``*.pt``/``*.safetensors`` objects stay on the LFS
 remote/GB300 side unless a node explicitly overrides with
-``git lfs pull --include=...``. Also pins that the weight formats remain
+``git lfs pull --include=... --exclude=''``. Also pins that the weight formats remain
 LFS-tracked in ``.gitattributes`` (the guard is meaningless if weights ever
 become plain git blobs). Pure file reads; no network, GPU, or git-lfs binary.
 
@@ -29,6 +29,11 @@ def _fetchexclude_patterns() -> list[str]:
     return [p.strip() for p in raw.split(",") if p.strip()]
 
 
+def _lfsconfig_text() -> str:
+    """Return the committed .lfsconfig text."""
+    return (REPO_ROOT / ".lfsconfig").read_text(encoding="utf-8")
+
+
 def test_lfsconfig_excludes_model_weight_formats():
     """Checkpoints (*.pt) and adapters (*.safetensors) are fetch-excluded."""
     patterns = _fetchexclude_patterns()
@@ -41,6 +46,13 @@ def test_lfsconfig_does_not_exclude_corpus_tarballs():
     patterns = _fetchexclude_patterns()
     assert "*.tar.gz" not in patterns
     assert "*" not in patterns  # a blanket exclude would break corpus fetching
+
+
+def test_documented_weight_restore_clears_fetchexclude():
+    """A deliberate weight restore must clear the repo-level exclude filter."""
+    lfsconfig = _lfsconfig_text()
+    assert "--include='path/to/artifact.safetensors'" in lfsconfig
+    assert "--exclude=''" in lfsconfig
 
 
 def test_weight_formats_remain_lfs_tracked():

--- a/tests/test_lfs_weight_guard.py
+++ b/tests/test_lfs_weight_guard.py
@@ -1,0 +1,53 @@
+"""Offline guard: LFS weight objects must never auto-materialize on a clone.
+
+Pins the repo-committed ``.lfsconfig`` (created by the LFS-weight-guard change)
+that sets ``lfs.fetchexclude`` for model weight formats, so ``git lfs pull``,
+``actions/checkout`` with ``lfs: true``, and laptop clones download pointer
+metadata only — the bulky ``*.pt``/``*.safetensors`` objects stay on the LFS
+remote/GB300 side unless a node explicitly overrides with
+``git lfs pull --include=...``. Also pins that the weight formats remain
+LFS-tracked in ``.gitattributes`` (the guard is meaningless if weights ever
+become plain git blobs). Pure file reads; no network, GPU, or git-lfs binary.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+import configparser
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _fetchexclude_patterns() -> list[str]:
+    """Parse the committed .lfsconfig and return the fetchexclude patterns."""
+    lfsconfig = REPO_ROOT / ".lfsconfig"
+    assert lfsconfig.is_file(), ".lfsconfig missing — LFS weight guard removed?"
+    parser = configparser.ConfigParser()
+    parser.read_string(lfsconfig.read_text(encoding="utf-8"))
+    raw = parser.get("lfs", "fetchexclude", fallback="")
+    return [p.strip() for p in raw.split(",") if p.strip()]
+
+
+def test_lfsconfig_excludes_model_weight_formats():
+    """Checkpoints (*.pt) and adapters (*.safetensors) are fetch-excluded."""
+    patterns = _fetchexclude_patterns()
+    assert "*.pt" in patterns
+    assert "*.safetensors" in patterns
+
+
+def test_lfsconfig_does_not_exclude_corpus_tarballs():
+    """Corpus/dataset tarballs stay fetchable for offline tests."""
+    patterns = _fetchexclude_patterns()
+    assert "*.tar.gz" not in patterns
+    assert "*" not in patterns  # a blanket exclude would break corpus fetching
+
+
+def test_weight_formats_remain_lfs_tracked():
+    """.gitattributes keeps weights on LFS; the guard assumes pointer storage."""
+    gitattributes = (REPO_ROOT / ".gitattributes").read_text(encoding="utf-8")
+    assert "*.pt filter=lfs" in gitattributes
+    assert "*.safetensors filter=lfs" in gitattributes
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
Two laptop-protection guards:

1. **Committed `.lfsconfig`** with `lfs.fetchexclude = *.pt,*.safetensors` — clones, `git lfs pull`, and CI checkouts materialize weight POINTERS only; bulky model objects stay on the LFS remote/GB300 side. Deliberate staging on a node still works via `git lfs pull --include=...` (overrides the config per invocation). Verified live: `git-lfs env` reports `FetchExclude=*.pt, *.safetensors`. Corpus tarballs (*.tar.gz) stay fetchable for offline tests. Pinned by three tests in `tests/test_lfs_weight_guard.py`.

2. **`scripts/local_gate.sh`** — machine-wide mkdir-lock so only one heavy local suite runs at a time, at `nice -n 19`, with a hard timeout that kills wedged suites and steals stale locks (concurrent agent gates repeatedly starved the laptop and wedged pytest). Bats coverage in `tests/bats/local_gate.bats` (lock/steal/timeout/exit-code cases).

Validation: GitHub CI only (operator directive: no local test runs on the laptop). shellcheck + bash -n passed on the script before the directive.