### PR TITLE
Add Phase 1 golden acceptance producer

### DIFF
--- a/configs/inference/phase1_golden_acceptance.yaml
+++ b/configs/inference/phase1_golden_acceptance.yaml
@@ -1,0 +1,20 @@
+schema_version: phase1_golden_acceptance.v1
+name: phase1_golden_acceptance
+phase: 1
+task: redfish_json_reconstruction
+metrics:
+  ece_bins: 10
+thresholds:
+  min_rows: 1
+  max_missing_target_rows: 0
+  max_missing_prediction_rows: 0
+  min_model_json_parse_rate: 1.0
+  min_model_json_exact_match_rate: 0.0
+  min_model_odata_id_match_rate: 1.0
+  min_model_eval_tokens_per_sec:
+  min_model_eval_samples_per_sec:
+  max_model_ece:
+  max_model_latency_sec_p95:
+  min_exact_match_delta_vs_baseline: 0.0
+  min_parse_rate_delta_vs_baseline: 0.0
+  min_odata_id_delta_vs_baseline: 0.0

--- a/docs/phase_1.md
+++ b/docs/phase_1.md
@@ -107,11 +107,12 @@ cross-entropy only on the `y_true` JSON completion.
 
 Use the `PHASE1_WANDB_METRIC_KEYS` registry, defined in
 `igc/modules/base/metric_keys.py`, for metrics that the current Phase 1 training
-surface tracks or reserves.
+surface tracks directly.
 The live registry keeps Phase 1 curves separate from goal extraction or RL:
 
-Current Phase 1 has the W&B namespace and basic training/eval metrics, but it does
-not yet have the full train/validation/test/calibration gate.
+Current Phase 1 has the W&B namespace, basic training/eval metrics, and the
+offline held-out prediction producer for reconstruction, throughput, data-shape,
+calibration, and test-time evidence.
 
 - `phase1_finetune/train/loss`
 - `phase1_finetune/train/epoch_loss`
@@ -125,10 +126,12 @@ not yet have the full train/validation/test/calibration gate.
 - `phase1_finetune/throughput/train_tokens_per_sec`
 - `phase1_finetune/throughput/train_samples_per_sec`
 
-The acceptance gate below still requires reconstruction, throughput, data-shape,
-calibration, and test-time evidence before a full Phase 1 run is accepted. These
-metric names are intentionally not in the live registry until the producer code
-lands:
+The held-out producer in `scripts/phase1_inference_gate.py` consumes existing
+baseline and `model_x` prediction JSONL artifacts, compares them under the
+spec in `configs/inference/phase1_golden_acceptance.yaml`, and writes compact
+metrics/evidence to caller-supplied paths. These keys are listed in
+`PHASE1_ACCEPTANCE_METRIC_KEYS`, defined in
+`igc/modules/base/metric_keys.py`, and emitted by the producer:
 
 - `phase1_finetune/eval/top_k_accuracy`
 - `phase1_finetune/eval/json_parse_rate`

--- a/igc/modules/base/metric_keys.py
+++ b/igc/modules/base/metric_keys.py
@@ -16,18 +16,19 @@ PHASE2_LABELLED_REQUESTS = "phase2_labelled_requests"
 PHASE3_ARGUMENT_EXTRACT = "phase3_argument_extraction"
 
 
-def phase_metric(namespace: str, group: str, name: str) -> str:
-    """Return a stable ``<namespace>/<group>/<name>`` metric key.
+def phase_metric(namespace: str, group: str, name: str | None = None) -> str:
+    """Return a stable slash-separated metric key.
 
     :param namespace: Phase namespace, for example :data:`PHASE1_FINETUNE`.
-    :param group: Metric group such as ``train`` or ``eval``.
-    :param name: Metric name inside the group.
+    :param group: Metric group or metric name.
+    :param name: Optional metric name inside the group.
     :return: Slash-separated W&B/TensorBoard metric key.
     :raises ValueError: if any component is empty.
     """
-    if not namespace or not group or not name:
-        raise ValueError("metric namespace, group, and name must be non-empty")
-    return f"{namespace}/{group}/{name}"
+    parts = (namespace, group) if name is None else (namespace, group, name)
+    if any(not part for part in parts):
+        raise ValueError("metric key components must be non-empty")
+    return "/".join(parts)
 
 
 PHASE1_WANDB_METRIC_KEYS = (
@@ -44,6 +45,25 @@ PHASE1_WANDB_METRIC_KEYS = (
     phase_metric(PHASE1_FINETUNE, "throughput", "train_samples_per_sec"),
 )
 
+PHASE1_ACCEPTANCE_METRIC_KEYS = (
+    phase_metric(PHASE1_FINETUNE, "eval", "top_k_accuracy"),
+    phase_metric(PHASE1_FINETUNE, "eval", "json_parse_rate"),
+    phase_metric(PHASE1_FINETUNE, "eval", "json_exact_match_rate"),
+    phase_metric(PHASE1_FINETUNE, "eval", "odata_id_match_rate"),
+    phase_metric(PHASE1_FINETUNE, "throughput", "eval_tokens_per_sec"),
+    phase_metric(PHASE1_FINETUNE, "throughput", "eval_samples_per_sec"),
+    phase_metric(PHASE1_FINETUNE, "data", "padding_ratio"),
+    phase_metric(PHASE1_FINETUNE, "data", "mean_sequence_length"),
+    phase_metric(PHASE1_FINETUNE, "data", "max_sequence_length"),
+    phase_metric(PHASE1_FINETUNE, "calibration", "log_prob_per_token"),
+    phase_metric(PHASE1_FINETUNE, "calibration", "ece"),
+    phase_metric(PHASE1_FINETUNE, "test", "latency_sec_p50"),
+    phase_metric(PHASE1_FINETUNE, "test", "latency_sec_p95"),
+    phase_metric(PHASE1_FINETUNE, "test", "memory_peak_mb"),
+)
+
+PHASE1_ALL_METRIC_KEYS = PHASE1_WANDB_METRIC_KEYS + PHASE1_ACCEPTANCE_METRIC_KEYS
+
 PHASE2_WANDB_METRIC_KEYS = (
     phase_metric(PHASE2_GOAL_EXTRACT, "train", "loss"),
     phase_metric(PHASE2_GOAL_EXTRACT, "train", "perplexity"),
@@ -59,18 +79,18 @@ PHASE2_WANDB_METRIC_KEYS = (
 )
 
 PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS = (
-    phase_metric(PHASE2_LABELLED_REQUESTS, "build", "draft_total"),
-    phase_metric(PHASE2_LABELLED_REQUESTS, "build", "accepted_total"),
-    phase_metric(PHASE2_LABELLED_REQUESTS, "build", "rejected_total"),
-    phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "nonsense_rate"),
-    phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "invalid_json_rate"),
-    phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "pro_accept_rate"),
-    phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "rest_api_set_match_rate"),
-    phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "empty_set_match_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "draft_total"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "accepted_total"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "rejected_total"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "nonsense_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "invalid_json_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "pro_accept_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "rest_api_set_match_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "empty_set_match_rate"),
     phase_metric(PHASE2_LABELLED_REQUESTS, "sample_width", "k"),
     phase_metric(PHASE2_LABELLED_REQUESTS, "vendor", "source_corpus"),
-    phase_metric(PHASE2_LABELLED_REQUESTS, "spec", "prompt_spec_version"),
-    phase_metric(PHASE2_LABELLED_REQUESTS, "model", "model_x_artifact_sha"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "prompt_spec_version"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "model_x", "artifact_sha"),
     phase_metric(PHASE2_LABELLED_REQUESTS, "judge", "model"),
     phase_metric(PHASE2_LABELLED_REQUESTS, "judge", "profile"),
 )

--- a/igc/modules/train/phase1_acceptance.py
+++ b/igc/modules/train/phase1_acceptance.py
@@ -1,0 +1,203 @@
+"""Spec-driven Phase 1 golden acceptance checks.
+
+The acceptance layer consumes the compact payload from
+``igc.modules.train.phase1_golden`` and evaluates only configured thresholds.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from igc.modules.base.metric_keys import PHASE1_FINETUNE, phase_metric
+
+
+class Phase1AcceptanceError(ValueError):
+    """Raised when an acceptance spec is malformed."""
+
+
+@dataclass(frozen=True)
+class AcceptanceSpec:
+    """Thresholds for one Phase 1 held-out acceptance run."""
+
+    thresholds: Mapping[str, Any]
+    ece_bins: int = 10
+
+    @classmethod
+    def from_mapping(cls, spec: Mapping[str, Any] | None) -> "AcceptanceSpec":
+        """Build an acceptance spec from YAML/JSON mapping data."""
+        root = spec or {}
+        if not isinstance(root, Mapping):
+            raise Phase1AcceptanceError("acceptance spec must be a mapping")
+        metrics = root.get("metrics") or {}
+        if not isinstance(metrics, Mapping):
+            raise Phase1AcceptanceError("metrics spec must be a mapping")
+        thresholds = root.get("thresholds") or {}
+        if not isinstance(thresholds, Mapping):
+            raise Phase1AcceptanceError("thresholds spec must be a mapping")
+        ece_bins = int(metrics.get("ece_bins", 10))
+        if ece_bins <= 0:
+            raise Phase1AcceptanceError("metrics.ece_bins must be positive")
+        return cls(thresholds=thresholds, ece_bins=ece_bins)
+
+
+def evaluate_acceptance(
+    payload: Mapping[str, Any],
+    spec: AcceptanceSpec,
+) -> dict[str, Any]:
+    """Evaluate configured checks against a Phase 1 metrics payload."""
+    checks: list[dict[str, Any]] = []
+    metrics = _mapping(payload.get("metrics"), "metrics")
+    evidence = _mapping(payload.get("evidence"), "evidence")
+    comparison = _mapping(payload.get("comparison"), "comparison")
+    model_metrics = _mapping(metrics.get("model_x"), "metrics.model_x")
+    delta = _mapping(comparison.get("delta"), "comparison.delta")
+    model_evidence = _mapping(evidence.get("model_x"), "evidence.model_x")
+    model_counts = _mapping(model_evidence.get("counts"), "evidence.model_x.counts")
+    thresholds = spec.thresholds
+
+    _add_min_check(checks, "min_rows", model_counts.get("rows"), thresholds.get("min_rows"))
+    _add_max_check(
+        checks,
+        "max_missing_target_rows",
+        model_metrics.get("missing_target_rows"),
+        thresholds.get("max_missing_target_rows"),
+    )
+    _add_max_check(
+        checks,
+        "max_missing_prediction_rows",
+        model_metrics.get("missing_prediction_rows"),
+        thresholds.get("max_missing_prediction_rows"),
+    )
+    _add_min_check(
+        checks,
+        "min_model_json_parse_rate",
+        model_metrics.get(phase_metric(PHASE1_FINETUNE, "eval", "json_parse_rate")),
+        thresholds.get("min_model_json_parse_rate"),
+    )
+    _add_min_check(
+        checks,
+        "min_model_json_exact_match_rate",
+        model_metrics.get(phase_metric(PHASE1_FINETUNE, "eval", "json_exact_match_rate")),
+        thresholds.get("min_model_json_exact_match_rate"),
+    )
+    _add_min_check(
+        checks,
+        "min_model_odata_id_match_rate",
+        model_metrics.get(phase_metric(PHASE1_FINETUNE, "eval", "odata_id_match_rate")),
+        thresholds.get("min_model_odata_id_match_rate"),
+    )
+    _add_min_check(
+        checks,
+        "min_model_eval_tokens_per_sec",
+        model_metrics.get(phase_metric(PHASE1_FINETUNE, "throughput", "eval_tokens_per_sec")),
+        thresholds.get("min_model_eval_tokens_per_sec"),
+    )
+    _add_min_check(
+        checks,
+        "min_model_eval_samples_per_sec",
+        model_metrics.get(phase_metric(PHASE1_FINETUNE, "throughput", "eval_samples_per_sec")),
+        thresholds.get("min_model_eval_samples_per_sec"),
+    )
+    _add_max_check(
+        checks,
+        "max_model_ece",
+        model_metrics.get(phase_metric(PHASE1_FINETUNE, "calibration", "ece")),
+        thresholds.get("max_model_ece"),
+    )
+    _add_max_check(
+        checks,
+        "max_model_latency_sec_p95",
+        model_metrics.get(phase_metric(PHASE1_FINETUNE, "test", "latency_sec_p95")),
+        thresholds.get("max_model_latency_sec_p95"),
+    )
+    _add_min_check(
+        checks,
+        "min_exact_match_delta_vs_baseline",
+        delta.get(phase_metric(PHASE1_FINETUNE, "eval", "json_exact_match_rate")),
+        thresholds.get("min_exact_match_delta_vs_baseline"),
+    )
+    _add_min_check(
+        checks,
+        "min_parse_rate_delta_vs_baseline",
+        delta.get(phase_metric(PHASE1_FINETUNE, "eval", "json_parse_rate")),
+        thresholds.get("min_parse_rate_delta_vs_baseline"),
+    )
+    _add_min_check(
+        checks,
+        "min_odata_id_delta_vs_baseline",
+        delta.get(phase_metric(PHASE1_FINETUNE, "eval", "odata_id_match_rate")),
+        thresholds.get("min_odata_id_delta_vs_baseline"),
+    )
+
+    failures = [check for check in checks if not check["passed"]]
+    return {
+        "schema_version": "phase1_golden_acceptance.v1",
+        "status": "pass" if not failures else "fail",
+        "checks": checks,
+        "failures": failures,
+    }
+
+
+def _mapping(value: Any, name: str) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise Phase1AcceptanceError(f"{name} must be a mapping")
+    return value
+
+
+def _add_min_check(
+    checks: list[dict[str, Any]],
+    name: str,
+    observed: Any,
+    threshold: Any,
+) -> None:
+    if threshold is None:
+        return
+    checks.append(
+        _check(name, observed, threshold, ">=", _number(observed) >= _number(threshold))
+    )
+
+
+def _add_max_check(
+    checks: list[dict[str, Any]],
+    name: str,
+    observed: Any,
+    threshold: Any,
+) -> None:
+    if threshold is None:
+        return
+    checks.append(
+        _check(name, observed, threshold, "<=", _number(observed) <= _number(threshold))
+    )
+
+
+def _check(
+    name: str,
+    observed: Any,
+    threshold: Any,
+    operator: str,
+    passed: bool,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "operator": operator,
+        "observed": observed,
+        "threshold": threshold,
+        "passed": bool(passed),
+    }
+
+
+def _number(value: Any) -> float:
+    if value is None or isinstance(value, bool):
+        return float("nan")
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float("nan")
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/igc/modules/train/phase1_golden.py
+++ b/igc/modules/train/phase1_golden.py
@@ -1,0 +1,753 @@
+"""Offline Phase 1 held-out prediction metrics.
+
+This module consumes already-produced Phase 1 prediction JSONL artifacts. It
+does not load a model, touch a GPU, call W&B, or read corpora. Rows are matched
+by an explicit row id when present, otherwise by JSONL position.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from statistics import mean
+from typing import Any, Iterable, Mapping
+
+from igc.modules.base.metric_keys import PHASE1_FINETUNE, phase_metric
+
+JsonValue = Any
+
+
+class Phase1GoldenError(ValueError):
+    """Raised when a prediction artifact cannot be evaluated safely."""
+
+
+@dataclass(frozen=True)
+class PredictionRecord:
+    """Normalized view of one Phase 1 prediction row."""
+
+    key: str
+    line_number: int
+    rest_api: str
+    target_json: JsonValue | None
+    prediction_json: JsonValue | None
+    parse_ok: bool
+    parse_error: str = ""
+    exact_match: bool | None = None
+    odata_id_match: bool | None = None
+    top_k_match: bool | None = None
+    sequence_length: int | None = None
+    generated_tokens: int | None = None
+    padding_tokens: int | None = None
+    latency_sec: float | None = None
+    memory_peak_mb: float | None = None
+    confidence: float | None = None
+    log_prob: float | None = None
+    log_prob_per_token: float | None = None
+
+
+@dataclass(frozen=True)
+class ArtifactSummary:
+    """Public-safe metadata for an input JSONL artifact."""
+
+    role: str
+    name: str
+    sha256: str
+    bytes: int
+    rows: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable summary."""
+        return dict(self.__dict__)
+
+
+@dataclass
+class ArtifactMetrics:
+    """Metrics computed for one prediction artifact."""
+
+    role: str
+    artifact: ArtifactSummary
+    row_count: int
+    parsed_rows: int
+    missing_target_rows: int
+    missing_prediction_rows: int
+    exact_match_count: int
+    exact_match_rows: int
+    odata_id_match_count: int
+    odata_id_rows: int
+    top_k_match_count: int
+    top_k_rows: int
+    total_generated_tokens: int
+    total_latency_sec: float
+    sequence_lengths: list[int] = field(default_factory=list)
+    padding_ratios: list[float] = field(default_factory=list)
+    latencies_sec: list[float] = field(default_factory=list)
+    memory_peaks_mb: list[float] = field(default_factory=list)
+    row_log_prob_per_token: list[tuple[float, int]] = field(default_factory=list)
+    calibration_pairs: list[tuple[float, bool]] = field(default_factory=list)
+
+    def _rate(self, numerator: int, denominator: int) -> float | None:
+        return None if denominator == 0 else numerator / denominator
+
+    def to_metric_dict(self, *, ece_bins: int = 10) -> dict[str, float | int | None]:
+        """Return standard Phase 1 metric keys for this artifact."""
+        return {
+            "row_count": self.row_count,
+            "missing_target_rows": self.missing_target_rows,
+            "missing_prediction_rows": self.missing_prediction_rows,
+            phase_metric(PHASE1_FINETUNE, "eval", "json_parse_rate"): (
+                self._rate(self.parsed_rows, self.row_count)
+            ),
+            phase_metric(PHASE1_FINETUNE, "eval", "json_exact_match_rate"): (
+                self._rate(self.exact_match_count, self.exact_match_rows)
+            ),
+            phase_metric(PHASE1_FINETUNE, "eval", "odata_id_match_rate"): (
+                self._rate(self.odata_id_match_count, self.odata_id_rows)
+            ),
+            phase_metric(PHASE1_FINETUNE, "eval", "top_k_accuracy"): (
+                self._rate(self.top_k_match_count, self.top_k_rows)
+            ),
+            phase_metric(PHASE1_FINETUNE, "throughput", "eval_tokens_per_sec"): (
+                None
+                if self.total_latency_sec <= 0
+                else self.total_generated_tokens / self.total_latency_sec
+            ),
+            phase_metric(PHASE1_FINETUNE, "throughput", "eval_samples_per_sec"): (
+                None if self.total_latency_sec <= 0 else self.row_count / self.total_latency_sec
+            ),
+            phase_metric(PHASE1_FINETUNE, "data", "padding_ratio"): (
+                None if not self.padding_ratios else mean(self.padding_ratios)
+            ),
+            phase_metric(PHASE1_FINETUNE, "data", "mean_sequence_length"): (
+                None if not self.sequence_lengths else mean(self.sequence_lengths)
+            ),
+            phase_metric(PHASE1_FINETUNE, "data", "max_sequence_length"): (
+                None if not self.sequence_lengths else max(self.sequence_lengths)
+            ),
+            phase_metric(PHASE1_FINETUNE, "calibration", "log_prob_per_token"): (
+                _weighted_mean(self.row_log_prob_per_token)
+            ),
+            phase_metric(PHASE1_FINETUNE, "calibration", "ece"): (
+                expected_calibration_error(self.calibration_pairs, bins=ece_bins)
+            ),
+            phase_metric(PHASE1_FINETUNE, "test", "latency_sec_p50"): percentile(
+                self.latencies_sec,
+                50,
+            ),
+            phase_metric(PHASE1_FINETUNE, "test", "latency_sec_p95"): percentile(
+                self.latencies_sec,
+                95,
+            ),
+            phase_metric(PHASE1_FINETUNE, "test", "memory_peak_mb"): (
+                None if not self.memory_peaks_mb else max(self.memory_peaks_mb)
+            ),
+        }
+
+    def to_evidence_dict(self, *, ece_bins: int = 10) -> dict[str, Any]:
+        """Return compact evidence for artifact-level metrics."""
+        return {
+            "artifact": self.artifact.to_dict(),
+            "counts": {
+                "rows": self.row_count,
+                "parsed_rows": self.parsed_rows,
+                "missing_target_rows": self.missing_target_rows,
+                "missing_prediction_rows": self.missing_prediction_rows,
+                "exact_match_rows": self.exact_match_rows,
+                "exact_match_count": self.exact_match_count,
+                "odata_id_rows": self.odata_id_rows,
+                "odata_id_match_count": self.odata_id_match_count,
+                "top_k_rows": self.top_k_rows,
+                "top_k_match_count": self.top_k_match_count,
+            },
+            "metrics": self.to_metric_dict(ece_bins=ece_bins),
+        }
+
+
+def _weighted_mean(values: Iterable[tuple[float, int]]) -> float | None:
+    total_weight = 0
+    total = 0.0
+    for value, weight in values:
+        if weight <= 0:
+            continue
+        total += value * weight
+        total_weight += weight
+    return None if total_weight == 0 else total / total_weight
+
+
+def percentile(values: Iterable[float], pct: float) -> float | None:
+    """Return a linear-interpolated percentile for non-empty values."""
+    ordered = sorted(values)
+    if not ordered:
+        return None
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (len(ordered) - 1) * pct / 100.0
+    lower = int(rank)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = rank - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
+
+
+def expected_calibration_error(
+    pairs: Iterable[tuple[float, bool]],
+    *,
+    bins: int = 10,
+) -> float | None:
+    """Compute equal-width ECE from ``(confidence, correct)`` pairs."""
+    clean = [(conf, correct) for conf, correct in pairs if 0.0 <= conf <= 1.0]
+    if not clean:
+        return None
+    if bins <= 0:
+        raise Phase1GoldenError("ece bins must be positive")
+    total = len(clean)
+    ece = 0.0
+    for index in range(bins):
+        low = index / bins
+        high = (index + 1) / bins
+        if index == bins - 1:
+            bucket = [(c, ok) for c, ok in clean if low <= c <= high]
+        else:
+            bucket = [(c, ok) for c, ok in clean if low <= c < high]
+        if not bucket:
+            continue
+        confidence = mean(c for c, _ in bucket)
+        accuracy = mean(1.0 if ok else 0.0 for _, ok in bucket)
+        ece += (len(bucket) / total) * abs(accuracy - confidence)
+    return ece
+
+
+def artifact_summary(path: str | Path, role: str, rows: int) -> ArtifactSummary:
+    """Hash a JSONL artifact without exposing its parent path."""
+    p = Path(path)
+    digest = hashlib.sha256()
+    size = 0
+    with p.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            size += len(chunk)
+            digest.update(chunk)
+    return ArtifactSummary(
+        role=role,
+        name=p.name,
+        sha256=digest.hexdigest(),
+        bytes=size,
+        rows=rows,
+    )
+
+
+def load_prediction_rows(path: str | Path) -> list[dict[str, Any]]:
+    """Load a non-empty JSONL prediction artifact."""
+    rows: list[dict[str, Any]] = []
+    p = Path(path)
+    with p.open(encoding="utf-8") as fh:
+        for line_number, line in enumerate(fh, start=1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as err:
+                raise Phase1GoldenError(
+                    f"{p.name}:{line_number}: invalid JSONL row"
+                ) from err
+            if not isinstance(row, dict):
+                raise Phase1GoldenError(
+                    f"{p.name}:{line_number}: prediction row must be an object"
+                )
+            rows.append(row)
+    if not rows:
+        raise Phase1GoldenError(f"{p.name}: no prediction rows")
+    return rows
+
+
+def evaluate_prediction_jsonl(
+    path: str | Path,
+    *,
+    role: str,
+    ece_bins: int = 10,
+) -> ArtifactMetrics:
+    """Evaluate one Phase 1 prediction JSONL artifact."""
+    raw_rows = load_prediction_rows(path)
+    records = [normalize_prediction_row(row, index) for index, row in enumerate(raw_rows)]
+    metrics = _metrics_from_records(
+        role=role,
+        records=records,
+        artifact=artifact_summary(path, role, len(records)),
+    )
+    if ece_bins <= 0:
+        raise Phase1GoldenError("ece bins must be positive")
+    return metrics
+
+
+def _metrics_from_records(
+    *,
+    role: str,
+    records: list[PredictionRecord],
+    artifact: ArtifactSummary,
+) -> ArtifactMetrics:
+    metrics = ArtifactMetrics(
+        role=role,
+        artifact=artifact,
+        row_count=len(records),
+        parsed_rows=sum(1 for record in records if record.parse_ok),
+        missing_target_rows=sum(1 for record in records if record.target_json is None),
+        missing_prediction_rows=sum(1 for record in records if not record.parse_ok),
+        exact_match_count=sum(1 for record in records if record.exact_match is True),
+        exact_match_rows=sum(1 for record in records if record.exact_match is not None),
+        odata_id_match_count=sum(1 for record in records if record.odata_id_match is True),
+        odata_id_rows=sum(1 for record in records if record.odata_id_match is not None),
+        top_k_match_count=sum(1 for record in records if record.top_k_match is True),
+        top_k_rows=sum(1 for record in records if record.top_k_match is not None),
+        total_generated_tokens=sum(record.generated_tokens or 0 for record in records),
+        total_latency_sec=sum(record.latency_sec or 0.0 for record in records),
+    )
+    metrics.latencies_sec.extend(
+        record.latency_sec for record in records if record.latency_sec is not None
+    )
+    metrics.sequence_lengths.extend(
+        record.sequence_length for record in records if record.sequence_length is not None
+    )
+    metrics.padding_ratios.extend(_padding_ratios(records))
+    metrics.memory_peaks_mb.extend(
+        record.memory_peak_mb for record in records if record.memory_peak_mb is not None
+    )
+    metrics.row_log_prob_per_token.extend(_log_prob_values(records))
+    metrics.calibration_pairs.extend(
+        (record.confidence, record.exact_match)
+        for record in records
+        if record.confidence is not None and record.exact_match is not None
+    )
+    return metrics
+
+
+def normalize_prediction_row(row: Mapping[str, Any], index: int) -> PredictionRecord:
+    """Normalize one raw prediction row into evaluator fields."""
+    target = _target_json(row)
+    rest_api = _rest_api(row, target)
+    prediction_raw = _prediction_value(row)
+    prediction_json, parse_ok, parse_error = parse_json_value(prediction_raw)
+    exact_match = None
+    if target is not None:
+        exact_match = parse_ok and prediction_json == target
+    odata_match = _odata_id_match(prediction_json, rest_api) if parse_ok else False
+    if not rest_api:
+        odata_match = None
+    generated_tokens = _int_from_paths(row, _GENERATED_TOKEN_PATHS)
+    sequence_length = _int_from_paths(row, _SEQUENCE_LENGTH_PATHS)
+    padding_tokens = _int_from_paths(row, _PADDING_TOKEN_PATHS)
+    return PredictionRecord(
+        key=_row_key(row, index),
+        line_number=index + 1,
+        rest_api=rest_api,
+        target_json=target,
+        prediction_json=prediction_json,
+        parse_ok=parse_ok,
+        parse_error=parse_error,
+        exact_match=exact_match,
+        odata_id_match=odata_match,
+        top_k_match=_top_k_match(row, target),
+        sequence_length=sequence_length,
+        generated_tokens=generated_tokens,
+        padding_tokens=padding_tokens,
+        latency_sec=_float_from_paths(row, _LATENCY_PATHS),
+        memory_peak_mb=_float_from_paths(row, _MEMORY_PATHS),
+        confidence=_confidence(row),
+        log_prob=_float_from_paths(row, _LOG_PROB_PATHS),
+        log_prob_per_token=_float_from_paths(row, _LOG_PROB_PER_TOKEN_PATHS),
+    )
+
+
+def compare_prediction_artifacts(
+    baseline: ArtifactMetrics,
+    model: ArtifactMetrics,
+    *,
+    ece_bins: int = 10,
+) -> dict[str, Any]:
+    """Compare baseline and ``model_x`` metrics."""
+    baseline_metrics = baseline.to_metric_dict(ece_bins=ece_bins)
+    model_metrics = model.to_metric_dict(ece_bins=ece_bins)
+    delta: dict[str, float | None] = {}
+    for key, model_value in model_metrics.items():
+        baseline_value = baseline_metrics.get(key)
+        if isinstance(model_value, (int, float)) and isinstance(baseline_value, (int, float)):
+            delta[key] = model_value - baseline_value
+        else:
+            delta[key] = None
+    return {
+        "baseline_role": baseline.role,
+        "model_role": model.role,
+        "row_count_delta": model.row_count - baseline.row_count,
+        "delta": delta,
+    }
+
+
+def build_phase1_golden_payload(
+    *,
+    baseline_jsonl: str | Path,
+    model_jsonl: str | Path,
+    ece_bins: int = 10,
+) -> dict[str, Any]:
+    """Compute baseline-vs-model_x metrics and compact evidence."""
+    baseline = evaluate_prediction_jsonl(
+        baseline_jsonl,
+        role="baseline",
+        ece_bins=ece_bins,
+    )
+    model = evaluate_prediction_jsonl(
+        model_jsonl,
+        role="model_x",
+        ece_bins=ece_bins,
+    )
+    return {
+        "schema_version": "phase1_golden_metrics.v1",
+        "phase": 1,
+        "task": "redfish_json_reconstruction",
+        "metric_namespace": PHASE1_FINETUNE,
+        "metrics": {
+            "baseline": baseline.to_metric_dict(ece_bins=ece_bins),
+            "model_x": model.to_metric_dict(ece_bins=ece_bins),
+        },
+        "comparison": compare_prediction_artifacts(
+            baseline,
+            model,
+            ece_bins=ece_bins,
+        ),
+        "evidence": {
+            "baseline": baseline.to_evidence_dict(ece_bins=ece_bins),
+            "model_x": model.to_evidence_dict(ece_bins=ece_bins),
+        },
+    }
+
+
+def write_json(path: str | Path, payload: Mapping[str, Any]) -> None:
+    """Write a compact JSON payload."""
+    with Path(path).open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+
+
+def parse_json_value(value: Any) -> tuple[JsonValue | None, bool, str]:
+    """Parse a prediction value as JSON, allowing a single fenced/object fragment."""
+    if value is None:
+        return None, False, "missing prediction"
+    if isinstance(value, (dict, list)):
+        return value, True, ""
+    if not isinstance(value, str):
+        return None, False, f"unsupported prediction type {type(value).__name__}"
+    text = _strip_fence(value.strip())
+    try:
+        return json.loads(text), True, ""
+    except json.JSONDecodeError:
+        fragment = _first_json_fragment(text)
+        if fragment is None:
+            return None, False, "prediction is not JSON"
+        try:
+            return json.loads(fragment), True, ""
+        except json.JSONDecodeError as err:
+            return None, False, f"prediction JSON parse failed: {err.msg}"
+
+
+def _strip_fence(text: str) -> str:
+    if not text.startswith("```"):
+        return text
+    lines = text.splitlines()
+    if len(lines) >= 3 and lines[-1].strip() == "```":
+        return "\n".join(lines[1:-1]).strip()
+    return text
+
+
+def _first_json_fragment(text: str) -> str | None:
+    start = _first_json_start(text)
+    if start is None:
+        return None
+    stack: list[str] = []
+    in_string = False
+    escape = False
+    for index, char in enumerate(text[start:], start=start):
+        if in_string:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+            continue
+        if char in "{[":
+            stack.append("}" if char == "{" else "]")
+            continue
+        if char in "}]":
+            if not stack or char != stack[-1]:
+                return None
+            stack.pop()
+            if not stack:
+                return text[start : index + 1]
+    return None
+
+
+def _first_json_start(text: str) -> int | None:
+    """Return the first JSON opener that is not inside surrounding quotes."""
+    in_string = False
+    escape = False
+    for index, char in enumerate(text):
+        if in_string:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+            continue
+        if char in "{[":
+            return index
+    return None
+
+
+def _target_json(row: Mapping[str, Any]) -> JsonValue | None:
+    value = _first_path(
+        row,
+        (
+            ("y_true", "json"),
+            ("target", "json"),
+            ("expected", "json"),
+            ("reference", "json"),
+            ("y_true",),
+            ("target",),
+            ("expected",),
+            ("reference",),
+        ),
+    )
+    parsed, ok, _ = parse_json_value(value)
+    return parsed if ok else None
+
+
+def _prediction_value(row: Mapping[str, Any]) -> Any:
+    return _first_path(
+        row,
+        (
+            ("y_pred", "json"),
+            ("y_pred", "redfish_json"),
+            ("y_pred", "output_json"),
+            ("y_pred", "prediction"),
+            ("y_pred", "text"),
+            ("y_pred", "raw"),
+            ("prediction", "json"),
+            ("prediction", "text"),
+            ("prediction", "raw"),
+            ("prediction",),
+            ("predicted_json",),
+            ("output_json",),
+            ("generated_json",),
+            ("generated_text",),
+            ("completion",),
+            ("output",),
+            ("y_pred",),
+        ),
+    )
+
+
+def _rest_api(row: Mapping[str, Any], target: JsonValue | None) -> str:
+    value = _first_path(row, (("x", "rest_api"), ("rest_api",), ("uri",), ("url",)))
+    if isinstance(value, str) and value:
+        return value
+    if isinstance(target, dict) and isinstance(target.get("@odata.id"), str):
+        return target["@odata.id"]
+    return ""
+
+
+def _row_key(row: Mapping[str, Any], index: int) -> str:
+    value = _first_path(
+        row,
+        (("id",), ("row_id",), ("sample_id",), ("example_id",), ("uid",)),
+    )
+    return str(value) if value is not None else str(index)
+
+
+def _odata_id_match(prediction: JsonValue | None, rest_api: str) -> bool | None:
+    if not rest_api:
+        return None
+    if not isinstance(prediction, dict):
+        return False
+    return prediction.get("@odata.id") == rest_api
+
+
+def _top_k_match(row: Mapping[str, Any], target: JsonValue | None) -> bool | None:
+    if target is None:
+        return None
+    candidates = _first_path(
+        row,
+        (
+            ("y_pred_top_k",),
+            ("top_k_predictions",),
+            ("top_k",),
+            ("candidates",),
+            ("prediction", "top_k"),
+            ("y_pred", "top_k"),
+        ),
+    )
+    if candidates is None:
+        return None
+    if not isinstance(candidates, list):
+        return False
+    for candidate in candidates:
+        candidate_json, ok, _ = parse_json_value(_unwrap_prediction_candidate(candidate))
+        if ok and candidate_json == target:
+            return True
+    return False
+
+
+def _unwrap_prediction_candidate(candidate: Any) -> Any:
+    if not isinstance(candidate, dict):
+        return candidate
+    return _first_path(
+        candidate,
+        (
+            ("json",),
+            ("redfish_json",),
+            ("prediction",),
+            ("text",),
+            ("raw",),
+        ),
+        default=candidate,
+    )
+
+
+def _padding_ratios(records: Iterable[PredictionRecord]) -> list[float]:
+    ratios = []
+    for record in records:
+        if record.sequence_length and record.padding_tokens is not None:
+            ratios.append(record.padding_tokens / record.sequence_length)
+    return ratios
+
+
+def _log_prob_values(records: Iterable[PredictionRecord]) -> list[tuple[float, int]]:
+    values = []
+    for record in records:
+        weight = record.generated_tokens or record.sequence_length or 1
+        if record.log_prob_per_token is not None:
+            values.append((record.log_prob_per_token, weight))
+        elif record.log_prob is not None and weight > 0:
+            values.append((record.log_prob / weight, weight))
+    return values
+
+
+def _confidence(row: Mapping[str, Any]) -> float | None:
+    value = _float_from_paths(
+        row,
+        (
+            ("confidence",),
+            ("probability",),
+            ("mean_token_probability",),
+            ("calibration", "confidence"),
+            ("metrics", "confidence"),
+            ("y_pred", "confidence"),
+            ("prediction", "confidence"),
+        ),
+    )
+    if value is None:
+        return None
+    return max(0.0, min(1.0, value))
+
+
+def _first_path(
+    row: Mapping[str, Any],
+    paths: Iterable[tuple[str, ...]],
+    *,
+    default: Any = None,
+) -> Any:
+    for path in paths:
+        current: Any = row
+        found = True
+        for key in path:
+            if not isinstance(current, Mapping) or key not in current:
+                found = False
+                break
+            current = current[key]
+        if found:
+            return current
+    return default
+
+
+def _float_from_paths(
+    row: Mapping[str, Any],
+    paths: Iterable[tuple[str, ...]],
+) -> float | None:
+    value = _first_path(row, paths)
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _int_from_paths(
+    row: Mapping[str, Any],
+    paths: Iterable[tuple[str, ...]],
+) -> int | None:
+    value = _float_from_paths(row, paths)
+    if value is None:
+        return None
+    return int(value)
+
+
+_GENERATED_TOKEN_PATHS = (
+    ("generated_tokens",),
+    ("completion_tokens",),
+    ("output_tokens",),
+    ("tokens", "generated"),
+    ("usage", "completion_tokens"),
+    ("metrics", "generated_tokens"),
+)
+
+_SEQUENCE_LENGTH_PATHS = (
+    ("sequence_length",),
+    ("seq_len",),
+    ("tokens", "sequence_length"),
+    ("usage", "total_tokens"),
+    ("metrics", "sequence_length"),
+)
+
+_PADDING_TOKEN_PATHS = (
+    ("padding_tokens",),
+    ("tokens", "padding"),
+    ("metrics", "padding_tokens"),
+)
+
+_LATENCY_PATHS = (
+    ("latency_sec",),
+    ("elapsed_sec",),
+    ("duration_sec",),
+    ("test_time_sec",),
+    ("metrics", "latency_sec"),
+    ("timing", "latency_sec"),
+)
+
+_MEMORY_PATHS = (
+    ("memory_peak_mb",),
+    ("peak_memory_mb",),
+    ("metrics", "memory_peak_mb"),
+)
+
+_LOG_PROB_PATHS = (
+    ("log_prob",),
+    ("logprob",),
+    ("sequence_log_prob",),
+    ("completion_log_prob",),
+    ("metrics", "log_prob"),
+)
+
+_LOG_PROB_PER_TOKEN_PATHS = (
+    ("log_prob_per_token",),
+    ("mean_log_prob",),
+    ("metrics", "log_prob_per_token"),
+)
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/scripts/phase1_inference_gate.py
+++ b/scripts/phase1_inference_gate.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Evaluate Phase 1 held-out prediction JSONL artifacts offline."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Any
+
+import yaml
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from igc.modules.train.phase1_acceptance import (  # noqa: E402
+    AcceptanceSpec,
+    Phase1AcceptanceError,
+    evaluate_acceptance,
+)
+from igc.modules.train.phase1_golden import (  # noqa: E402
+    Phase1GoldenError,
+    build_phase1_golden_payload,
+    write_json,
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--spec", required=True, help="YAML metric/threshold spec.")
+    parser.add_argument(
+        "--baseline-jsonl",
+        required=True,
+        help="Already-produced baseline prediction JSONL artifact.",
+    )
+    parser.add_argument(
+        "--model-jsonl",
+        required=True,
+        help="Already-produced model_x prediction JSONL artifact.",
+    )
+    parser.add_argument(
+        "--metrics-out",
+        required=True,
+        help="Output JSON path for compact baseline/model_x metric tables.",
+    )
+    parser.add_argument(
+        "--evidence-out",
+        required=True,
+        help="Output JSON path for artifact summaries and acceptance checks.",
+    )
+    parser.add_argument(
+        "--report-only",
+        action="store_true",
+        help="Return 0 after writing evidence even if acceptance checks fail.",
+    )
+    return parser.parse_args(argv)
+
+
+def load_spec(path: str | Path) -> dict[str, Any]:
+    """Load the YAML spec as a mapping."""
+    with Path(path).open(encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    if not isinstance(data, dict):
+        raise Phase1AcceptanceError("spec root must be a mapping")
+    return data
+
+
+def build_outputs(
+    *,
+    spec_path: str | Path,
+    baseline_jsonl: str | Path,
+    model_jsonl: str | Path,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build the metrics and evidence payloads for CLI callers."""
+    spec_root = load_spec(spec_path)
+    spec = AcceptanceSpec.from_mapping(spec_root)
+    metrics_payload = build_phase1_golden_payload(
+        baseline_jsonl=baseline_jsonl,
+        model_jsonl=model_jsonl,
+        ece_bins=spec.ece_bins,
+    )
+    acceptance = evaluate_acceptance(metrics_payload, spec)
+    evidence = {
+        "schema_version": "phase1_inference_gate_evidence.v1",
+        "phase": 1,
+        "task": metrics_payload["task"],
+        "metric_namespace": metrics_payload["metric_namespace"],
+        "spec": {
+            "name": spec_root.get("name", ""),
+            "schema_version": spec_root.get("schema_version", ""),
+            "ece_bins": spec.ece_bins,
+            "thresholds": dict(spec.thresholds),
+        },
+        "artifacts": {
+            "baseline": metrics_payload["evidence"]["baseline"]["artifact"],
+            "model_x": metrics_payload["evidence"]["model_x"]["artifact"],
+        },
+        "counts": {
+            "baseline": metrics_payload["evidence"]["baseline"]["counts"],
+            "model_x": metrics_payload["evidence"]["model_x"]["counts"],
+        },
+        "comparison": metrics_payload["comparison"],
+        "acceptance": acceptance,
+    }
+    metrics_out = {
+        "schema_version": metrics_payload["schema_version"],
+        "phase": metrics_payload["phase"],
+        "task": metrics_payload["task"],
+        "metric_namespace": metrics_payload["metric_namespace"],
+        "metrics": metrics_payload["metrics"],
+        "comparison": metrics_payload["comparison"],
+    }
+    return metrics_out, evidence
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = parse_args(argv)
+    try:
+        metrics_payload, evidence = build_outputs(
+            spec_path=args.spec,
+            baseline_jsonl=args.baseline_jsonl,
+            model_jsonl=args.model_jsonl,
+        )
+        write_json(args.metrics_out, metrics_payload)
+        write_json(args.evidence_out, evidence)
+    except (OSError, Phase1AcceptanceError, Phase1GoldenError) as exc:
+        print(f"PHASE1 INFERENCE GATE ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    status = evidence["acceptance"]["status"]
+    print(json.dumps({"status": status, "evidence_out": args.evidence_out}, sort_keys=True))
+    if status != "pass" and not args.report_only:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_phase1_metric_keys.py
+++ b/tests/modules/test_phase1_metric_keys.py
@@ -1,9 +1,11 @@
-"""Phase 1 metric-key registry must not advertise known dead tuples.
+"""Phase 1 metric-key registry includes the committed acceptance producer keys.
 
 Author:
 Mus mbayramo@stanford.edu
 """
 from igc.modules.base.metric_keys import (
+    PHASE1_ACCEPTANCE_METRIC_KEYS,
+    PHASE1_ALL_METRIC_KEYS,
     PHASE1_FINETUNE,
     PHASE1_WANDB_METRIC_KEYS,
     phase_metric,
@@ -19,13 +21,23 @@ def test_phase1_metric_registry_keeps_expected_live_keys() -> None:
     assert phase_metric(PHASE1_FINETUNE, "throughput", "train_tokens_per_sec") in keys
 
 
-def test_phase1_metric_registry_omits_unwired_structural_keys() -> None:
-    """Do not advertise structural/data metrics until a real producer lands."""
-    keys = set(PHASE1_WANDB_METRIC_KEYS)
-    assert phase_metric(PHASE1_FINETUNE, "eval", "json_parse_rate") not in keys
-    assert phase_metric(PHASE1_FINETUNE, "eval", "json_exact_match_rate") not in keys
-    assert phase_metric(PHASE1_FINETUNE, "eval", "odata_id_match_rate") not in keys
-    assert phase_metric(PHASE1_FINETUNE, "data", "padding_ratio") not in keys
+def test_phase1_metric_registry_includes_golden_acceptance_keys() -> None:
+    """The offline held-out producer emits the acceptance metric family."""
+    keys = set(PHASE1_ACCEPTANCE_METRIC_KEYS)
+    assert phase_metric(PHASE1_FINETUNE, "eval", "json_parse_rate") in keys
+    assert phase_metric(PHASE1_FINETUNE, "eval", "json_exact_match_rate") in keys
+    assert phase_metric(PHASE1_FINETUNE, "eval", "odata_id_match_rate") in keys
+    assert phase_metric(PHASE1_FINETUNE, "throughput", "eval_tokens_per_sec") in keys
+    assert phase_metric(PHASE1_FINETUNE, "data", "padding_ratio") in keys
+    assert phase_metric(PHASE1_FINETUNE, "calibration", "ece") in keys
+    assert phase_metric(PHASE1_FINETUNE, "test", "latency_sec_p95") in keys
+
+
+def test_phase1_all_metric_keys_combines_live_and_acceptance_families() -> None:
+    """Consumers that want both families can opt into the combined registry."""
+    all_keys = set(PHASE1_ALL_METRIC_KEYS)
+    assert set(PHASE1_WANDB_METRIC_KEYS) < all_keys
+    assert set(PHASE1_ACCEPTANCE_METRIC_KEYS) < all_keys
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/modules/train/test_phase1_acceptance.py
+++ b/tests/modules/train/test_phase1_acceptance.py
@@ -1,0 +1,111 @@
+"""Offline tests for Phase 1 golden acceptance checks.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+from igc.modules.base.metric_keys import PHASE1_FINETUNE, phase_metric
+from igc.modules.train.phase1_acceptance import AcceptanceSpec, evaluate_acceptance
+
+
+def _payload() -> dict:
+    exact_key = phase_metric(PHASE1_FINETUNE, "eval", "json_exact_match_rate")
+    parse_key = phase_metric(PHASE1_FINETUNE, "eval", "json_parse_rate")
+    odata_key = phase_metric(PHASE1_FINETUNE, "eval", "odata_id_match_rate")
+    ece_key = phase_metric(PHASE1_FINETUNE, "calibration", "ece")
+    latency_key = phase_metric(PHASE1_FINETUNE, "test", "latency_sec_p95")
+    samples_key = phase_metric(PHASE1_FINETUNE, "throughput", "eval_samples_per_sec")
+    tokens_key = phase_metric(PHASE1_FINETUNE, "throughput", "eval_tokens_per_sec")
+    return {
+        "metrics": {
+            "model_x": {
+                "missing_target_rows": 0,
+                "missing_prediction_rows": 0,
+                exact_key: 0.9,
+                parse_key: 1.0,
+                odata_key: 1.0,
+                ece_key: 0.05,
+                latency_key: 1.2,
+                samples_key: 4.0,
+                tokens_key: 100.0,
+            }
+        },
+        "comparison": {
+            "delta": {
+                exact_key: 0.1,
+                parse_key: 0.0,
+                odata_key: 0.0,
+            }
+        },
+        "evidence": {"model_x": {"counts": {"rows": 10}}},
+    }
+
+
+def test_acceptance_passes_configured_thresholds() -> None:
+    """Configured thresholds pass when all observed values satisfy them."""
+    spec = AcceptanceSpec.from_mapping(
+        {
+            "metrics": {"ece_bins": 10},
+            "thresholds": {
+                "min_rows": 10,
+                "max_missing_target_rows": 0,
+                "max_missing_prediction_rows": 0,
+                "min_model_json_parse_rate": 1.0,
+                "min_model_json_exact_match_rate": 0.8,
+                "min_model_odata_id_match_rate": 1.0,
+                "max_model_ece": 0.1,
+                "max_model_latency_sec_p95": 2.0,
+                "min_model_eval_samples_per_sec": 1.0,
+                "min_model_eval_tokens_per_sec": 50.0,
+                "min_exact_match_delta_vs_baseline": 0.0,
+            },
+        }
+    )
+
+    result = evaluate_acceptance(_payload(), spec)
+    assert result["status"] == "pass"
+    assert result["checks"]
+    assert not result["failures"]
+
+
+def test_acceptance_fails_when_delta_threshold_is_not_met() -> None:
+    """A configured model-vs-baseline improvement threshold is enforced."""
+    spec = AcceptanceSpec.from_mapping(
+        {"thresholds": {"min_exact_match_delta_vs_baseline": 0.2}}
+    )
+    result = evaluate_acceptance(_payload(), spec)
+    assert result["status"] == "fail"
+    assert result["failures"][0]["name"] == "min_exact_match_delta_vs_baseline"
+
+
+def test_acceptance_fails_when_required_metric_is_absent() -> None:
+    """A configured threshold over a missing metric fails closed."""
+    payload = _payload()
+    exact_key = phase_metric(PHASE1_FINETUNE, "eval", "json_exact_match_rate")
+    del payload["metrics"]["model_x"][exact_key]
+    spec = AcceptanceSpec.from_mapping(
+        {"thresholds": {"min_model_json_exact_match_rate": 0.1}}
+    )
+
+    result = evaluate_acceptance(payload, spec)
+    assert result["status"] == "fail"
+    assert result["failures"][0]["observed"] is None
+
+
+def test_none_thresholds_are_report_only() -> None:
+    """Unset thresholds do not create checks."""
+    spec = AcceptanceSpec.from_mapping(
+        {
+            "thresholds": {
+                "min_rows": None,
+                "max_model_ece": None,
+            }
+        }
+    )
+    result = evaluate_acceptance(_payload(), spec)
+    assert result["status"] == "pass"
+    assert result["checks"] == []
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/modules/train/test_phase1_golden.py
+++ b/tests/modules/train/test_phase1_golden.py
@@ -1,0 +1,201 @@
+"""Offline tests for Phase 1 held-out prediction metrics.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from igc.modules.base.metric_keys import PHASE1_FINETUNE, phase_metric
+from igc.modules.train.phase1_golden import (
+    Phase1GoldenError,
+    build_phase1_golden_payload,
+    evaluate_prediction_jsonl,
+    expected_calibration_error,
+    parse_json_value,
+)
+
+
+def _target(rest_api: str, name: str) -> dict:
+    return {"@odata.id": rest_api, "Name": name}
+
+
+def _row(rest_api: str, prediction, **overrides) -> dict:
+    target = _target(rest_api, overrides.pop("target_name", rest_api.rsplit("/", 1)[-1]))
+    row = {
+        "id": rest_api,
+        "phase": 1,
+        "task": "redfish_json_reconstruction",
+        "x": {"rest_api": rest_api, "allowed_methods": ["GET"], "json": target},
+        "y_true": {"json": target},
+        "y_pred": {"json": prediction},
+        "generated_tokens": overrides.pop("generated_tokens", 10),
+        "sequence_length": overrides.pop("sequence_length", 12),
+        "padding_tokens": overrides.pop("padding_tokens", 1),
+        "latency_sec": overrides.pop("latency_sec", 1.0),
+        "memory_peak_mb": overrides.pop("memory_peak_mb", 128.0),
+        "confidence": overrides.pop("confidence", 0.9),
+        "log_prob": overrides.pop("log_prob", -5.0),
+    }
+    row.update(overrides)
+    return row
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> Path:
+    path.write_text("\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n")
+    return path
+
+
+def test_build_phase1_golden_payload_compares_baseline_and_model(tmp_path: Path) -> None:
+    """model_x metrics are emitted with deltas against the baseline artifact."""
+    rest_a = "/redfish/v1/Systems/1"
+    rest_b = "/redfish/v1/Managers/1"
+    baseline = _write_jsonl(
+        tmp_path / "baseline.jsonl",
+        [
+            _row(rest_a, _target(rest_a, "1"), generated_tokens=10, latency_sec=1.0),
+            _row(
+                rest_b,
+                {"@odata.id": rest_b, "Name": "wrong"},
+                generated_tokens=20,
+                latency_sec=2.0,
+                sequence_length=20,
+                padding_tokens=2,
+                confidence=0.7,
+            ),
+        ],
+    )
+    model = _write_jsonl(
+        tmp_path / "model_x.jsonl",
+        [
+            _row(
+                rest_a,
+                json.dumps(_target(rest_a, "1")),
+                generated_tokens=10,
+                latency_sec=1.0,
+                sequence_length=10,
+                padding_tokens=1,
+            ),
+            _row(
+                rest_b,
+                _target(rest_b, "1"),
+                target_name="1",
+                generated_tokens=20,
+                latency_sec=2.0,
+                sequence_length=20,
+                padding_tokens=2,
+                confidence=0.8,
+            ),
+        ],
+    )
+
+    payload = build_phase1_golden_payload(baseline_jsonl=baseline, model_jsonl=model)
+    model_metrics = payload["metrics"]["model_x"]
+    baseline_metrics = payload["metrics"]["baseline"]
+    exact_key = phase_metric(PHASE1_FINETUNE, "eval", "json_exact_match_rate")
+    throughput_key = phase_metric(PHASE1_FINETUNE, "throughput", "eval_tokens_per_sec")
+
+    assert payload["metric_namespace"] == PHASE1_FINETUNE
+    assert baseline_metrics[exact_key] == 0.5
+    assert model_metrics[exact_key] == 1.0
+    assert payload["comparison"]["delta"][exact_key] == 0.5
+    assert model_metrics[throughput_key] == pytest.approx(10.0)
+    assert model_metrics[phase_metric(PHASE1_FINETUNE, "data", "padding_ratio")] == 0.1
+    assert model_metrics[phase_metric(PHASE1_FINETUNE, "test", "latency_sec_p95")] == 1.95
+    assert payload["evidence"]["model_x"]["artifact"]["name"] == "model_x.jsonl"
+    assert "sha256" in payload["evidence"]["model_x"]["artifact"]
+
+
+def test_prediction_parser_accepts_fenced_json_fragment() -> None:
+    """Model outputs wrapped in text still parse when they contain one JSON object."""
+    parsed, ok, error = parse_json_value('prefix ```json\n{"a": 1}\n``` suffix')
+    assert ok, error
+    assert parsed == {"a": 1}
+
+
+def test_prediction_parser_skips_braces_inside_quoted_text() -> None:
+    """JSON fragment extraction starts outside surrounding quoted prose."""
+    parsed, ok, error = parse_json_value('"not {json}" then {"ok": true}')
+    assert ok, error
+    assert parsed == {"ok": True}
+
+
+def test_top_k_accuracy_is_reported_when_candidates_exist(tmp_path: Path) -> None:
+    """Top-k accuracy is optional and only uses rows with candidate lists."""
+    rest_api = "/redfish/v1/Systems/1"
+    target = _target(rest_api, "1")
+    path = _write_jsonl(
+        tmp_path / "topk.jsonl",
+        [
+            _row(
+                rest_api,
+                {"not": "correct"},
+                top_k_predictions=[{"json": {"not": "correct"}}, {"json": target}],
+            )
+        ],
+    )
+
+    metrics = evaluate_prediction_jsonl(path, role="model_x").to_metric_dict()
+    assert metrics[phase_metric(PHASE1_FINETUNE, "eval", "top_k_accuracy")] == 1.0
+
+
+def test_bad_jsonl_row_raises_clear_error(tmp_path: Path) -> None:
+    """Malformed JSONL rows fail closed."""
+    path = tmp_path / "bad.jsonl"
+    path.write_text("{not json}\n")
+    with pytest.raises(Phase1GoldenError, match="invalid JSONL row"):
+        evaluate_prediction_jsonl(path, role="model_x")
+
+
+def test_missing_prediction_counts_as_missing_prediction_row(tmp_path: Path) -> None:
+    """Rows with a target but no prediction are counted for fail-closed gates."""
+    rest_api = "/redfish/v1/Systems/1"
+    target = _target(rest_api, "1")
+    path = _write_jsonl(
+        tmp_path / "missing-prediction.jsonl",
+        [
+            {
+                "id": "missing",
+                "x": {"rest_api": rest_api, "json": target},
+                "y_true": {"json": target},
+            }
+        ],
+    )
+
+    metrics = evaluate_prediction_jsonl(path, role="model_x").to_metric_dict()
+    assert metrics["missing_prediction_rows"] == 1
+    assert metrics[phase_metric(PHASE1_FINETUNE, "eval", "json_parse_rate")] == 0.0
+
+
+def test_missing_target_is_not_filled_from_input_json(tmp_path: Path) -> None:
+    """Input JSON is context, not an implicit reconstruction target."""
+    rest_api = "/redfish/v1/Systems/1"
+    target = _target(rest_api, "1")
+    path = _write_jsonl(
+        tmp_path / "missing-target.jsonl",
+        [
+            {
+                "id": "missing-target",
+                "x": {"rest_api": rest_api, "json": target},
+                "y_pred": {"json": target},
+            }
+        ],
+    )
+
+    metrics = evaluate_prediction_jsonl(path, role="model_x").to_metric_dict()
+    assert metrics["missing_target_rows"] == 1
+    assert metrics[phase_metric(PHASE1_FINETUNE, "eval", "json_exact_match_rate")] is None
+
+
+def test_expected_calibration_error_uses_equal_width_bins() -> None:
+    """ECE uses absolute confidence/accuracy gaps weighted by bin population."""
+    assert expected_calibration_error([(0.9, True), (0.2, False)], bins=10) == pytest.approx(
+        0.15
+    )
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/scripts/test_phase1_inference_gate.py
+++ b/tests/scripts/test_phase1_inference_gate.py
@@ -1,0 +1,149 @@
+"""CLI tests for ``scripts/phase1_inference_gate.py``.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+from igc.modules.base.metric_keys import PHASE1_FINETUNE, phase_metric
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "phase1_inference_gate.py"
+
+
+def _load_script():
+    """Import the script as a module without requiring PYTHONPATH setup."""
+    spec = importlib.util.spec_from_file_location("phase1_inference_gate", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_jsonl(path: Path, *, exact: bool) -> Path:
+    rest_api = "/redfish/v1/Systems/1"
+    target = {"@odata.id": rest_api, "Name": "System"}
+    prediction = target if exact else {"@odata.id": rest_api, "Name": "Wrong"}
+    row = {
+        "id": "row-1",
+        "x": {"rest_api": rest_api, "json": target},
+        "y_true": {"json": target},
+        "y_pred": {"json": prediction},
+        "generated_tokens": 10,
+        "latency_sec": 1.0,
+        "confidence": 0.9,
+    }
+    path.write_text(json.dumps(row) + "\n")
+    return path
+
+
+def _write_spec(path: Path, *, exact_delta: float = 0.0) -> Path:
+    path.write_text(
+        "\n".join(
+            [
+                "schema_version: phase1_golden_acceptance.v1",
+                "metrics:",
+                "  ece_bins: 10",
+                "thresholds:",
+                "  min_rows: 1",
+                "  max_missing_target_rows: 0",
+                "  max_missing_prediction_rows: 0",
+                "  min_model_json_parse_rate: 1.0",
+                "  min_model_odata_id_match_rate: 1.0",
+                f"  min_exact_match_delta_vs_baseline: {exact_delta}",
+            ]
+        )
+        + "\n"
+    )
+    return path
+
+
+def test_phase1_inference_gate_writes_metrics_and_evidence(tmp_path: Path, capsys) -> None:
+    """The CLI writes compact JSON outputs and returns 0 for passing thresholds."""
+    script = _load_script()
+    baseline = _write_jsonl(tmp_path / "baseline.jsonl", exact=False)
+    model = _write_jsonl(tmp_path / "model_x.jsonl", exact=True)
+    spec = _write_spec(tmp_path / "spec.yaml", exact_delta=1.0)
+    metrics_out = tmp_path / "metrics.json"
+    evidence_out = tmp_path / "evidence.json"
+
+    code = script.main(
+        [
+            "--spec",
+            str(spec),
+            "--baseline-jsonl",
+            str(baseline),
+            "--model-jsonl",
+            str(model),
+            "--metrics-out",
+            str(metrics_out),
+            "--evidence-out",
+            str(evidence_out),
+        ]
+    )
+
+    assert code == 0
+    assert json.loads(capsys.readouterr().out)["status"] == "pass"
+    metrics = json.loads(metrics_out.read_text())
+    evidence = json.loads(evidence_out.read_text())
+    assert metrics["metrics"]["model_x"][
+        phase_metric(PHASE1_FINETUNE, "eval", "json_exact_match_rate")
+    ] == 1.0
+    assert evidence["acceptance"]["status"] == "pass"
+    assert evidence["artifacts"]["baseline"]["name"] == "baseline.jsonl"
+
+
+def test_phase1_inference_gate_returns_one_on_acceptance_failure(tmp_path: Path) -> None:
+    """Failed acceptance still writes evidence, then exits with code 1."""
+    script = _load_script()
+    baseline = _write_jsonl(tmp_path / "baseline.jsonl", exact=True)
+    model = _write_jsonl(tmp_path / "model_x.jsonl", exact=True)
+    spec = _write_spec(tmp_path / "spec.yaml", exact_delta=0.5)
+    evidence_out = tmp_path / "evidence.json"
+
+    code = script.main(
+        [
+            "--spec",
+            str(spec),
+            "--baseline-jsonl",
+            str(baseline),
+            "--model-jsonl",
+            str(model),
+            "--metrics-out",
+            str(tmp_path / "metrics.json"),
+            "--evidence-out",
+            str(evidence_out),
+        ]
+    )
+
+    assert code == 1
+    assert json.loads(evidence_out.read_text())["acceptance"]["status"] == "fail"
+
+
+def test_phase1_inference_gate_returns_two_for_missing_input(tmp_path: Path) -> None:
+    """Missing JSONL input returns the documented error code."""
+    script = _load_script()
+    spec = _write_spec(tmp_path / "spec.yaml")
+
+    code = script.main(
+        [
+            "--spec",
+            str(spec),
+            "--baseline-jsonl",
+            str(tmp_path / "missing-baseline.jsonl"),
+            "--model-jsonl",
+            str(tmp_path / "missing-model.jsonl"),
+            "--metrics-out",
+            str(tmp_path / "metrics.json"),
+            "--evidence-out",
+            str(tmp_path / "evidence.json"),
+        ]
+    )
+
+    assert code == 2
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
Adds the held-out baseline-vs-model_x golden comparison package plus the eval-throughput/calibration/test-time acceptance producer for Phase 1.

Evidence:
- Brain review 93b72bb412a03297: NO BLOCKING FINDINGS at head cff57c9
- Remote slot2 CPU-only validation (igc-dev-p1-golden-producer): git diff --check clean, focused pytest 18 passed, ruff on touched files passed
- Unblocks queue items P1-GOLDEN-001 and P1-GOLDEN-002