### PR TITLE
Add Phase 2 labelled-request live provider CLI and gates

### DIFF
--- a/configs/phase2_labelled_requests.yaml
+++ b/configs/phase2_labelled_requests.yaml
@@ -17,6 +17,28 @@ judge:
   model_id: ${PHASE2_JUDGE_MODEL_ID}
   profile: ${PHASE2_JUDGE_PROFILE}
 
+safety:
+  live_without_gate_max_candidates: 3
+
+providers:
+  draft:
+    adapter: mock
+    base_url_env: PHASE2_MODEL_X_BASE_URL
+    api_key_env: PHASE2_MODEL_X_API_KEY
+    endpoint_path: /v1/chat/completions
+    timeout_seconds: 30
+    response_text_path: choices.0.message.content
+  judge:
+    adapter: mock
+    base_url_env: PHASE2_JUDGE_BASE_URL
+    api_key_env: PHASE2_JUDGE_API_KEY
+    endpoint_path: /v1/chat/completions
+    timeout_seconds: 30
+    response_text_path: choices.0.message.content
+    payload_request_fields:
+      - route
+      - profile
+
 generation:
   max_new_tokens: 96
   temperature: 0.2

--- a/configs/phase2_labelled_requests.yaml
+++ b/configs/phase2_labelled_requests.yaml
@@ -1,0 +1,70 @@
+dataset:
+  name: phase2_labelled_requests
+  prompt_spec_version: phase2-labelled-requests-v1
+
+sampling:
+  sample_widths:
+    - 1
+    - 2
+    - 3
+
+model_x:
+  model_id: ${PHASE1_MODEL_X_MODEL_ID}
+  artifact_sha: ${PHASE1_MODEL_X_ARTIFACT_SHA}
+
+judge:
+  route: ${PHASE2_JUDGE_ROUTE}
+  model_id: ${PHASE2_JUDGE_MODEL_ID}
+  profile: ${PHASE2_JUDGE_PROFILE}
+
+generation:
+  max_new_tokens: 96
+  temperature: 0.2
+  top_p: 0.95
+
+prompts:
+  model_x_draft:
+    system: |
+      You draft one concise, natural operator request from Redfish REST API evidence.
+      Cover all sampled APIs and do not add unsupported work.
+    template: |
+      Sampled REST API records:
+      {records_json}
+
+      Return only the human request text.
+  pro_judge:
+    system: |
+      You judge whether a draft operator request maps back to the exact sampled REST API set.
+      Treat API order as irrelevant unless the text explicitly uses ordering language.
+    template: |
+      Sampled REST API records:
+      {records_json}
+
+      Draft operator request:
+      {draft_text}
+
+      Return JSON with accepted, rest_api_list, nonsense, reason, and order_evidence.
+
+wandb:
+  namespace: phase2_labelled_requests
+  metric_keys:
+    - phase2_labelled_requests/draft_total
+    - phase2_labelled_requests/accepted_total
+    - phase2_labelled_requests/rejected_total
+    - phase2_labelled_requests/nonsense_rate
+    - phase2_labelled_requests/invalid_json_rate
+    - phase2_labelled_requests/pro_accept_rate
+    - phase2_labelled_requests/rest_api_set_match_rate
+    - phase2_labelled_requests/empty_set_match_rate
+    - phase2_labelled_requests/sample_width/k
+    - phase2_labelled_requests/vendor/source_corpus
+    - phase2_labelled_requests/prompt_spec_version
+    - phase2_labelled_requests/model_x/artifact_sha
+    - phase2_labelled_requests/judge/model
+    - phase2_labelled_requests/judge/profile
+
+acceptance:
+  min_pro_accept_rate: 0.9
+  min_rest_api_set_match_rate: 0.98
+  max_nonsense_rate: 0.01
+  max_invalid_json_rate: 0.01

--- a/configs/phase2_labelled_requests.yaml
+++ b/configs/phase2_labelled_requests.yaml
@@ -1,0 +1,88 @@
+version: phase2_labelled_requests.v1
+dataset_name: phase2_labelled_requests
+
+sample_widths:
+  - 1
+  - 2
+  - 3
+
+wandb:
+  namespace: phase2_labelled_requests
+  project: igc
+  run_group: phase2_labelled_requests_offline_plumbing
+
+model_x:
+  id: phase1_redfish_model_x
+  artifact_sha: fixture-model-x-sha256
+  artifact_source: approved_model_store_placeholder
+
+judge:
+  route:
+    name: private_pro_judge
+    transport: configured_private_runtime
+    endpoint_env: PHASE2_PRO_JUDGE_ENDPOINT
+  model: private_pro
+  profile: max_reasoning
+
+generation:
+  draft_human_request:
+    temperature: 0.2
+    top_p: 0.9
+    max_tokens: 256
+  pro_judge_set_match:
+    temperature: 0.0
+    top_p: 1.0
+    max_tokens: 512
+
+acceptance_thresholds:
+  pro_accept_rate_min: 0.95
+  rest_api_set_match_rate_min: 0.98
+  empty_set_match_rate_min: 1.0
+  nonsense_rate_max: 0.02
+  invalid_json_rate_max: 0.01
+
+prompts:
+  draft_human_request:
+    version: phase2_labelled_requests.prompt.draft.v1
+    template: |
+      You generate one natural operator request for the dataset {dataset_name}.
+      The request must ask for all and only the sampled REST API records.
+      Do not include endpoint URLs in the request text.
+      Do not invent actions, arguments, hosts, credentials, or ordering language.
+      If there are multiple records, use a natural compound request.
+
+      Sample width: {sample_width}
+      REST API records:
+      {records_json}
+
+      Return JSON only with this shape:
+      {{
+        "text": "natural operator request"
+      }}
+  pro_judge_set_match:
+    version: phase2_labelled_requests.prompt.judge.v1
+    template: |
+      You judge whether drafted operator text maps back to the same unordered
+      REST API set for the dataset {dataset_name}. Empty set equals empty set.
+      Order is not the primary objective unless the text explicitly carries
+      ordering language such as "then", "before", "after", or numbered steps.
+
+      Draft text:
+      {draft_text}
+
+      Expected REST API set:
+      {rest_api_list_json}
+
+      Allowed methods by REST API:
+      {allowed_methods_json}
+
+      REST API records:
+      {records_json}
+
+      Return JSON only with this shape:
+      {{
+        "accepted": true,
+        "rest_api_list": ["/redfish/v1/example"],
+        "nonsense": false,
+        "reason": "short evidence-backed reason"
+      }}

--- a/docs/phase_2.md
+++ b/docs/phase_2.md
@@ -44,17 +44,28 @@ coordination notes may call that manifest `D1`; new runtime code, configs, metri
 canonical `phase2_labelled_requests` name.
 
 The offline builder spec lives in `configs/phase2_labelled_requests.yaml`.
-That spec owns prompt text, `model_x` identifiers, judge route/profile fields,
-generation settings, sample widths, W&B namespace/key lists, and acceptance
-thresholds. Runtime Python must load those values rather than hardcoding prompt
-or model literals.
+That spec owns prompt text, `model_x` identifiers, provider adapter metadata,
+judge route/profile fields, generation settings, sample widths, W&B
+namespace/key lists, safety caps, and acceptance thresholds. Runtime Python
+must load those values rather than hardcoding prompt or model literals.
 
 The offline fixture CLI is `scripts/build_phase2_labelled_requests.py`. It
 loads the YAML spec, reads tiny JSONL records with `rest_api`,
 `allowed_methods`, `json`, `vendor`, and `source_corpus`, then writes accepted
 `phase2_labelled_requests` JSONL plus an aggregate metrics JSON. Its provider
-modes are local-only mock and file fixtures; real `model_x` or private judge
-adapters must be wired separately before any slot2/slot11 generation run.
+modes are YAML-selected config, local-only mock, local file fixtures, and an
+OpenAI-compatible live adapter. The checked-in config keeps both draft and
+judge adapters on `mock`; operators must explicitly select the live adapter by
+YAML or CLI and provide the environment variables named by the spec before any
+live `model_x` or private Pro judge call is possible.
+
+The live adapter is only a provider surface. It resolves the model and route
+placeholders from environment variables, reads base URLs from the spec's
+`base_url_env` fields, extracts text from the configured response JSON path,
+and sends no W&B, Redfish, GPU, or dataset-scale work on its own. A live run
+whose `--count` exceeds `safety.live_without_gate_max_candidates` must pass
+`--live-provider-gate-passed`; otherwise the CLI exits before opening a live
+provider connection.
 
 ## Build Input
 
@@ -270,10 +281,11 @@ The offline plumbing is accepted when focused pytest coverage proves:
   counters emit the required keys;
 - Phase 3 argument extraction remains outside this builder.
 
-A later approved run can point the YAML route metadata at the fine-tuned
+A later approved run can point the YAML provider metadata at the restored
 `model_x` artifact and private Pro judge. That run is outside the local CPU
 plumbing gate and must not be simulated with live GPU inference, live W&B, live
-Redfish crawls, model downloads, or cluster jobs.
+Redfish crawls, model downloads, cluster jobs, or dataset-scale generation
+until the provider and launch gates have passed.
 
 Author:
 Mus mbayramo@stanford.edu

--- a/docs/phase_2.md
+++ b/docs/phase_2.md
@@ -120,8 +120,6 @@ The generated text should be passed through a review/judge step with the same `j
 Accepted output becomes the final `phase2_labelled_requests` row. Rejected
 output is not used for fine-tuning.
 
-## Final Row
-
 The offline parser accepts a row only when the judge JSON parses, the judge did
 not mark the draft as nonsense, and the judged REST API set equals the expected
 set after ignoring order. If the expected and judged sets are both empty, the
@@ -153,16 +151,14 @@ An accepted row stores the text label with the sampled REST API evidence:
     ]
   },
   "y_true": {
-    "rest_api_set": ["/redfish/v1/Systems"],
+    "rest_api_list": ["/redfish/v1/Systems"],
     "order_evidence": "none"
   },
   "validation": {
-    "text_source": "model_x_then_private_pro_judge",
-    "pro_judged": true,
-    "rest_api_set_match": true,
-    "empty_set_match": false,
-    "nonsense": false,
-    "invalid_json": false
+    "text_source": "model_x_then_private_judge",
+    "review_judged": true,
+    "set_coverage_preserved": true,
+    "nonsense": false
   }
 }
 ```

--- a/docs/phase_2.md
+++ b/docs/phase_2.md
@@ -49,6 +49,13 @@ generation settings, sample widths, W&B namespace/key lists, and acceptance
 thresholds. Runtime Python must load those values rather than hardcoding prompt
 or model literals.
 
+The offline fixture CLI is `scripts/build_phase2_labelled_requests.py`. It
+loads the YAML spec, reads tiny JSONL records with `rest_api`,
+`allowed_methods`, `json`, `vendor`, and `source_corpus`, then writes accepted
+`phase2_labelled_requests` JSONL plus an aggregate metrics JSON. Its provider
+modes are local-only mock and file fixtures; real `model_x` or private judge
+adapters must be wired separately before any slot2/slot11 generation run.
+
 ## Build Input
 
 To build one `phase2_labelled_requests` row, sample one, two, or three Redfish
@@ -136,19 +143,19 @@ An accepted row stores the text label with the sampled REST API evidence:
   "task": "text_to_rest_api_list",
   "x": {
     "text": "check the available computer systems",
-    "records": [
+    "json": [
       {
-        "rest_api": "/redfish/v1/Systems",
-        "allowed_methods": ["GET", "HEAD"],
-        "json": {
-          "@odata.id": "/redfish/v1/Systems",
-          "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
-          "Members": [],
-          "Members@odata.count": 0,
-          "Name": "Computer System Collection"
-        }
+        "@odata.id": "/redfish/v1/Systems",
+        "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+        "Members": [],
+        "Members@odata.count": 0,
+        "Name": "Computer System Collection"
       }
-    ]
+    ],
+    "allowed_methods": {
+      "/redfish/v1/Systems": ["GET", "HEAD"]
+    },
+    "rest_api_list": ["/redfish/v1/Systems"]
   },
   "y_true": {
     "rest_api_list": ["/redfish/v1/Systems"],
@@ -159,6 +166,11 @@ An accepted row stores the text label with the sampled REST API evidence:
     "review_judged": true,
     "set_coverage_preserved": true,
     "nonsense": false
+  },
+  "metadata": {
+    "prompt_spec_version": "phase2-labelled-requests-v1",
+    "vendor": ["fixture_vendor"],
+    "source_corpus": ["fixture_corpus"]
   }
 }
 ```
@@ -200,6 +212,11 @@ The labelled-request generation builder records these keys under the
 - `phase2_labelled_requests/model_x/artifact_sha`
 - `phase2_labelled_requests/judge/model`
 - `phase2_labelled_requests/judge/profile`
+
+`accepted_total` counts rows that pass JSON parsing, Pro acceptance, nonsense
+rejection, and unordered REST API set matching. `pro_accept_rate` is narrower:
+it tracks valid judge responses whose own `accepted` flag is true, even if the
+row later fails the set-match gate.
 
 ## Goal-Extractor Training W&B Metrics
 

--- a/docs/phase_2.md
+++ b/docs/phase_2.md
@@ -1,37 +1,51 @@
-# Phase 2: Ordered REST Goal Extraction
+# Phase 2: Labelled REST Request Extraction
 
-Phase 2 builds and trains `D1`, the dataset for extracting Redfish REST goals from an operator
-sentence. `model_x` must already have completed Phase 1 Redfish JSON pretraining.
+Legacy notes and old branches may call the Phase 2 text-labelled artifact `D1`.
+New code, configs, metrics, and docs use the canonical dataset name
+`phase2_labelled_requests`. `model_x` must already have completed Phase 1
+Redfish JSON pretraining before real generation runs; offline plumbing may use
+tiny fixtures and injected providers only.
 
 Names are fixed as follows:
 
 - `D0`: Phase 1 JSON reconstruction data.
-- `D1`: Phase 2 text-to-ordered-REST-goal data.
+- `phase2_labelled_requests`: Phase 2 text-to-REST-API-set data.
 - `model_x`: the Phase 1 Redfish-tuned LLM.
 - `x`: the input context shown to the model.
 - `y_true`: the exact target label stored in the dataset.
 - `y_pred`: the model output during inference or evaluation.
 - `rest_api`: one concrete Redfish URI.
-- `rest_api_list`: ordered list of concrete Redfish URIs.
+- `rest_api_list`: canonical list of concrete Redfish URIs; correctness is the
+  unordered API set unless `order_evidence` is explicit.
 - `allowed_methods`: methods from the same discovery run's `rest_api_map.npy`.
 - `json`: full Redfish JSON resource body.
 
-Phase 2 output is ordered. If the operator sentence says "check tasks, then check systems", the
-target order is tasks first and systems second. If the sentence has no explicit order, the dataset
-builder still stores a deterministic order and marks that order as weak evidence so evaluation can
-separate exact-order accuracy from set-recall.
+Phase 2 output is a REST API set extraction target. If the operator sentence
+says "check tasks, then check systems", the row records explicit order evidence
+for auxiliary order metrics. If the sentence has no explicit order, evaluation
+treats `[A, B]` and `[B, A]` as the same target. Empty set equals empty set for
+hard-negative or no-action rows.
 
-## D1 Build Input
+## Builder Spec
 
-To build one `D1` row, sample one, two, or three Redfish records from `D0` or the same captured
-corpus. Each sampled record must carry its `rest_api`, full `json`, and `allowed_methods`.
+The offline builder spec lives in `configs/phase2_labelled_requests.yaml`.
+That spec owns prompt text, `model_x` identifiers, judge route/profile fields,
+generation settings, sample widths, W&B namespace/key lists, and acceptance
+thresholds. Runtime Python must load those values rather than hardcoding prompt
+or model literals.
+
+## Build Input
+
+To build one `phase2_labelled_requests` row, sample one, two, or three Redfish
+records from Phase 1 rows or the same captured corpus. Each sampled record must
+carry its `rest_api`, full `json`, and `allowed_methods`.
 The following block is an intermediate synthetic-text generation request, not the final stored row:
 `x` is the sampled Redfish context, and `y_pred.text` is the draft operator sentence.
 
 ```json
 {
   "x": {
-    "task": "produce_human_text_for_ordered_rest_api_list",
+    "task": "produce_human_text_for_rest_api_set",
     "json": [
       {
         "@odata.context": "/redfish/v1/$metadata#TaskCollection.TaskCollection",
@@ -77,29 +91,30 @@ The following block is an intermediate synthetic-text generation request, not th
 }
 ```
 
-`y_pred.text` is only a draft. If `model_x` emits junk text, that text must not enter `D1`. It must
-be cleaned or rejected.
+`y_pred.text` is only a draft. If `model_x` emits junk text, that text must not
+enter `phase2_labelled_requests`. It must be cleaned or rejected.
 
 ## Review Cleanup And Judge
 
 The generated text should be passed through a review/judge step with the same `json`,
-`allowed_methods`, and ordered `rest_api_list`. The reviewer has two jobs:
+`allowed_methods`, and canonical `rest_api_list`. The reviewer has two jobs:
 
 1. rewrite the text into a natural operator sentence if needed;
-2. judge whether the sentence asks for all and only the sampled `rest_api_list`, in the intended
-   order when the sentence contains ordering language.
+2. judge whether the sentence asks for all and only the sampled REST API set,
+   considering order only when the sentence contains ordering language.
 
-Accepted output becomes the final `D1` row. Rejected output is not used for fine-tuning.
+Accepted output becomes the final `phase2_labelled_requests` row. Rejected
+output is not used for fine-tuning.
 
-## Final D1 Row
+## Final Row
 
 This is the row used to fine-tune text-to-REST-goal extraction:
 
 ```json
 {
   "phase": 2,
-  "dataset": "D1",
-  "task": "text_to_ordered_rest_api_list",
+  "dataset": "phase2_labelled_requests",
+  "task": "text_to_rest_api_set",
   "x": {
     "text": "check the task queue, then list the available computer systems",
     "json": [
@@ -167,10 +182,36 @@ The rendered training target is canonical JSON:
 }
 ```
 
-Cross-entropy is computed on the target JSON tokens. Evaluation parses `y_pred`, reads
-`y_pred.rest_api_list`, and reports both ordered exact match and set match.
+Cross-entropy is computed on the target JSON tokens. Evaluation parses `y_pred`,
+reads `y_pred.rest_api_list`, and treats unordered set match as the primary
+correctness metric. Ordered exact match is auxiliary and applies only when
+`order_evidence` is explicit.
 
-## Phase 2 W&B Metrics
+## Labelled-Request W&B Metrics
+
+The labelled-request generation builder records these keys under the
+`phase2_labelled_requests/*` namespace:
+
+- `phase2_labelled_requests/draft_total`
+- `phase2_labelled_requests/accepted_total`
+- `phase2_labelled_requests/rejected_total`
+- `phase2_labelled_requests/nonsense_rate`
+- `phase2_labelled_requests/invalid_json_rate`
+- `phase2_labelled_requests/pro_accept_rate`
+- `phase2_labelled_requests/rest_api_set_match_rate`
+- `phase2_labelled_requests/empty_set_match_rate`
+- `phase2_labelled_requests/sample_width/k`
+- `phase2_labelled_requests/vendor/source_corpus`
+- `phase2_labelled_requests/prompt_spec_version`
+- `phase2_labelled_requests/model_x/artifact_sha`
+- `phase2_labelled_requests/judge/model`
+- `phase2_labelled_requests/judge/profile`
+
+## Goal-Extractor Training W&B Metrics
+
+After accepted labelled-request rows exist, the later `goal_extractor` training
+path may emit these legacy trainer metrics. They are separate from
+`phase2_labelled_requests/*` generation metrics above.
 
 - `phase2_goal_extract/train/loss`
 - `phase2_goal_extract/train/perplexity`

--- a/docs/phase_2.md
+++ b/docs/phase_2.md
@@ -1,211 +1,177 @@
-# Phase 2: Ordered REST Goal Extraction
+# Phase 2: Labelled Request Dataset
 
-Phase 2 builds and trains `D1`, the dataset for extracting Redfish REST goals from an operator
-sentence. `model_x` must already have completed Phase 1 Redfish JSON pretraining.
+Phase 2 builds `phase2_labelled_requests`, the dataset name defined by
+`configs/phase2_labelled_requests.yaml` in this repository. The dataset adds the
+missing human request text label for one, two, or three Redfish REST API records
+that already carry paths, allowed HTTP methods, and JSON bodies.
 
-Names are fixed as follows:
+`model_x`, produced by Phase 1 Redfish JSON pretraining, drafts the missing
+operator text. The private Pro judge, selected by the `judge` section in
+`configs/phase2_labelled_requests.yaml`, decides whether that text maps back to
+the same unordered REST API set. Empty set equals empty set. Order is recorded
+only as secondary evidence when the text explicitly says things like "then",
+"before", "after", or uses numbered steps.
 
-- `D0`: Phase 1 JSON reconstruction data.
-- `D1`: Phase 2 text-to-ordered-REST-goal data.
-- `model_x`: the Phase 1 Redfish-tuned LLM.
-- `x`: the input context shown to the model.
-- `y_true`: the exact target label stored in the dataset.
-- `y_pred`: the model output during inference or evaluation.
-- `rest_api`: one concrete Redfish URI.
-- `rest_api_list`: ordered list of concrete Redfish URIs.
-- `allowed_methods`: methods from the same discovery run's `rest_api_map.npy`.
-- `json`: full Redfish JSON resource body.
+## Config Contract
 
-Phase 2 output is ordered. If the operator sentence says "check tasks, then check systems", the
-target order is tasks first and systems second. If the sentence has no explicit order, the dataset
-builder still stores a deterministic order and marks that order as weak evidence so evaluation can
-separate exact-order accuracy from set-recall.
+`configs/phase2_labelled_requests.yaml`, added by the Phase 2 labelled-request
+plumbing step, is the single runtime source for:
 
-## D1 Build Input
+- prompt templates and prompt spec versions under `prompts`;
+- `model_x` identifiers and the model artifact SHA under `model_x`;
+- private judge route metadata, judge model, and judge profile under `judge`;
+- generation settings under `generation`;
+- sample widths `1`, `2`, and `3` under `sample_widths`;
+- W&B namespace metadata under `wandb`;
+- acceptance thresholds under `acceptance_thresholds`.
 
-To build one `D1` row, sample one, two, or three Redfish records from `D0` or the same captured
-corpus. Each sampled record must carry its `rest_api`, full `json`, and `allowed_methods`.
-The following block is an intermediate synthetic-text generation request, not the final stored row:
-`x` is the sampled Redfish context, and `y_pred.text` is the draft operator sentence.
+Runtime code must load this YAML spec. Prompt text, model IDs, judge route names,
+generation temperatures, token limits, W&B namespaces, and acceptance thresholds
+must not be embedded directly in dataset-builder code.
+
+## Build Input
+
+One build item samples `k in {1, 2, 3}` records from the Redfish corpus. Each
+record has this minimum shape:
 
 ```json
 {
-  "x": {
-    "task": "produce_human_text_for_ordered_rest_api_list",
-    "json": [
-      {
-        "@odata.context": "/redfish/v1/$metadata#TaskCollection.TaskCollection",
-        "@odata.id": "/redfish/v1/TaskService/Tasks",
-        "@odata.type": "#TaskCollection.TaskCollection",
-        "Description": "Collection of Tasks",
-        "Members": [],
-        "Members@odata.count": 0,
-        "Name": "Task Collection"
-      },
-      {
-        "@odata.context": "/redfish/v1/$metadata#ComputerSystemCollection.ComputerSystemCollection",
-        "@odata.id": "/redfish/v1/Systems",
-        "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
-        "Description": "Collection of Computer Systems",
-        "Members": [
-          {
-            "@odata.id": "/redfish/v1/Systems/System.Embedded.1"
-          }
-        ],
-        "Members@odata.count": 1,
-        "Name": "Computer System Collection"
-      }
-    ],
-    "allowed_methods": {
-      "/redfish/v1/TaskService/Tasks": [
-        "GET",
-        "HEAD"
-      ],
-      "/redfish/v1/Systems": [
-        "GET",
-        "HEAD"
-      ]
-    },
-    "rest_api_list": [
-      "/redfish/v1/TaskService/Tasks",
-      "/redfish/v1/Systems"
-    ]
+  "rest_api": "/redfish/v1/Systems",
+  "allowed_methods": ["GET", "HEAD"],
+  "json": {
+    "@odata.id": "/redfish/v1/Systems",
+    "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+    "Members": [],
+    "Members@odata.count": 0,
+    "Name": "Computer System Collection"
   },
-  "y_pred": {
-    "text": "check the task queue, then list the available computer systems"
-  }
+  "vendor": "fixture",
+  "source_corpus": "unit_fixture"
 }
 ```
 
-`y_pred.text` is only a draft. If `model_x` emits junk text, that text must not enter `D1`. It must
-be cleaned or rejected.
+The sampled records are rendered into the YAML `draft_human_request` prompt. A
+later approved run can send that prompt to `model_x`; offline unit tests use only
+fixtures and do not call a model.
 
-## Review Cleanup And Judge
+## Draft And Judge
 
-The generated text should be passed through a review/judge step with the same `json`,
-`allowed_methods`, and ordered `rest_api_list`. The reviewer has two jobs:
+`model_x` should return JSON containing the drafted text:
 
-1. rewrite the text into a natural operator sentence if needed;
-2. judge whether the sentence asks for all and only the sampled `rest_api_list`, in the intended
-   order when the sentence contains ordering language.
+```json
+{
+  "text": "check the available computer systems"
+}
+```
 
-Accepted output becomes the final `D1` row. Rejected output is not used for fine-tuning.
+The draft text, sampled records, allowed methods, and expected REST API set are
+then rendered into the YAML `pro_judge_set_match` prompt. The private Pro judge
+returns JSON with the judged REST API set:
 
-## Final D1 Row
+```json
+{
+  "accepted": true,
+  "rest_api_list": ["/redfish/v1/Systems"],
+  "nonsense": false,
+  "reason": "The request asks for the sampled Systems collection only."
+}
+```
 
-This is the row used to fine-tune text-to-REST-goal extraction:
+The offline parser accepts a row only when the judge JSON parses, the judge did
+not mark the draft as nonsense, and the judged REST API set equals the expected
+set after ignoring order. If the expected and judged sets are both empty, the
+row counts as an empty-set match.
+
+## Final Row
+
+An accepted row stores the text label with the sampled REST API evidence:
 
 ```json
 {
   "phase": 2,
-  "dataset": "D1",
-  "task": "text_to_ordered_rest_api_list",
+  "dataset": "phase2_labelled_requests",
+  "task": "text_to_rest_api_set",
   "x": {
-    "text": "check the task queue, then list the available computer systems",
-    "json": [
+    "text": "check the available computer systems",
+    "records": [
       {
-        "@odata.context": "/redfish/v1/$metadata#TaskCollection.TaskCollection",
-        "@odata.id": "/redfish/v1/TaskService/Tasks",
-        "@odata.type": "#TaskCollection.TaskCollection",
-        "Description": "Collection of Tasks",
-        "Members": [],
-        "Members@odata.count": 0,
-        "Name": "Task Collection"
-      },
-      {
-        "@odata.context": "/redfish/v1/$metadata#ComputerSystemCollection.ComputerSystemCollection",
-        "@odata.id": "/redfish/v1/Systems",
-        "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
-        "Description": "Collection of Computer Systems",
-        "Members": [
-          {
-            "@odata.id": "/redfish/v1/Systems/System.Embedded.1"
-          }
-        ],
-        "Members@odata.count": 1,
-        "Name": "Computer System Collection"
+        "rest_api": "/redfish/v1/Systems",
+        "allowed_methods": ["GET", "HEAD"],
+        "json": {
+          "@odata.id": "/redfish/v1/Systems",
+          "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+          "Members": [],
+          "Members@odata.count": 0,
+          "Name": "Computer System Collection"
+        }
       }
-    ],
-    "allowed_methods": {
-      "/redfish/v1/TaskService/Tasks": [
-        "GET",
-        "HEAD"
-      ],
-      "/redfish/v1/Systems": [
-        "GET",
-        "HEAD"
-      ]
-    }
+    ]
   },
   "y_true": {
-    "rest_api_list": [
-      "/redfish/v1/TaskService/Tasks",
-      "/redfish/v1/Systems"
-    ],
-    "order_evidence": "explicit_then"
+    "rest_api_set": ["/redfish/v1/Systems"],
+    "order_evidence": "none"
   },
   "validation": {
-    "text_source": "model_x_then_review",
-    "review_judged": true,
-    "all_rest_api_present": true,
-    "extra_rest_api_present": false,
-    "order_preserved": true
+    "text_source": "model_x_then_private_pro_judge",
+    "pro_judged": true,
+    "rest_api_set_match": true,
+    "empty_set_match": false,
+    "nonsense": false,
+    "invalid_json": false
   }
 }
 ```
 
-## Fine-Tuning Target
+The row may preserve a deterministic list order for storage, but Phase 2
+acceptance is set-based unless the text itself carries explicit ordering
+language. Phase 3 argument extraction remains a separate phase and consumes
+accepted request labels only after a downstream contract chooses how to preserve
+or infer call order.
 
-The rendered training target is canonical JSON:
+## Metrics
 
-```json
-{
-  "rest_api_list": [
-    "/redfish/v1/TaskService/Tasks",
-    "/redfish/v1/Systems"
-  ]
-}
-```
+`PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS`, defined in
+`igc/modules/base/metric_keys.py`, records the metric keys used by the offline
+builder seam. The canonical namespace comes from `wandb.namespace` in
+`configs/phase2_labelled_requests.yaml` and is `phase2_labelled_requests`.
 
-Cross-entropy is computed on the target JSON tokens. Evaluation parses `y_pred`, reads
-`y_pred.rest_api_list`, and reports both ordered exact match and set match.
+Required keys:
 
-## Phase 2 W&B Metrics
+- `phase2_labelled_requests/build/draft_total`
+- `phase2_labelled_requests/build/accepted_total`
+- `phase2_labelled_requests/build/rejected_total`
+- `phase2_labelled_requests/eval/nonsense_rate`
+- `phase2_labelled_requests/eval/invalid_json_rate`
+- `phase2_labelled_requests/eval/pro_accept_rate`
+- `phase2_labelled_requests/eval/rest_api_set_match_rate`
+- `phase2_labelled_requests/eval/empty_set_match_rate`
+- `phase2_labelled_requests/sample_width/k`
+- `phase2_labelled_requests/vendor/source_corpus`
+- `phase2_labelled_requests/spec/prompt_spec_version`
+- `phase2_labelled_requests/model/model_x_artifact_sha`
+- `phase2_labelled_requests/judge/model`
+- `phase2_labelled_requests/judge/profile`
 
-- `phase2_goal_extract/train/loss`
-- `phase2_goal_extract/train/perplexity`
-- `phase2_goal_extract/train/optimizer_step`
-- `phase2_goal_extract/eval/loss`
-- `phase2_goal_extract/eval/perplexity`
-- `phase2_goal_extract/eval/token_accuracy`
-- `phase2_goal_extract/eval/ordered_exact_match_rate`
-- `phase2_goal_extract/eval/set_match_rate`
-- `phase2_goal_extract/eval/precision`
-- `phase2_goal_extract/eval/recall`
-- `phase2_goal_extract/eval/f1`
-- `phase2_goal_extract/eval/top_k_api_accuracy`
-- `phase2_goal_extract/eval/invalid_api_rate`
-- `phase2_goal_extract/eval/missing_required_api_rate`
-- `phase2_goal_extract/eval/missing_allowed_methods_rate`
-- `phase2_goal_extract/eval/order_violation_rate`
-- `phase2_goal_extract/order/kendall_tau`
-- `phase2_goal_extract/order/edit_distance`
-- `phase2_goal_extract/throughput/train_tokens_per_sec`
-- `phase2_goal_extract/throughput/train_samples_per_sec`
-- `phase2_goal_extract/throughput/eval_tokens_per_sec`
-- `phase2_goal_extract/throughput/eval_samples_per_sec`
-- `phase2_goal_extract/data/avg_num_apis`
-- `phase2_goal_extract/data/max_num_apis`
-- `phase2_goal_extract/data/mean_sequence_length`
-- `phase2_goal_extract/data/padding_ratio`
-- `phase2_goal_extract/calibration/log_prob_per_sequence`
-- `phase2_goal_extract/calibration/ece`
-- `phase2_goal_extract/test/latency_sec_p50`
-- `phase2_goal_extract/test/latency_sec_p95`
-- `phase2_goal_extract/test/memory_peak_mb`
+These keys can be emitted by offline counters without opening a live W&B run.
 
-When Phase 2 moves beyond mock plumbing, its acceptance gate must mirror Phase 1: approved full
-corpora, readable W&B plots, checkpoint/report storage, and reviewed Git LFS artifact metadata.
+## Acceptance Gate
+
+The offline plumbing is accepted when focused pytest coverage proves:
+
+- sample widths `k=1`, `k=2`, and `k=3` are supported;
+- prompt specs load from YAML and render sampled record payloads;
+- REST API set comparison is unordered;
+- empty set equals empty set;
+- Pro judge JSON parsing handles accepted, rejected, nonsense, and invalid JSON
+  outcomes;
+- nonsense, invalid JSON, Pro accept, REST API set match, and empty-set match
+  counters emit the required keys;
+- Phase 3 argument extraction remains outside this builder.
+
+A later approved run can point the YAML route metadata at the fine-tuned
+`model_x` artifact and private Pro judge. That run is outside the local CPU
+plumbing gate and must not be simulated with live GPU inference, live W&B, live
+Redfish crawls, model downloads, or cluster jobs.
 
 Author:
 Mus mbayramo@stanford.edu

--- a/igc/ds/phase2_labelled_requests.py
+++ b/igc/ds/phase2_labelled_requests.py
@@ -241,6 +241,15 @@ def load_phase2_labelled_requests_spec(path: str | Path) -> Phase2LabelledReques
             f"acceptance missing required keys: {', '.join(missing_acceptance)}",
         )
 
+    acceptance_thresholds: dict[str, float] = {}
+    for key, value in acceptance.items():
+        try:
+            acceptance_thresholds[str(key)] = float(value)
+        except (TypeError, ValueError) as exc:
+            raise Phase2LabelledRequestsSpecError(
+                f"acceptance.{key} must be numeric",
+            ) from exc
+
     return Phase2LabelledRequestsSpec(
         dataset_name=dataset_name,
         prompt_spec_version=_required_string(
@@ -269,7 +278,7 @@ def load_phase2_labelled_requests_spec(path: str | Path) -> Phase2LabelledReques
         judge_template=_required_string(judge_prompt, "template", "prompts.pro_judge.template"),
         wandb_namespace=wandb_namespace,
         metric_keys=metric_keys,
-        acceptance_thresholds={key: float(value) for key, value in acceptance.items()},
+        acceptance_thresholds=acceptance_thresholds,
     )
 
 
@@ -355,7 +364,16 @@ def parse_pro_judge_result(raw: str) -> ProJudgeResult:
             reason=f"{rest_api_field} must contain only strings",
         )
 
-    accepted_key = "accepted" if "accepted" in parsed else "accept"
+    if "accepted" in parsed:
+        accepted_key = "accepted"
+    elif "accept" in parsed:
+        accepted_key = "accept"
+    else:
+        return ProJudgeResult(
+            accepted=False,
+            invalid_json=True,
+            reason="accepted or accept is required",
+        )
     accepted = _optional_bool(parsed, accepted_key)
     if accepted is None:
         return ProJudgeResult(

--- a/igc/ds/phase2_labelled_requests.py
+++ b/igc/ds/phase2_labelled_requests.py
@@ -213,7 +213,12 @@ def load_phase2_labelled_requests_spec(path: str | Path) -> Phase2LabelledReques
         )
 
     sampling = _mapping(raw, "sampling", required=True)
-    sample_widths = tuple(int(width) for width in _sequence(sampling, "sample_widths"))
+    raw_sample_widths = _sequence(sampling, "sample_widths")
+    if not all(isinstance(width, int) and not isinstance(width, bool) for width in raw_sample_widths):
+        raise Phase2LabelledRequestsSpecError(
+            "sampling.sample_widths must be integer sequence [1, 2, 3]",
+        )
+    sample_widths = tuple(raw_sample_widths)
     if sample_widths != (1, 2, 3):
         raise Phase2LabelledRequestsSpecError("sampling.sample_widths must be [1, 2, 3]")
 
@@ -416,6 +421,7 @@ class Phase2LabelledRequestCounters:
     draft_total: int = 0  # number of draft text attempts.
     accepted_total: int = 0  # number of rows accepted into the dataset.
     rejected_total: int = 0  # number of rows rejected by parser/judge/set check.
+    pro_accept_total: int = 0  # number of valid judge responses with accepted=true.
     nonsense_total: int = 0  # number of drafts flagged as nonsense.
     invalid_json_total: int = 0  # number of judge responses with invalid JSON.
     rest_api_set_match_total: int = 0  # number of rows with matching API sets.
@@ -453,6 +459,8 @@ class Phase2LabelledRequestCounters:
             self.nonsense_total += 1
         if result.invalid_json:
             self.invalid_json_total += 1
+        if result.accepted and not result.invalid_json:
+            self.pro_accept_total += 1
         if set_match:
             self.rest_api_set_match_total += 1
         if not result.invalid_json and not expected_rest_api_list:
@@ -472,7 +480,7 @@ class Phase2LabelledRequestCounters:
             _REJECTED_TOTAL_KEY: self.rejected_total,
             _NONSENSE_RATE_KEY: _rate(self.nonsense_total, self.draft_total),
             _INVALID_JSON_RATE_KEY: _rate(self.invalid_json_total, self.draft_total),
-            _PRO_ACCEPT_RATE_KEY: _rate(self.accepted_total, self.draft_total),
+            _PRO_ACCEPT_RATE_KEY: _rate(self.pro_accept_total, self.draft_total),
             _REST_API_SET_MATCH_RATE_KEY: _rate(self.rest_api_set_match_total, self.draft_total),
             _EMPTY_SET_MATCH_RATE_KEY: _rate(
                 self.empty_set_match_total,

--- a/igc/ds/phase2_labelled_requests.py
+++ b/igc/ds/phase2_labelled_requests.py
@@ -1,0 +1,481 @@
+"""Offline plumbing for the Phase 2 labelled request dataset.
+
+The builder samples Redfish REST API records, renders configured prompts, and
+parses configured judge responses. This module is deliberately pure: it does not
+call models, W&B, GPUs, Redfish hosts, or private runtime endpoints.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import random
+from typing import Any, Mapping, Sequence
+
+import yaml
+
+from igc.modules.base.metric_keys import phase_metric
+
+
+class Phase2LabelledRequestsSpecError(ValueError):
+    """Raised when the Phase 2 labelled request YAML spec is invalid."""
+
+
+_TOP_LEVEL_KEYS = {
+    "version",
+    "dataset_name",
+    "sample_widths",
+    "wandb",
+    "model_x",
+    "judge",
+    "generation",
+    "acceptance_thresholds",
+    "prompts",
+}
+_PHASE2_SAMPLE_WIDTHS = (1, 2, 3)
+
+
+@dataclass(frozen=True)
+class PromptSpec:
+    """One prompt template loaded from ``configs/phase2_labelled_requests.yaml``."""
+
+    name: str
+    version: str
+    template: str
+
+
+@dataclass(frozen=True)
+class Phase2LabelledRequestsSpec:
+    """Normalized runtime spec loaded from ``configs/phase2_labelled_requests.yaml``."""
+
+    path: Path
+    version: str
+    dataset_name: str
+    sample_widths: tuple[int, ...]
+    wandb: dict[str, Any]
+    model_x: dict[str, Any]
+    judge: dict[str, Any]
+    generation: dict[str, Any]
+    acceptance_thresholds: dict[str, float]
+    prompts: dict[str, PromptSpec]
+
+
+@dataclass(frozen=True)
+class Phase2RestApiRecord:
+    """One Redfish REST API record available to the labelled-request builder."""
+
+    rest_api: str
+    allowed_methods: tuple[str, ...]
+    json_body: Mapping[str, Any]
+    vendor: str = ""
+    source_corpus: str = ""
+
+    def __post_init__(self) -> None:
+        """Normalize method storage while preserving public record data."""
+        if not self.rest_api:
+            raise ValueError("rest_api must be non-empty")
+        object.__setattr__(self, "allowed_methods", tuple(self.allowed_methods))
+
+    def to_prompt_dict(self) -> dict[str, Any]:
+        """Return the public-safe record shape used by configured prompts."""
+        return {
+            "rest_api": self.rest_api,
+            "allowed_methods": list(self.allowed_methods),
+            "json": dict(self.json_body),
+            "vendor": self.vendor,
+            "source_corpus": self.source_corpus,
+        }
+
+
+@dataclass(frozen=True)
+class Phase2RequestSample:
+    """A sampled set of one to three REST API records."""
+
+    records: tuple[Phase2RestApiRecord, ...]
+
+    @property
+    def sample_width(self) -> int:
+        """Return the number of sampled REST API records."""
+        return len(self.records)
+
+    @property
+    def rest_api_list(self) -> tuple[str, ...]:
+        """Return sampled REST APIs in deterministic stored order."""
+        return tuple(record.rest_api for record in self.records)
+
+    @property
+    def allowed_methods_by_rest_api(self) -> dict[str, list[str]]:
+        """Return allowed HTTP methods keyed by REST API."""
+        return {
+            record.rest_api: list(record.allowed_methods)
+            for record in self.records
+        }
+
+    def to_prompt_payload(self) -> list[dict[str, Any]]:
+        """Return the sampled record payload for prompt rendering."""
+        return [record.to_prompt_dict() for record in self.records]
+
+
+@dataclass(frozen=True)
+class ProJudgeResult:
+    """Parsed private-judge decision for one drafted request label."""
+
+    valid_json: bool
+    accepted: bool
+    pro_accept: bool
+    rest_api_set_match: bool
+    empty_set_match: bool
+    nonsense: bool
+    invalid_json: bool
+    rest_api_list: tuple[str, ...] = ()
+    reason: str = ""
+    raw: str = ""
+
+
+@dataclass
+class Phase2LabelledRequestCounters:
+    """Offline counters for Phase 2 labelled request generation metrics."""
+
+    draft_total: int = 0
+    accepted_total: int = 0
+    rejected_total: int = 0
+    nonsense_total: int = 0
+    invalid_json_total: int = 0
+    pro_accept_total: int = 0
+    rest_api_set_match_total: int = 0
+    empty_set_match_total: int = 0
+    last_sample_width: int = 0
+    last_vendor: str = ""
+    last_source_corpus: str = ""
+
+    def record_outcome(
+        self,
+        result: ProJudgeResult,
+        *,
+        sample_width: int,
+        vendor: str,
+        source_corpus: str,
+        spec: Phase2LabelledRequestsSpec,
+    ) -> None:
+        """Record one draft/judge outcome without opening a live metrics run."""
+        if sample_width not in spec.sample_widths:
+            raise ValueError(f"sample width must be one of {spec.sample_widths}")
+
+        self.draft_total += 1
+        self.last_sample_width = sample_width
+        self.last_vendor = vendor
+        self.last_source_corpus = source_corpus
+
+        if result.accepted:
+            self.accepted_total += 1
+        else:
+            self.rejected_total += 1
+        if result.nonsense:
+            self.nonsense_total += 1
+        if result.invalid_json:
+            self.invalid_json_total += 1
+        if result.pro_accept:
+            self.pro_accept_total += 1
+        if result.rest_api_set_match:
+            self.rest_api_set_match_total += 1
+        if result.empty_set_match:
+            self.empty_set_match_total += 1
+
+    def to_wandb_metrics(self, spec: Phase2LabelledRequestsSpec) -> dict[str, Any]:
+        """Return metric-key/value pairs suitable for an offline W&B logger seam."""
+        namespace = _required_string(spec.wandb, "namespace", context="wandb")
+        source_value = (
+            f"{self.last_vendor}/{self.last_source_corpus}"
+            if self.last_vendor or self.last_source_corpus else ""
+        )
+        return {
+            phase_metric(namespace, "build", "draft_total"): self.draft_total,
+            phase_metric(namespace, "build", "accepted_total"): self.accepted_total,
+            phase_metric(namespace, "build", "rejected_total"): self.rejected_total,
+            phase_metric(namespace, "eval", "nonsense_rate"): self._rate(self.nonsense_total),
+            phase_metric(namespace, "eval", "invalid_json_rate"): self._rate(
+                self.invalid_json_total
+            ),
+            phase_metric(namespace, "eval", "pro_accept_rate"): self._rate(
+                self.pro_accept_total
+            ),
+            phase_metric(namespace, "eval", "rest_api_set_match_rate"): self._rate(
+                self.rest_api_set_match_total
+            ),
+            phase_metric(namespace, "eval", "empty_set_match_rate"): self._rate(
+                self.empty_set_match_total
+            ),
+            phase_metric(namespace, "sample_width", "k"): self.last_sample_width,
+            phase_metric(namespace, "vendor", "source_corpus"): source_value,
+            phase_metric(namespace, "spec", "prompt_spec_version"): spec.version,
+            phase_metric(namespace, "model", "model_x_artifact_sha"): _required_string(
+                spec.model_x, "artifact_sha", context="model_x"
+            ),
+            phase_metric(namespace, "judge", "model"): _required_string(
+                spec.judge, "model", context="judge"
+            ),
+            phase_metric(namespace, "judge", "profile"): _required_string(
+                spec.judge, "profile", context="judge"
+            ),
+        }
+
+    def _rate(self, numerator: int) -> float:
+        """Return a stable zero-safe rate over drafted examples."""
+        if self.draft_total == 0:
+            return 0.0
+        return numerator / self.draft_total
+
+
+def load_phase2_labelled_requests_spec(
+    path: str | Path,
+) -> Phase2LabelledRequestsSpec:
+    """Load and validate the Phase 2 labelled request YAML spec."""
+    spec_path = Path(path)
+    try:
+        raw = yaml.safe_load(spec_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise Phase2LabelledRequestsSpecError(
+            f"cannot read Phase 2 labelled request spec {spec_path}: {exc}"
+        ) from exc
+    except yaml.YAMLError as exc:
+        raise Phase2LabelledRequestsSpecError(
+            f"cannot parse YAML in Phase 2 labelled request spec {spec_path}: {exc}"
+        ) from exc
+
+    if not isinstance(raw, dict):
+        raise Phase2LabelledRequestsSpecError("Phase 2 spec must be a YAML mapping")
+
+    unknown = sorted(set(raw) - _TOP_LEVEL_KEYS)
+    if unknown:
+        raise Phase2LabelledRequestsSpecError(
+            f"unknown top-level keys: {', '.join(unknown)}"
+        )
+
+    version = _required_string(raw, "version")
+    dataset_name = _required_string(raw, "dataset_name")
+    sample_widths = _sample_widths(raw.get("sample_widths"))
+    prompts = _prompt_specs(_mapping(raw, "prompts", required=True))
+
+    return Phase2LabelledRequestsSpec(
+        path=spec_path,
+        version=version,
+        dataset_name=dataset_name,
+        sample_widths=sample_widths,
+        wandb=_mapping(raw, "wandb", required=True),
+        model_x=_mapping(raw, "model_x", required=True),
+        judge=_mapping(raw, "judge", required=True),
+        generation=_mapping(raw, "generation", required=True),
+        acceptance_thresholds=_float_mapping(
+            _mapping(raw, "acceptance_thresholds", required=True),
+            "acceptance_thresholds",
+        ),
+        prompts=prompts,
+    )
+
+
+def sample_rest_api_records(
+    records: Sequence[Phase2RestApiRecord],
+    *,
+    k: int,
+    rng: random.Random,
+    allowed_widths: Sequence[int],
+) -> Phase2RequestSample:
+    """Sample ``k`` REST API records without replacement."""
+    allowed = tuple(allowed_widths)
+    if k not in allowed:
+        raise ValueError(f"sample width must be one of {allowed}")
+    if len(records) < k:
+        raise ValueError("not enough records to sample requested width")
+    return Phase2RequestSample(tuple(rng.sample(list(records), k)))
+
+
+def render_phase2_prompt(
+    spec: Phase2LabelledRequestsSpec,
+    prompt_name: str,
+    sample: Phase2RequestSample,
+    *,
+    draft_text: str = "",
+) -> str:
+    """Render a configured Phase 2 prompt for one sampled record set."""
+    try:
+        prompt = spec.prompts[prompt_name]
+    except KeyError as exc:
+        raise Phase2LabelledRequestsSpecError(
+            f"unknown prompt in Phase 2 spec: {prompt_name}"
+        ) from exc
+
+    variables = {
+        "dataset_name": spec.dataset_name,
+        "prompt_spec_version": prompt.version,
+        "sample_width": sample.sample_width,
+        "records_json": _json(sample.to_prompt_payload()),
+        "rest_api_list_json": _json(list(sample.rest_api_list)),
+        "allowed_methods_json": _json(sample.allowed_methods_by_rest_api),
+        "draft_text": draft_text,
+        "judge_model": _required_string(spec.judge, "model", context="judge"),
+        "judge_profile": _required_string(spec.judge, "profile", context="judge"),
+        "model_x_id": _required_string(spec.model_x, "id", context="model_x"),
+    }
+    try:
+        return prompt.template.format(**variables)
+    except KeyError as exc:
+        missing = exc.args[0]
+        raise Phase2LabelledRequestsSpecError(
+            f"prompt {prompt_name} references unknown variable {missing}"
+        ) from exc
+
+
+def rest_api_sets_equal(
+    expected_rest_apis: Sequence[str],
+    actual_rest_apis: Sequence[str],
+) -> bool:
+    """Return unordered REST API set equality; empty set equals empty set."""
+    return frozenset(expected_rest_apis) == frozenset(actual_rest_apis)
+
+
+def parse_pro_judge_result(
+    raw: str,
+    *,
+    expected_rest_apis: Sequence[str],
+) -> ProJudgeResult:
+    """Parse a private Pro judge JSON response for one drafted label."""
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return ProJudgeResult(
+            valid_json=False,
+            accepted=False,
+            pro_accept=False,
+            rest_api_set_match=False,
+            empty_set_match=False,
+            nonsense=False,
+            invalid_json=True,
+            reason=str(exc),
+            raw=raw,
+        )
+
+    if not isinstance(decoded, Mapping):
+        return ProJudgeResult(
+            valid_json=False,
+            accepted=False,
+            pro_accept=False,
+            rest_api_set_match=False,
+            empty_set_match=False,
+            nonsense=False,
+            invalid_json=True,
+            reason="judge response must be a JSON object",
+            raw=raw,
+        )
+
+    rest_api_list = _string_tuple(
+        decoded.get("rest_api_list", decoded.get("rest_api_set", ())),
+        "rest_api_list",
+    )
+    computed_set_match = rest_api_sets_equal(expected_rest_apis, rest_api_list)
+    judge_set_match = decoded.get("rest_api_set_match")
+    rest_api_set_match = (
+        computed_set_match if not isinstance(judge_set_match, bool)
+        else judge_set_match and computed_set_match
+    )
+    empty_set_match = not expected_rest_apis and not rest_api_list
+    nonsense = bool(decoded.get("nonsense", False))
+    requested_accept = bool(decoded.get("accepted", decoded.get("accept", False)))
+    pro_accept = requested_accept and rest_api_set_match and not nonsense
+
+    return ProJudgeResult(
+        valid_json=True,
+        accepted=pro_accept,
+        pro_accept=pro_accept,
+        rest_api_set_match=rest_api_set_match,
+        empty_set_match=empty_set_match,
+        nonsense=nonsense,
+        invalid_json=False,
+        rest_api_list=rest_api_list,
+        reason=str(decoded.get("reason", "")),
+        raw=raw,
+    )
+
+
+def _mapping(raw: Mapping[str, Any], key: str, *, required: bool = False) -> dict[str, Any]:
+    """Return a YAML mapping field as a dict."""
+    value = raw.get(key)
+    if value is None:
+        if required:
+            raise Phase2LabelledRequestsSpecError(f"missing required field: {key}")
+        return {}
+    if not isinstance(value, Mapping):
+        raise Phase2LabelledRequestsSpecError(f"{key} must be a mapping")
+    return dict(value)
+
+
+def _required_string(
+    raw: Mapping[str, Any],
+    key: str,
+    *,
+    context: str | None = None,
+) -> str:
+    """Return a non-empty string field from a mapping."""
+    value = raw.get(key)
+    if not isinstance(value, str) or not value:
+        prefix = f"{context}." if context else ""
+        raise Phase2LabelledRequestsSpecError(f"{prefix}{key} must be a non-empty string")
+    return value
+
+
+def _sample_widths(value: Any) -> tuple[int, ...]:
+    """Validate configured sample widths."""
+    if not isinstance(value, list) or not value:
+        raise Phase2LabelledRequestsSpecError("sample_widths must be a non-empty list")
+    widths = tuple(value)
+    if widths != _PHASE2_SAMPLE_WIDTHS:
+        raise Phase2LabelledRequestsSpecError(
+            f"sample_widths must be {list(_PHASE2_SAMPLE_WIDTHS)}"
+        )
+    return widths
+
+
+def _prompt_specs(raw: Mapping[str, Any]) -> dict[str, PromptSpec]:
+    """Normalize prompt specs from the YAML mapping."""
+    prompts: dict[str, PromptSpec] = {}
+    for name, value in raw.items():
+        if not isinstance(value, Mapping):
+            raise Phase2LabelledRequestsSpecError(f"prompt {name} must be a mapping")
+        prompt = dict(value)
+        prompts[name] = PromptSpec(
+            name=name,
+            version=_required_string(prompt, "version", context=f"prompts.{name}"),
+            template=_required_string(prompt, "template", context=f"prompts.{name}"),
+        )
+    return prompts
+
+
+def _float_mapping(raw: Mapping[str, Any], context: str) -> dict[str, float]:
+    """Return a mapping whose values are numeric thresholds."""
+    out: dict[str, float] = {}
+    for key, value in raw.items():
+        if not isinstance(value, (int, float)):
+            raise Phase2LabelledRequestsSpecError(f"{context}.{key} must be numeric")
+        out[str(key)] = float(value)
+    return out
+
+
+def _string_tuple(value: Any, context: str) -> tuple[str, ...]:
+    """Return a tuple of strings from a JSON list field."""
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise Phase2LabelledRequestsSpecError(f"{context} must be a list")
+    if not all(isinstance(item, str) for item in value):
+        raise Phase2LabelledRequestsSpecError(f"{context} entries must be strings")
+    return tuple(value)
+
+
+def _json(value: Any) -> str:
+    """Return stable pretty JSON for prompt variables."""
+    return json.dumps(value, indent=2, sort_keys=True)
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/igc/ds/phase2_labelled_requests.py
+++ b/igc/ds/phase2_labelled_requests.py
@@ -1,0 +1,550 @@
+"""Offline Phase 2 labelled-request dataset plumbing.
+
+Used by tests and future dataset-build scripts when constructing
+``phase2_labelled_requests`` rows from Redfish REST API evidence. The module is
+pure: it loads YAML specs, renders configured prompts, samples tiny records, and
+parses injected judge responses without opening W&B, loading a model, or calling
+the network.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from pathlib import Path
+import random
+from typing import Any, Callable, Mapping, Sequence
+
+import yaml
+
+from igc.modules.base.metric_keys import (
+    PHASE2_LABELLED_REQUESTS,
+    PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS,
+)
+
+_DRAFT_TOTAL_KEY = PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS[0]
+_ACCEPTED_TOTAL_KEY = PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS[1]
+_REJECTED_TOTAL_KEY = PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS[2]
+_NONSENSE_RATE_KEY = PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS[3]
+_INVALID_JSON_RATE_KEY = PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS[4]
+_PRO_ACCEPT_RATE_KEY = PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS[5]
+_REST_API_SET_MATCH_RATE_KEY = PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS[6]
+_EMPTY_SET_MATCH_RATE_KEY = PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS[7]
+
+
+class Phase2LabelledRequestsSpecError(ValueError):
+    """Raised when the labelled-request YAML spec is missing required fields."""
+
+
+@dataclass(frozen=True)
+class RestApiRecord:
+    """One sampled Redfish REST API record.
+
+    :param rest_api: concrete Redfish URI sampled from the corpus.
+    :param allowed_methods: HTTP methods legal on this URI.
+    :param json_body: Redfish response body for the URI.
+    :param vendor: vendor/source family used for metric grouping.
+    :param source_corpus: corpus artifact or fixture name that supplied the row.
+    """
+
+    rest_api: str  # concrete Redfish URI that becomes part of the known target set.
+    allowed_methods: tuple[str, ...]  # HTTP methods legal on this URI.
+    json_body: Mapping[str, Any]  # Redfish response body shown as evidence.
+    vendor: str = ""  # vendor/source family for W&B grouping.
+    source_corpus: str = ""  # corpus artifact or fixture name for provenance.
+
+    def to_prompt_dict(self) -> dict[str, Any]:
+        """Serialize the record shape shown to model and judge prompts."""
+        return {
+            "rest_api": self.rest_api,  # sampled API path the text must cover.
+            "allowed_methods": list(self.allowed_methods),  # legal methods for this API.
+            "json": dict(self.json_body),  # JSON evidence for this API.
+            "vendor": self.vendor,  # vendor/source family for provenance.
+            "source_corpus": self.source_corpus,  # corpus artifact or fixture name.
+        }
+
+
+@dataclass(frozen=True)
+class ModelXSpec:
+    """Configured model_x identity for draft text generation."""
+
+    model_id: str  # model identifier or runtime placeholder supplied by YAML.
+    artifact_sha: str = ""  # Phase 1 artifact SHA or runtime placeholder.
+
+
+@dataclass(frozen=True)
+class JudgeSpec:
+    """Configured private judge routing profile."""
+
+    route: str  # judge route name, for example a private Pro route placeholder.
+    model_id: str  # judge model identifier or runtime placeholder supplied by YAML.
+    profile: str  # judge invocation profile or runtime placeholder.
+
+
+@dataclass(frozen=True)
+class Phase2LabelledRequestsSpec:
+    """Loaded YAML contract for labelled-request generation.
+
+    :param dataset_name: canonical emitted dataset name.
+    :param prompt_spec_version: version string copied into rows and metrics.
+    :param sample_widths: accepted sample widths, always one, two, and three.
+    :param model_x: configured draft model identity.
+    :param judge: configured private judge route and model profile.
+    :param generation: generation knobs passed to the injected draft provider.
+    :param model_x_system: system prompt text for the draft provider.
+    :param model_x_template: prompt template for sampled records.
+    :param judge_system: system prompt text for the judge provider.
+    :param judge_template: prompt template for records plus draft text.
+    :param wandb_namespace: W&B namespace for builder metrics.
+    :param metric_keys: complete metric-key list from the spec.
+    :param acceptance_thresholds: configured acceptance thresholds.
+    """
+
+    dataset_name: str  # canonical emitted dataset name.
+    prompt_spec_version: str  # prompt/spec version copied into rows.
+    sample_widths: tuple[int, ...]  # accepted sample widths.
+    model_x: ModelXSpec  # draft model identity from YAML.
+    judge: JudgeSpec  # judge route and model identity from YAML.
+    generation: Mapping[str, Any]  # generation settings passed through unchanged.
+    model_x_system: str  # YAML system prompt for model_x draft generation.
+    model_x_template: str  # YAML prompt template for sampled records.
+    judge_system: str  # YAML system prompt for private judge review.
+    judge_template: str  # YAML prompt template for judge input.
+    wandb_namespace: str  # W&B metric namespace.
+    metric_keys: tuple[str, ...]  # metric keys declared by the spec.
+    acceptance_thresholds: Mapping[str, float]  # acceptance threshold values.
+
+
+@dataclass(frozen=True)
+class ProJudgeResult:
+    """Parsed private judge decision for one draft text."""
+
+    accepted: bool  # whether the judge says this text may enter the dataset.
+    rest_api_list: tuple[str, ...] = ()  # API set the judge extracted from text.
+    nonsense: bool = False  # true when the draft is junk or not an operator request.
+    invalid_json: bool = False  # true when the judge response could not be parsed.
+    reason: str = ""  # short non-secret judge reason.
+    order_evidence: str = "none"  # explicit order signal, or ``none``.
+
+
+@dataclass(frozen=True)
+class Phase2LabelledRequestRow:
+    """Accepted Phase 2 labelled-request row."""
+
+    text: str  # human request text accepted by the private judge.
+    records: tuple[RestApiRecord, ...]  # sampled Redfish records used as context.
+    rest_api_list: tuple[str, ...]  # canonical sampled REST API list.
+    order_evidence: str  # explicit order signal, or ``none``.
+    prompt_spec_version: str  # prompt/spec version used for this row.
+    validation: Mapping[str, Any] = field(default_factory=dict)  # judge validation flags.
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the accepted row as JSON-compatible data."""
+        allowed_methods = {
+            record.rest_api: list(record.allowed_methods)
+            for record in self.records
+        }
+        return {
+            "phase": 2,  # Phase number for labelled-request rows.
+            "dataset": PHASE2_LABELLED_REQUESTS,  # canonical dataset name.
+            "task": "text_to_rest_api_set",  # Phase 2 extraction task.
+            "x": {
+                "text": self.text,  # accepted human request text.
+                "json": [dict(record.json_body) for record in self.records],  # JSON context.
+                "allowed_methods": allowed_methods,  # legal methods per REST API.
+                "rest_api_list": list(self.rest_api_list),  # context API list.
+            },
+            "y_true": {
+                "rest_api_list": list(self.rest_api_list),  # unordered target API set.
+                "order_evidence": self.order_evidence,  # explicit order signal if any.
+            },
+            "validation": dict(self.validation),  # judge verdict details.
+            "metadata": {
+                "prompt_spec_version": self.prompt_spec_version,  # prompt/config version.
+                "vendor": [record.vendor for record in self.records],  # vendor provenance.
+                "source_corpus": [record.source_corpus for record in self.records],  # corpus provenance.
+            },
+        }
+
+
+DraftProvider = Callable[[dict[str, Any]], str]
+JudgeProvider = Callable[[dict[str, Any]], str]
+
+
+def load_phase2_labelled_requests_spec(path: str | Path) -> Phase2LabelledRequestsSpec:
+    """Load and validate a labelled-request YAML spec.
+
+    :param path: YAML spec path.
+    :return: normalized spec object.
+    :raises Phase2LabelledRequestsSpecError: if required fields are missing.
+    """
+    spec_path = Path(path)
+    try:
+        raw = yaml.safe_load(spec_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise Phase2LabelledRequestsSpecError(f"cannot read spec {spec_path}: {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise Phase2LabelledRequestsSpecError(f"cannot parse YAML in {spec_path}: {exc}") from exc
+
+    if not isinstance(raw, Mapping):
+        raise Phase2LabelledRequestsSpecError("phase2 labelled-request spec must be a mapping")
+
+    dataset = _mapping(raw, "dataset", required=True)
+    dataset_name = _required_string(dataset, "name", "dataset.name")
+    if dataset_name != PHASE2_LABELLED_REQUESTS:
+        raise Phase2LabelledRequestsSpecError(
+            f"dataset.name must be {PHASE2_LABELLED_REQUESTS!r}",
+        )
+
+    sampling = _mapping(raw, "sampling", required=True)
+    sample_widths = tuple(int(width) for width in _sequence(sampling, "sample_widths"))
+    if sample_widths != (1, 2, 3):
+        raise Phase2LabelledRequestsSpecError("sampling.sample_widths must be [1, 2, 3]")
+
+    model_x_raw = _mapping(raw, "model_x", required=True)
+    judge_raw = _mapping(raw, "judge", required=True)
+    prompts = _mapping(raw, "prompts", required=True)
+    model_prompt = _mapping(prompts, "model_x_draft", required=True)
+    judge_prompt = _mapping(prompts, "pro_judge", required=True)
+    wandb = _mapping(raw, "wandb", required=True)
+
+    metric_keys = tuple(str(key) for key in _sequence(wandb, "metric_keys"))
+    if metric_keys != PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS:
+        raise Phase2LabelledRequestsSpecError("wandb.metric_keys must match the registry")
+
+    wandb_namespace = _required_string(wandb, "namespace", "wandb.namespace")
+    if wandb_namespace != PHASE2_LABELLED_REQUESTS:
+        raise Phase2LabelledRequestsSpecError(
+            f"wandb.namespace must be {PHASE2_LABELLED_REQUESTS!r}",
+        )
+
+    return Phase2LabelledRequestsSpec(
+        dataset_name=dataset_name,
+        prompt_spec_version=_required_string(
+            dataset,
+            "prompt_spec_version",
+            "dataset.prompt_spec_version",
+        ),
+        sample_widths=sample_widths,
+        model_x=ModelXSpec(
+            model_id=_required_string(model_x_raw, "model_id", "model_x.model_id"),
+            artifact_sha=str(model_x_raw.get("artifact_sha", "")),
+        ),
+        judge=JudgeSpec(
+            route=_required_string(judge_raw, "route", "judge.route"),
+            model_id=_required_string(judge_raw, "model_id", "judge.model_id"),
+            profile=_required_string(judge_raw, "profile", "judge.profile"),
+        ),
+        generation=dict(_mapping(raw, "generation", required=True)),
+        model_x_system=_required_string(model_prompt, "system", "prompts.model_x_draft.system"),
+        model_x_template=_required_string(
+            model_prompt,
+            "template",
+            "prompts.model_x_draft.template",
+        ),
+        judge_system=_required_string(judge_prompt, "system", "prompts.pro_judge.system"),
+        judge_template=_required_string(judge_prompt, "template", "prompts.pro_judge.template"),
+        wandb_namespace=wandb_namespace,
+        metric_keys=metric_keys,
+        acceptance_thresholds={
+            key: float(value)
+            for key, value in _mapping(raw, "acceptance", required=True).items()
+        },
+    )
+
+
+def render_model_x_prompt(
+    spec: Phase2LabelledRequestsSpec,
+    records: Sequence[RestApiRecord],
+) -> str:
+    """Render the model_x prompt from YAML-provided prompt fields."""
+    return _render_prompt(
+        system=spec.model_x_system,
+        template=spec.model_x_template,
+        records=records,
+        draft_text="",
+    )
+
+
+def render_pro_judge_prompt(
+    spec: Phase2LabelledRequestsSpec,
+    records: Sequence[RestApiRecord],
+    draft_text: str,
+) -> str:
+    """Render the private judge prompt from YAML-provided prompt fields."""
+    return _render_prompt(
+        system=spec.judge_system,
+        template=spec.judge_template,
+        records=records,
+        draft_text=draft_text,
+    )
+
+
+def sample_phase2_contexts(
+    records: Sequence[RestApiRecord],
+    *,
+    k: int,
+    rng: random.Random,
+) -> tuple[RestApiRecord, ...]:
+    """Sample one, two, or three REST API records without replacement."""
+    if k not in (1, 2, 3):
+        raise ValueError("sample width must be one of 1, 2, or 3")
+    if len(records) < k:
+        raise ValueError("not enough records for requested sample width")
+    return tuple(rng.sample(list(records), k))
+
+
+def parse_pro_judge_result(raw: str) -> ProJudgeResult:
+    """Parse a private judge JSON result without raising on malformed output."""
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return ProJudgeResult(
+            accepted=False,
+            invalid_json=True,
+            reason=f"invalid_json: {exc.msg}",
+        )
+    if isinstance(parsed, Mapping) and isinstance(parsed.get("y_pred"), Mapping):
+        parsed = parsed["y_pred"]
+    if not isinstance(parsed, Mapping):
+        return ProJudgeResult(accepted=False, invalid_json=True, reason="judge result is not a mapping")
+
+    rest_api_list = parsed.get("rest_api_list", ())
+    if not isinstance(rest_api_list, Sequence) or isinstance(rest_api_list, (str, bytes)):
+        return ProJudgeResult(accepted=False, invalid_json=True, reason="rest_api_list is not a list")
+
+    return ProJudgeResult(
+        accepted=bool(parsed.get("accepted", False)),
+        rest_api_list=tuple(str(item) for item in rest_api_list),
+        nonsense=bool(parsed.get("nonsense", False)),
+        invalid_json=False,
+        reason=str(parsed.get("reason", "")),
+        order_evidence=str(parsed.get("order_evidence", "none")),
+    )
+
+
+def compare_rest_api_sets(expected: Sequence[str], predicted: Sequence[str]) -> bool:
+    """Return true when two REST API lists name the same unordered set."""
+    return set(expected) == set(predicted)
+
+
+def empty_set_matches(expected: Sequence[str], predicted: Sequence[str]) -> bool:
+    """Return true only when both expected and predicted API sets are empty."""
+    return not expected and not predicted
+
+
+@dataclass
+class Phase2LabelledRequestCounters:
+    """Counters and rates for offline labelled-request generation."""
+
+    draft_total: int = 0  # number of draft text attempts.
+    accepted_total: int = 0  # number of rows accepted into the dataset.
+    rejected_total: int = 0  # number of rows rejected by parser/judge/set check.
+    nonsense_total: int = 0  # number of drafts flagged as nonsense.
+    invalid_json_total: int = 0  # number of judge responses with invalid JSON.
+    rest_api_set_match_total: int = 0  # number of rows with matching API sets.
+    empty_set_expected_total: int = 0  # number of valid judged no-action rows.
+    empty_set_match_total: int = 0  # number of valid judged no-action matches.
+
+    def observe_draft(self, text: str) -> None:
+        """Count one draft attempt.
+
+        :param text: generated text; stored only as quality signal, never logged.
+        """
+        _ = text
+        self.draft_total += 1
+
+    def observe_judge(
+        self,
+        result: ProJudgeResult,
+        *,
+        expected_rest_api_list: Sequence[str],
+    ) -> None:
+        """Count one parsed judge decision against the known sampled API set."""
+        set_match = (
+            not result.invalid_json
+            and compare_rest_api_sets(expected_rest_api_list, result.rest_api_list)
+        )
+        accepted = result.accepted and set_match and not result.nonsense and not result.invalid_json
+
+        if result.nonsense:
+            self.nonsense_total += 1
+        if result.invalid_json:
+            self.invalid_json_total += 1
+        if set_match:
+            self.rest_api_set_match_total += 1
+        if not result.invalid_json and not expected_rest_api_list:
+            self.empty_set_expected_total += 1
+            if empty_set_matches(expected_rest_api_list, result.rest_api_list):
+                self.empty_set_match_total += 1
+        if accepted:
+            self.accepted_total += 1
+        else:
+            self.rejected_total += 1
+
+    def summary(self) -> dict[str, float | int]:
+        """Return scalar metrics suitable for W&B/TensorBoard logging."""
+        return {
+            _DRAFT_TOTAL_KEY: self.draft_total,
+            _ACCEPTED_TOTAL_KEY: self.accepted_total,
+            _REJECTED_TOTAL_KEY: self.rejected_total,
+            _NONSENSE_RATE_KEY: _rate(self.nonsense_total, self.draft_total),
+            _INVALID_JSON_RATE_KEY: _rate(self.invalid_json_total, self.draft_total),
+            _PRO_ACCEPT_RATE_KEY: _rate(self.accepted_total, self.draft_total),
+            _REST_API_SET_MATCH_RATE_KEY: _rate(self.rest_api_set_match_total, self.draft_total),
+            _EMPTY_SET_MATCH_RATE_KEY: _rate(
+                self.empty_set_match_total,
+                self.empty_set_expected_total,
+            ),
+        }
+
+
+class Phase2LabelledRequestBuilder:
+    """Offline builder that uses injected model_x and judge providers."""
+
+    def __init__(
+        self,
+        spec: Phase2LabelledRequestsSpec,
+        *,
+        draft_provider: DraftProvider,
+        judge_provider: JudgeProvider,
+    ) -> None:
+        """Create a builder with pure injected provider callables."""
+        self._spec = spec
+        self._draft_provider = draft_provider
+        self._judge_provider = judge_provider
+
+    def build_one(
+        self,
+        records: Sequence[RestApiRecord],
+        *,
+        k: int,
+        rng: random.Random,
+    ) -> tuple[Phase2LabelledRequestRow | None, Phase2LabelledRequestCounters]:
+        """Build and judge one accepted row candidate.
+
+        :param records: candidate REST API records.
+        :param k: sample width, one through three.
+        :param rng: deterministic RNG supplied by the caller.
+        :return: accepted row plus counters, or ``None`` plus rejection counters.
+        """
+        sampled = sample_phase2_contexts(records, k=k, rng=rng)
+        expected_rest_api_list = tuple(record.rest_api for record in sampled)
+        counters = Phase2LabelledRequestCounters()
+
+        draft_request = {
+            "prompt": render_model_x_prompt(self._spec, sampled),  # full configured prompt.
+            "model_id": self._spec.model_x.model_id,  # draft model from YAML.
+            "generation": dict(self._spec.generation),  # generation knobs from YAML.
+            "sample_width": k,  # current sample width metric value.
+        }
+        draft_text = self._draft_provider(draft_request)
+        counters.observe_draft(draft_text)
+
+        judge_request = {
+            "prompt": render_pro_judge_prompt(self._spec, sampled, draft_text),  # judge prompt.
+            "model_id": self._spec.judge.model_id,  # judge model from YAML.
+            "profile": self._spec.judge.profile,  # judge profile from YAML.
+            "route": self._spec.judge.route,  # judge route from YAML.
+            "expected_rest_api_list": list(expected_rest_api_list),  # known sampled set.
+        }
+        judge_result = parse_pro_judge_result(self._judge_provider(judge_request))
+        counters.observe_judge(judge_result, expected_rest_api_list=expected_rest_api_list)
+
+        set_match = compare_rest_api_sets(expected_rest_api_list, judge_result.rest_api_list)
+        accepted = (
+            judge_result.accepted
+            and set_match
+            and not judge_result.nonsense
+            and not judge_result.invalid_json
+        )
+        if not accepted:
+            return None, counters
+
+        row = Phase2LabelledRequestRow(
+            text=draft_text,
+            records=sampled,
+            rest_api_list=expected_rest_api_list,
+            order_evidence=judge_result.order_evidence,
+            prompt_spec_version=self._spec.prompt_spec_version,
+            validation={
+                "text_source": "model_x_then_private_judge",  # draft then judge path.
+                "review_judged": True,  # private judge parsed successfully.
+                "all_rest_api_present": set(expected_rest_api_list) <= set(judge_result.rest_api_list),
+                "extra_rest_api_present": not set(judge_result.rest_api_list) <= set(expected_rest_api_list),
+                "set_coverage_preserved": set_match,  # unordered API set contract.
+                "nonsense": judge_result.nonsense,  # judge nonsense flag.
+            },
+        )
+        return row, counters
+
+
+def to_minimal_phase3_input(row: Phase2LabelledRequestRow | None) -> dict[str, Any]:
+    """Convert an accepted Phase 2 row into a Phase 3 input fixture."""
+    if row is None:
+        raise ValueError("phase2 row is required")
+    allowed_methods = {
+        record.rest_api: list(record.allowed_methods)
+        for record in row.records
+    }
+    return {
+        "text": row.text,  # accepted human request text.
+        "rest_api_list": list(row.rest_api_list),  # Phase 2 API-set target.
+        "json": [dict(record.json_body) for record in row.records],  # same-row JSON context.
+        "allowed_methods": allowed_methods,  # same-row allowed methods.
+    }
+
+
+def _render_prompt(
+    *,
+    system: str,
+    template: str,
+    records: Sequence[RestApiRecord],
+    draft_text: str,
+) -> str:
+    """Render a configured prompt template with JSON-safe record payloads."""
+    records_json = json.dumps(
+        [record.to_prompt_dict() for record in records],
+        indent=2,
+        sort_keys=True,
+    )
+    body = template.format(records_json=records_json, draft_text=draft_text)
+    return f"{system.rstrip()}\n\n{body.strip()}"
+
+
+def _mapping(source: Mapping[str, Any], key: str, *, required: bool = False) -> Mapping[str, Any]:
+    """Read a YAML child mapping."""
+    value = source.get(key)
+    if value is None and not required:
+        return {}
+    if not isinstance(value, Mapping):
+        raise Phase2LabelledRequestsSpecError(f"{key} must be a mapping")
+    return value
+
+
+def _sequence(source: Mapping[str, Any], key: str) -> Sequence[Any]:
+    """Read a YAML sequence field."""
+    value = source.get(key)
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise Phase2LabelledRequestsSpecError(f"{key} must be a sequence")
+    return value
+
+
+def _required_string(source: Mapping[str, Any], key: str, label: str) -> str:
+    """Read a required non-empty YAML string field."""
+    value = source.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise Phase2LabelledRequestsSpecError(f"{label} must be a non-empty string")
+    return value
+
+
+def _rate(numerator: int, denominator: int) -> float:
+    """Compute a stable zero-safe rate."""
+    if denominator <= 0:
+        return 0.0
+    return numerator / denominator
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/igc/ds/phase2_labelled_requests.py
+++ b/igc/ds/phase2_labelled_requests.py
@@ -46,6 +46,7 @@ _REQUIRED_ACCEPTANCE_KEYS = (
     "max_nonsense_rate",
     "max_invalid_json_rate",
 )
+_PROVIDER_ADAPTERS = frozenset({"mock", "file", "openai-compatible"})
 
 
 class Phase2LabelledRequestsSpecError(ValueError):
@@ -98,6 +99,28 @@ class JudgeSpec:
 
 
 @dataclass(frozen=True)
+class ProviderAdapterSpec:
+    """Configured provider adapter for draft or judge calls.
+
+    :param adapter: adapter selector loaded from YAML, for example ``mock``.
+    :param base_url_env: environment variable that supplies a live HTTP base URL.
+    :param api_key_env: optional environment variable that supplies a bearer token.
+    :param endpoint_path: HTTP path appended to the configured base URL.
+    :param timeout_seconds: request timeout for live HTTP calls.
+    :param response_text_path: dotted path to text in the provider JSON response.
+    :param payload_request_fields: request fields copied into the live HTTP JSON body.
+    """
+
+    adapter: str  # provider selector; live modes are opt-in by config/CLI.
+    base_url_env: str = ""  # env var containing the live provider base URL.
+    api_key_env: str = ""  # optional env var containing a provider bearer token.
+    endpoint_path: str = ""  # provider endpoint path such as a chat-completions route.
+    timeout_seconds: float = 30.0  # live request timeout.
+    response_text_path: str = ""  # dotted JSON path to generated text.
+    payload_request_fields: tuple[str, ...] = ()  # extra request fields copied to payload.
+
+
+@dataclass(frozen=True)
 class Phase2LabelledRequestsSpec:
     """Loaded YAML contract for labelled-request generation.
 
@@ -111,6 +134,9 @@ class Phase2LabelledRequestsSpec:
     :param model_x_template: prompt template for sampled records.
     :param judge_system: system prompt text for the judge provider.
     :param judge_template: prompt template for records plus draft text.
+    :param draft_provider: configured adapter metadata for model_x drafts.
+    :param judge_provider: configured adapter metadata for private judging.
+    :param live_without_gate_max_candidates: max live candidates allowed without gate flag.
     :param wandb_namespace: W&B namespace for builder metrics.
     :param metric_keys: complete metric-key list from the spec.
     :param acceptance_thresholds: configured acceptance thresholds.
@@ -126,6 +152,9 @@ class Phase2LabelledRequestsSpec:
     model_x_template: str  # YAML prompt template for sampled records.
     judge_system: str  # YAML system prompt for private judge review.
     judge_template: str  # YAML prompt template for judge input.
+    draft_provider: ProviderAdapterSpec  # draft adapter config from YAML.
+    judge_provider: ProviderAdapterSpec  # judge adapter config from YAML.
+    live_without_gate_max_candidates: int  # live candidate cap before gate flag is required.
     wandb_namespace: str  # W&B metric namespace.
     metric_keys: tuple[str, ...]  # metric keys declared by the spec.
     acceptance_thresholds: Mapping[str, float]  # acceptance threshold values.
@@ -178,7 +207,10 @@ class Phase2LabelledRequestRow:
             "metadata": {
                 "prompt_spec_version": self.prompt_spec_version,  # prompt/config version.
                 "vendor": [record.vendor for record in self.records],  # vendor provenance.
-                "source_corpus": [record.source_corpus for record in self.records],  # corpus provenance.
+                "source_corpus": [
+                    record.source_corpus
+                    for record in self.records
+                ],  # corpus provenance.
             },
         }
 
@@ -214,7 +246,10 @@ def load_phase2_labelled_requests_spec(path: str | Path) -> Phase2LabelledReques
 
     sampling = _mapping(raw, "sampling", required=True)
     raw_sample_widths = _sequence(sampling, "sample_widths")
-    if not all(isinstance(width, int) and not isinstance(width, bool) for width in raw_sample_widths):
+    if not all(
+        isinstance(width, int) and not isinstance(width, bool)
+        for width in raw_sample_widths
+    ):
         raise Phase2LabelledRequestsSpecError(
             "sampling.sample_widths must be integer sequence [1, 2, 3]",
         )
@@ -227,6 +262,22 @@ def load_phase2_labelled_requests_spec(path: str | Path) -> Phase2LabelledReques
     prompts = _mapping(raw, "prompts", required=True)
     model_prompt = _mapping(prompts, "model_x_draft", required=True)
     judge_prompt = _mapping(prompts, "pro_judge", required=True)
+    providers = _mapping(raw, "providers", required=True)
+    draft_provider = _provider_adapter_spec(
+        _mapping(providers, "draft"),
+        label="providers.draft",
+    )
+    judge_provider = _provider_adapter_spec(
+        _mapping(providers, "judge"),
+        label="providers.judge",
+    )
+    safety = _mapping(raw, "safety")
+    live_without_gate_max_candidates = _optional_non_negative_int(
+        safety,
+        "live_without_gate_max_candidates",
+        default=3,
+        label="safety.live_without_gate_max_candidates",
+    )
     wandb = _mapping(raw, "wandb", required=True)
 
     metric_keys = tuple(str(key) for key in _sequence(wandb, "metric_keys"))
@@ -281,6 +332,9 @@ def load_phase2_labelled_requests_spec(path: str | Path) -> Phase2LabelledReques
         ),
         judge_system=_required_string(judge_prompt, "system", "prompts.pro_judge.system"),
         judge_template=_required_string(judge_prompt, "template", "prompts.pro_judge.template"),
+        draft_provider=draft_provider,
+        judge_provider=judge_provider,
+        live_without_gate_max_candidates=live_without_gate_max_candidates,
         wandb_namespace=wandb_namespace,
         metric_keys=metric_keys,
         acceptance_thresholds=acceptance_thresholds,
@@ -341,7 +395,11 @@ def parse_pro_judge_result(raw: str) -> ProJudgeResult:
     if isinstance(parsed, Mapping) and isinstance(parsed.get("y_pred"), Mapping):
         parsed = parsed["y_pred"]
     if not isinstance(parsed, Mapping):
-        return ProJudgeResult(accepted=False, invalid_json=True, reason="judge result is not a mapping")
+        return ProJudgeResult(
+            accepted=False,
+            invalid_json=True,
+            reason="judge result is not a mapping",
+        )
 
     if "rest_api_list" in parsed:
         rest_api_value = parsed["rest_api_list"]
@@ -573,8 +631,12 @@ class Phase2LabelledRequestBuilder:
             validation={
                 "text_source": "model_x_then_private_judge",  # draft then judge path.
                 "review_judged": True,  # private judge parsed successfully.
-                "all_rest_api_present": set(expected_rest_api_list) <= set(judge_result.rest_api_list),
-                "extra_rest_api_present": not set(judge_result.rest_api_list) <= set(expected_rest_api_list),
+                "all_rest_api_present": (
+                    set(expected_rest_api_list) <= set(judge_result.rest_api_list)
+                ),
+                "extra_rest_api_present": (
+                    not set(judge_result.rest_api_list) <= set(expected_rest_api_list)
+                ),
                 "set_coverage_preserved": set_match,  # unordered API set contract.
                 "nonsense": judge_result.nonsense,  # judge nonsense flag.
             },
@@ -661,12 +723,102 @@ def _sequence(source: Mapping[str, Any], key: str) -> Sequence[Any]:
     return value
 
 
+def _optional_sequence(source: Mapping[str, Any], key: str) -> Sequence[Any]:
+    """Read an optional YAML sequence field."""
+    value = source.get(key, ())
+    if value == ():
+        return ()
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise Phase2LabelledRequestsSpecError(f"{key} must be a sequence")
+    return value
+
+
 def _required_string(source: Mapping[str, Any], key: str, label: str) -> str:
     """Read a required non-empty YAML string field."""
     value = source.get(key)
     if not isinstance(value, str) or not value.strip():
         raise Phase2LabelledRequestsSpecError(f"{label} must be a non-empty string")
     return value
+
+
+def _optional_string(source: Mapping[str, Any], key: str) -> str:
+    """Read an optional YAML string field."""
+    value = source.get(key, "")
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise Phase2LabelledRequestsSpecError(f"{key} must be a string")
+    return value.strip()
+
+
+def _optional_non_negative_int(
+    source: Mapping[str, Any],
+    key: str,
+    *,
+    default: int,
+    label: str,
+) -> int:
+    """Read an optional non-negative integer YAML field."""
+    value = source.get(key, default)
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise Phase2LabelledRequestsSpecError(f"{label} must be a non-negative integer")
+    return value
+
+
+def _optional_positive_float(source: Mapping[str, Any], key: str, *, default: float) -> float:
+    """Read an optional positive numeric YAML field."""
+    value = source.get(key, default)
+    if isinstance(value, bool):
+        raise Phase2LabelledRequestsSpecError(f"{key} must be numeric")
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise Phase2LabelledRequestsSpecError(f"{key} must be numeric") from exc
+    if result <= 0:
+        raise Phase2LabelledRequestsSpecError(f"{key} must be positive")
+    return result
+
+
+def _provider_adapter_spec(raw: Mapping[str, Any], *, label: str) -> ProviderAdapterSpec:
+    """Load one provider adapter block from YAML."""
+    adapter = _optional_string(raw, "adapter") or "mock"
+    if adapter not in _PROVIDER_ADAPTERS:
+        raise Phase2LabelledRequestsSpecError(
+            f"{label}.adapter must be one of {', '.join(sorted(_PROVIDER_ADAPTERS))}",
+        )
+    payload_values = _optional_sequence(raw, "payload_request_fields")
+    if not all(isinstance(item, str) and item.strip() for item in payload_values):
+        raise Phase2LabelledRequestsSpecError(
+            f"{label}.payload_request_fields must contain strings",
+        )
+    payload_fields = tuple(item.strip() for item in payload_values)
+
+    endpoint_path = _optional_string(raw, "endpoint_path")
+    response_text_path = _optional_string(raw, "response_text_path")
+    base_url_env = _optional_string(raw, "base_url_env")
+    if adapter == "openai-compatible":
+        if not base_url_env:
+            raise Phase2LabelledRequestsSpecError(
+                f"{label}.base_url_env is required for live providers",
+            )
+        if not endpoint_path:
+            raise Phase2LabelledRequestsSpecError(
+                f"{label}.endpoint_path is required for live providers",
+            )
+        if not response_text_path:
+            raise Phase2LabelledRequestsSpecError(
+                f"{label}.response_text_path is required for live providers",
+            )
+
+    return ProviderAdapterSpec(
+        adapter=adapter,
+        base_url_env=base_url_env,
+        api_key_env=_optional_string(raw, "api_key_env"),
+        endpoint_path=endpoint_path,
+        timeout_seconds=_optional_positive_float(raw, "timeout_seconds", default=30.0),
+        response_text_path=response_text_path,
+        payload_request_fields=payload_fields,
+    )
 
 
 def _optional_bool(source: Mapping[str, Any], key: str) -> bool | None:

--- a/igc/modules/base/metric_keys.py
+++ b/igc/modules/base/metric_keys.py
@@ -11,21 +11,23 @@ from __future__ import annotations
 
 PHASE1_PRETRAIN = "phase1_pretrain"
 PHASE2_GOAL_EXTRACT = "phase2_goal_extract"
+PHASE2_LABELLED_REQUESTS = "phase2_labelled_requests"
 PHASE3_ARGUMENT_EXTRACT = "phase3_argument_extract"
 
 
-def phase_metric(namespace: str, group: str, name: str) -> str:
-    """Return a stable ``<namespace>/<group>/<name>`` metric key.
+def phase_metric(namespace: str, group: str, name: str | None = None) -> str:
+    """Return a stable slash-separated metric key.
 
     :param namespace: Phase namespace, for example :data:`PHASE1_PRETRAIN`.
-    :param group: Metric group such as ``train`` or ``eval``.
-    :param name: Metric name inside the group.
+    :param group: Metric group or metric name.
+    :param name: Optional metric name inside the group.
     :return: Slash-separated W&B/TensorBoard metric key.
     :raises ValueError: if any component is empty.
     """
-    if not namespace or not group or not name:
-        raise ValueError("metric namespace, group, and name must be non-empty")
-    return f"{namespace}/{group}/{name}"
+    parts = (namespace, group) if name is None else (namespace, group, name)
+    if any(not part for part in parts):
+        raise ValueError("metric key components must be non-empty")
+    return "/".join(parts)
 
 
 PHASE1_WANDB_METRIC_KEYS = (
@@ -54,6 +56,23 @@ PHASE2_WANDB_METRIC_KEYS = (
     phase_metric(PHASE2_GOAL_EXTRACT, "eval", "missing_allowed_methods_rate"),
     phase_metric(PHASE2_GOAL_EXTRACT, "order", "kendall_tau"),
     phase_metric(PHASE2_GOAL_EXTRACT, "order", "edit_distance"),
+)
+
+PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS = (
+    phase_metric(PHASE2_LABELLED_REQUESTS, "draft_total"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "accepted_total"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "rejected_total"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "nonsense_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "invalid_json_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "pro_accept_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "rest_api_set_match_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "empty_set_match_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "sample_width", "k"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "vendor", "source_corpus"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "prompt_spec_version"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "model_x", "artifact_sha"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "judge", "model"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "judge", "profile"),
 )
 
 PHASE3_WANDB_METRIC_KEYS = (

--- a/igc/modules/base/metric_keys.py
+++ b/igc/modules/base/metric_keys.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 PHASE1_PRETRAIN = "phase1_pretrain"
 PHASE2_GOAL_EXTRACT = "phase2_goal_extract"
+PHASE2_LABELLED_REQUESTS = "phase2_labelled_requests"
 PHASE3_ARGUMENT_EXTRACT = "phase3_argument_extract"
 
 
@@ -54,6 +55,23 @@ PHASE2_WANDB_METRIC_KEYS = (
     phase_metric(PHASE2_GOAL_EXTRACT, "eval", "missing_allowed_methods_rate"),
     phase_metric(PHASE2_GOAL_EXTRACT, "order", "kendall_tau"),
     phase_metric(PHASE2_GOAL_EXTRACT, "order", "edit_distance"),
+)
+
+PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS = (
+    phase_metric(PHASE2_LABELLED_REQUESTS, "build", "draft_total"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "build", "accepted_total"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "build", "rejected_total"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "nonsense_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "invalid_json_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "pro_accept_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "rest_api_set_match_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "empty_set_match_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "sample_width", "k"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "vendor", "source_corpus"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "spec", "prompt_spec_version"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "model", "model_x_artifact_sha"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "judge", "model"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "judge", "profile"),
 )
 
 PHASE3_WANDB_METRIC_KEYS = (

--- a/scripts/build_phase2_labelled_requests.py
+++ b/scripts/build_phase2_labelled_requests.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Build offline ``phase2_labelled_requests`` JSONL rows from fixture records.
+
+The script is deliberately provider-injected: it loads the YAML spec, reads a
+tiny JSONL record fixture, and uses either deterministic mock providers or
+local draft/judge fixture files. It never opens W&B, downloads a model, calls a
+Redfish host, or reaches the network.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import sys
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping
+
+# Running as ``python scripts/build_phase2_labelled_requests.py`` puts
+# scripts/ on sys.path; add the repo root so ``import igc`` works without an
+# editable install.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from igc.ds.phase2_labelled_requests import (
+    PHASE2_LABELLED_REQUESTS,
+    Phase2LabelledRequestBuilder,
+    Phase2LabelledRequestCounters,
+    Phase2LabelledRequestsSpec,
+    RestApiRecord,
+    load_phase2_labelled_requests_spec,
+    phase2_acceptance_thresholds_pass,
+)
+
+DraftProvider = Callable[[dict[str, Any]], str]
+JudgeProvider = Callable[[dict[str, Any]], str]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--spec",
+        default="configs/phase2_labelled_requests.yaml",
+        help="YAML builder spec that owns prompts, model IDs, metrics, and thresholds.",
+    )
+    parser.add_argument(
+        "--records-jsonl",
+        required=True,
+        help="Input JSONL with rest_api, allowed_methods, json, vendor, and source_corpus.",
+    )
+    parser.add_argument(
+        "--output-jsonl",
+        required=True,
+        help=f"Destination JSONL for accepted {PHASE2_LABELLED_REQUESTS} rows.",
+    )
+    parser.add_argument(
+        "--metrics-out",
+        required=True,
+        help="Destination JSON file for aggregate offline builder metrics.",
+    )
+    parser.add_argument(
+        "--sample-width",
+        type=int,
+        required=True,
+        help="Number of REST API records sampled per candidate; must be 1, 2, or 3.",
+    )
+    parser.add_argument(
+        "--count",
+        type=int,
+        default=1,
+        help="Number of labelled-request candidates to attempt.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Deterministic sampler seed.",
+    )
+    parser.add_argument(
+        "--provider-mode",
+        choices=("mock", "file"),
+        default="mock",
+        help="Use deterministic local mock providers or local fixture files.",
+    )
+    parser.add_argument(
+        "--drafts-jsonl",
+        default="",
+        help="Provider-mode file: one draft text line per candidate.",
+    )
+    parser.add_argument(
+        "--judges-jsonl",
+        default="",
+        help="Provider-mode file: one raw judge JSON line per candidate.",
+    )
+    parser.add_argument(
+        "--allow-threshold-failure",
+        action="store_true",
+        help="Write artifacts and exit 0 even when YAML acceptance thresholds fail.",
+    )
+    return parser.parse_args(argv)
+
+
+def load_rest_api_records(path: Path) -> tuple[RestApiRecord, ...]:
+    """Load fixture REST API records from JSONL with line-numbered errors."""
+    records: list[RestApiRecord] = []
+    seen_rest_apis: set[str] = set()
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"{path}:{line_number}: invalid JSON: {exc.msg}") from exc
+        if not isinstance(row, Mapping):
+            raise SystemExit(f"{path}:{line_number}: row must be a JSON object")
+
+        record = _record_from_mapping(row, path=path, line_number=line_number)
+        if record.rest_api in seen_rest_apis:
+            raise SystemExit(f"{path}:{line_number}: duplicate rest_api {record.rest_api}")
+        seen_rest_apis.add(record.rest_api)
+        records.append(record)
+
+    if not records:
+        raise SystemExit(f"{path}: no REST API records found")
+    return tuple(records)
+
+
+def build_phase2_labelled_requests(
+    *,
+    spec: Phase2LabelledRequestsSpec,
+    records: tuple[RestApiRecord, ...],
+    sample_width: int,
+    count: int,
+    seed: int,
+    draft_provider: DraftProvider,
+    judge_provider: JudgeProvider,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Build accepted rows plus aggregate metrics using injected providers."""
+    if sample_width not in spec.sample_widths:
+        raise SystemExit("sample-width must be present in the YAML sampling.sample_widths")
+    if count < 1:
+        raise SystemExit("count must be positive")
+    if len(records) < sample_width:
+        raise SystemExit("not enough records for requested sample-width")
+
+    builder = Phase2LabelledRequestBuilder(
+        spec,
+        draft_provider=draft_provider,
+        judge_provider=judge_provider,
+    )
+    rng = random.Random(seed)
+    accepted_rows: list[dict[str, Any]] = []
+    counters = Phase2LabelledRequestCounters(
+        sample_width_k=sample_width,
+        prompt_spec_version=spec.prompt_spec_version,
+        model_x_artifact_sha=spec.model_x.artifact_sha,
+        judge_model=spec.judge.model_id,
+        judge_profile=spec.judge.profile,
+    )
+    source_labels: set[str] = set()
+
+    for _ in range(count):
+        row, candidate = builder.build_one(records, k=sample_width, rng=rng)
+        _merge_counters(counters, candidate)
+        if candidate.vendor_source_corpus:
+            source_labels.update(candidate.vendor_source_corpus.split(","))
+        if row is not None:
+            accepted_rows.append(row.to_dict())
+
+    counters.vendor_source_corpus = ",".join(sorted(source_labels))
+    summary = counters.summary()
+    summary.update({
+        "dataset": spec.dataset_name,
+        "records_in": len(records),
+        "requested_candidates": count,
+        "accepted_rows": len(accepted_rows),
+        "thresholds_pass": phase2_acceptance_thresholds_pass(spec, summary),
+    })
+    return accepted_rows, summary
+
+
+def write_jsonl(path: Path, rows: Iterable[Mapping[str, Any]]) -> int:
+    """Write JSONL rows and return the number written."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    count = 0
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True))
+            handle.write("\n")
+            count += 1
+    return count
+
+
+def write_metrics(path: Path, summary: Mapping[str, Any]) -> None:
+    """Write aggregate metrics JSON."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(dict(summary), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint.
+
+    :return: process-style exit code.
+    """
+    args = parse_args(argv)
+    spec = load_phase2_labelled_requests_spec(args.spec)
+    records = load_rest_api_records(Path(args.records_jsonl))
+    draft_provider, judge_provider = _providers(args)
+    rows, metrics = build_phase2_labelled_requests(
+        spec=spec,
+        records=records,
+        sample_width=args.sample_width,
+        count=args.count,
+        seed=args.seed,
+        draft_provider=draft_provider,
+        judge_provider=judge_provider,
+    )
+    rows_written = write_jsonl(Path(args.output_jsonl), rows)
+    write_metrics(Path(args.metrics_out), metrics)
+    print(
+        f"wrote dataset={metrics['dataset']} "
+        f"attempted={metrics['requested_candidates']} "
+        f"accepted={rows_written} "
+        f"thresholds_pass={metrics['thresholds_pass']} "
+        f"output_jsonl={args.output_jsonl} "
+        f"metrics_out={args.metrics_out}"
+    )
+    if not metrics["thresholds_pass"] and not args.allow_threshold_failure:
+        return 2
+    return 0
+
+
+def _record_from_mapping(row: Mapping[str, Any], *, path: Path, line_number: int) -> RestApiRecord:
+    """Normalize one JSONL row into a :class:`RestApiRecord`."""
+    source = row.get("x") if isinstance(row.get("x"), Mapping) else row
+    rest_api = source.get("rest_api")
+    if not isinstance(rest_api, str) or not rest_api.strip():
+        raise SystemExit(f"{path}:{line_number}: rest_api must be a non-empty string")
+
+    raw_methods = source.get("allowed_methods")
+    if not isinstance(raw_methods, list) or not all(isinstance(item, str) for item in raw_methods):
+        raise SystemExit(f"{path}:{line_number}: allowed_methods must be a list of strings")
+
+    json_body = source.get("json")
+    if not isinstance(json_body, Mapping):
+        raise SystemExit(f"{path}:{line_number}: json must be an object")
+
+    return RestApiRecord(
+        rest_api=rest_api,
+        allowed_methods=tuple(method.upper() for method in raw_methods),
+        json_body=dict(json_body),
+        vendor=str(row.get("vendor") or source.get("vendor") or ""),
+        source_corpus=str(row.get("source_corpus") or source.get("source_corpus") or ""),
+    )
+
+
+def _providers(args: argparse.Namespace) -> tuple[DraftProvider, JudgeProvider]:
+    """Return local draft and judge providers for the requested mode."""
+    if args.provider_mode == "mock":
+        return _mock_draft_provider, _mock_judge_provider
+    if not args.drafts_jsonl or not args.judges_jsonl:
+        raise SystemExit("--drafts-jsonl and --judges-jsonl are required for provider-mode file")
+    return (
+        _TextLineProvider(Path(args.drafts_jsonl), label="draft"),
+        _TextLineProvider(Path(args.judges_jsonl), label="judge"),
+    )
+
+
+def _mock_draft_provider(request: dict[str, Any]) -> str:
+    """Return deterministic fixture text for offline smoke tests."""
+    return f"fixture request covering {request['sample_width']} Redfish API record(s)"
+
+
+def _mock_judge_provider(request: dict[str, Any]) -> str:
+    """Return a deterministic accepting judge response for offline smoke tests."""
+    return json.dumps({
+        "accepted": True,
+        "rest_api_list": request["expected_rest_api_list"],
+        "nonsense": False,
+        "reason": "fixture",
+        "order_evidence": "none",
+    })
+
+
+class _TextLineProvider:
+    """Sequential provider backed by non-blank local text lines."""
+
+    def __init__(self, path: Path, *, label: str) -> None:
+        """Load provider fixture lines."""
+        self._path = path
+        self._label = label
+        self._lines = [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        self._index = 0
+        if not self._lines:
+            raise SystemExit(f"{path}: no {label} provider lines found")
+
+    def __call__(self, request: dict[str, Any]) -> str:
+        """Return the next provider line."""
+        _ = request
+        if self._index >= len(self._lines):
+            raise SystemExit(f"{self._path}: not enough {self._label} provider lines")
+        line = self._lines[self._index]
+        self._index += 1
+        return line
+
+
+def _merge_counters(
+    aggregate: Phase2LabelledRequestCounters,
+    candidate: Phase2LabelledRequestCounters,
+) -> None:
+    """Merge one candidate counter object into the aggregate counter object."""
+    aggregate.draft_total += candidate.draft_total
+    aggregate.accepted_total += candidate.accepted_total
+    aggregate.rejected_total += candidate.rejected_total
+    aggregate.pro_accept_total += candidate.pro_accept_total
+    aggregate.nonsense_total += candidate.nonsense_total
+    aggregate.invalid_json_total += candidate.invalid_json_total
+    aggregate.rest_api_set_match_total += candidate.rest_api_set_match_total
+    aggregate.empty_set_expected_total += candidate.empty_set_expected_total
+    aggregate.empty_set_match_total += candidate.empty_set_match_total
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/scripts/build_phase2_labelled_requests.py
+++ b/scripts/build_phase2_labelled_requests.py
@@ -16,6 +16,8 @@ import json
 import os
 import random
 import sys
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping
 
@@ -29,6 +31,7 @@ from igc.ds.phase2_labelled_requests import (
     Phase2LabelledRequestBuilder,
     Phase2LabelledRequestCounters,
     Phase2LabelledRequestsSpec,
+    ProviderAdapterSpec,
     RestApiRecord,
     load_phase2_labelled_requests_spec,
     phase2_acceptance_thresholds_pass,
@@ -36,6 +39,7 @@ from igc.ds.phase2_labelled_requests import (
 
 DraftProvider = Callable[[dict[str, Any]], str]
 JudgeProvider = Callable[[dict[str, Any]], str]
+JsonTransport = Callable[[str, Mapping[str, Any], Mapping[str, str], float], Mapping[str, Any]]
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -81,19 +85,39 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--provider-mode",
-        choices=("mock", "file"),
-        default="mock",
-        help="Use deterministic local mock providers or local fixture files.",
+        choices=("config", "mock", "file", "openai-compatible"),
+        default="config",
+        help=(
+            "Select providers from YAML, local mocks, local files, "
+            "or live OpenAI-compatible HTTP."
+        ),
+    )
+    parser.add_argument(
+        "--draft-provider-adapter",
+        choices=("mock", "file", "openai-compatible"),
+        default="",
+        help="Override only the model_x draft provider adapter from YAML.",
+    )
+    parser.add_argument(
+        "--judge-provider-adapter",
+        choices=("mock", "file", "openai-compatible"),
+        default="",
+        help="Override only the private judge provider adapter from YAML.",
     )
     parser.add_argument(
         "--drafts-jsonl",
         default="",
-        help="Provider-mode file: one draft text line per candidate.",
+        help="File adapter: one draft text line per candidate.",
     )
     parser.add_argument(
         "--judges-jsonl",
         default="",
-        help="Provider-mode file: one raw judge JSON line per candidate.",
+        help="File adapter: one raw judge JSON line per candidate.",
+    )
+    parser.add_argument(
+        "--live-provider-gate-passed",
+        action="store_true",
+        help="Allow live provider runs above the YAML safety.live_without_gate_max_candidates cap.",
     )
     parser.add_argument(
         "--allow-threshold-failure",
@@ -208,7 +232,19 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     spec = load_phase2_labelled_requests_spec(args.spec)
     records = load_rest_api_records(Path(args.records_jsonl))
-    draft_provider, judge_provider = _providers(args)
+    draft_adapter, judge_adapter = _selected_adapters(args, spec)
+    _enforce_live_provider_gate(
+        args,
+        spec=spec,
+        draft_adapter=draft_adapter,
+        judge_adapter=judge_adapter,
+    )
+    draft_provider, judge_provider = _providers(
+        args,
+        spec=spec,
+        draft_adapter=draft_adapter,
+        judge_adapter=judge_adapter,
+    )
     rows, metrics = build_phase2_labelled_requests(
         spec=spec,
         records=records,
@@ -257,16 +293,86 @@ def _record_from_mapping(row: Mapping[str, Any], *, path: Path, line_number: int
     )
 
 
-def _providers(args: argparse.Namespace) -> tuple[DraftProvider, JudgeProvider]:
-    """Return local draft and judge providers for the requested mode."""
-    if args.provider_mode == "mock":
-        return _mock_draft_provider, _mock_judge_provider
-    if not args.drafts_jsonl or not args.judges_jsonl:
-        raise SystemExit("--drafts-jsonl and --judges-jsonl are required for provider-mode file")
+def _selected_adapters(
+    args: argparse.Namespace,
+    spec: Phase2LabelledRequestsSpec,
+) -> tuple[str, str]:
+    """Resolve draft and judge adapter names from YAML plus CLI overrides."""
+    if args.provider_mode == "config":
+        draft_adapter = spec.draft_provider.adapter
+        judge_adapter = spec.judge_provider.adapter
+    else:
+        draft_adapter = args.provider_mode
+        judge_adapter = args.provider_mode
+    if args.draft_provider_adapter:
+        draft_adapter = args.draft_provider_adapter
+    if args.judge_provider_adapter:
+        judge_adapter = args.judge_provider_adapter
+    return draft_adapter, judge_adapter
+
+
+def _enforce_live_provider_gate(
+    args: argparse.Namespace,
+    *,
+    spec: Phase2LabelledRequestsSpec,
+    draft_adapter: str,
+    judge_adapter: str,
+) -> None:
+    """Block dataset-scale live provider runs until an explicit gate flag is passed."""
+    uses_live_adapter = "openai-compatible" in {draft_adapter, judge_adapter}
+    if not uses_live_adapter or args.live_provider_gate_passed:
+        return
+    if args.count > spec.live_without_gate_max_candidates:
+        raise SystemExit(
+            "live provider runs above safety.live_without_gate_max_candidates "
+            "require --live-provider-gate-passed",
+        )
+
+
+def _providers(
+    args: argparse.Namespace,
+    *,
+    spec: Phase2LabelledRequestsSpec,
+    draft_adapter: str,
+    judge_adapter: str,
+) -> tuple[DraftProvider, JudgeProvider]:
+    """Return draft and judge providers for the resolved adapters."""
     return (
-        _TextLineProvider(Path(args.drafts_jsonl), label="draft"),
-        _TextLineProvider(Path(args.judges_jsonl), label="judge"),
+        _provider_for_adapter(
+            draft_adapter,
+            config=spec.draft_provider,
+            text_path=args.drafts_jsonl,
+            label="draft",
+        ),
+        _provider_for_adapter(
+            judge_adapter,
+            config=spec.judge_provider,
+            text_path=args.judges_jsonl,
+            label="judge",
+        ),
     )
+
+
+def _provider_for_adapter(
+    adapter: str,
+    *,
+    config: ProviderAdapterSpec,
+    text_path: str,
+    label: str,
+) -> DraftProvider:
+    """Build one provider callable for the selected adapter."""
+    if adapter == "mock":
+        if label == "draft":
+            return _mock_draft_provider
+        return _mock_judge_provider
+    if adapter == "file":
+        if not text_path:
+            raise SystemExit(f"--{label}s-jsonl is required for {label} file provider")
+        return _TextLineProvider(Path(text_path), label=label)
+    if adapter == "openai-compatible":
+        _require_live_provider_config(config, label=label)
+        return _OpenAICompatibleChatProvider(config, label=label)
+    raise SystemExit(f"unknown {label} provider adapter {adapter!r}")
 
 
 def _mock_draft_provider(request: dict[str, Any]) -> str:
@@ -285,6 +391,83 @@ def _mock_judge_provider(request: dict[str, Any]) -> str:
     })
 
 
+def _require_live_provider_config(config: ProviderAdapterSpec, *, label: str) -> None:
+    """Fail early when a CLI override selects live HTTP without YAML routing fields."""
+    missing = [
+        field_name
+        for field_name in ("base_url_env", "endpoint_path", "response_text_path")
+        if not getattr(config, field_name)
+    ]
+    if missing:
+        joined = ", ".join(f"providers.{label}.{field_name}" for field_name in missing)
+        raise SystemExit(
+            f"{label} openai-compatible provider requires {joined}",
+        )
+
+
+class _OpenAICompatibleChatProvider:
+    """Small OpenAI-compatible chat-completions provider with injectable HTTP."""
+
+    def __init__(
+        self,
+        config: ProviderAdapterSpec,
+        *,
+        label: str,
+        env: Mapping[str, str] | None = None,
+        transport: JsonTransport | None = None,
+    ) -> None:
+        """Create a live provider from YAML config and environment variables."""
+        self._config = config
+        self._label = label
+        self._env = os.environ if env is None else env
+        self._transport = _urlopen_json_transport if transport is None else transport
+
+    def __call__(self, request: dict[str, Any]) -> str:
+        """Send one prompt to an OpenAI-compatible endpoint and return text."""
+        base_url = _required_env(
+            self._env,
+            self._config.base_url_env,
+            f"{self._label}.base_url_env",
+        )
+        model_id = _resolve_env_value(
+            str(request["model_id"]),
+            self._env,
+            f"{self._label}.model_id",
+        )
+        payload: dict[str, Any] = {
+            "model": model_id,
+            "messages": [{"role": "user", "content": request["prompt"]}],
+        }
+        generation = request.get("generation")
+        if isinstance(generation, Mapping):
+            payload.update(
+                _resolve_env_values(
+                    dict(generation),
+                    self._env,
+                    f"{self._label}.generation",
+                ),
+            )
+        for field_name in self._config.payload_request_fields:
+            if field_name in request:
+                payload[field_name] = _resolve_env_values(
+                    request[field_name],
+                    self._env,
+                    f"{self._label}.{field_name}",
+                )
+
+        response = self._transport(
+            _join_url(base_url, self._config.endpoint_path),
+            payload,
+            _headers(self._config, self._env),
+            self._config.timeout_seconds,
+        )
+        return _extract_response_text(
+            response,
+            self._config.response_text_path,
+            label=self._label,
+        )
+
+
 class _TextLineProvider:
     """Sequential provider backed by non-blank local text lines."""
 
@@ -292,7 +475,11 @@ class _TextLineProvider:
         """Load provider fixture lines."""
         self._path = path
         self._label = label
-        self._lines = [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        self._lines = [
+            line.strip()
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
         self._index = 0
         if not self._lines:
             raise SystemExit(f"{path}: no {label} provider lines found")
@@ -305,6 +492,116 @@ class _TextLineProvider:
         line = self._lines[self._index]
         self._index += 1
         return line
+
+
+def _urlopen_json_transport(
+    url: str,
+    payload: Mapping[str, Any],
+    headers: Mapping[str, str],
+    timeout: float,
+) -> Mapping[str, Any]:
+    """POST JSON to a live provider and parse the JSON response."""
+    data = json.dumps(dict(payload)).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers=dict(headers),
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read().decode("utf-8")
+    except urllib.error.URLError as exc:
+        raise SystemExit(f"live provider request failed: {exc.reason}") from exc
+    except OSError as exc:
+        raise SystemExit(f"live provider request failed: {exc}") from exc
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"live provider returned invalid JSON: {exc.msg}") from exc
+    if not isinstance(parsed, Mapping):
+        raise SystemExit("live provider response must be a JSON object")
+    return parsed
+
+
+def _headers(config: ProviderAdapterSpec, env: Mapping[str, str]) -> dict[str, str]:
+    """Build HTTP headers without exposing bearer values."""
+    headers = {"Content-Type": "application/json"}
+    if config.api_key_env:
+        api_key = env.get(config.api_key_env, "")
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+def _join_url(base_url: str, endpoint_path: str) -> str:
+    """Join a configured base URL and endpoint path."""
+    return f"{base_url.rstrip('/')}/{endpoint_path.lstrip('/')}"
+
+
+def _required_env(env: Mapping[str, str], key: str, label: str) -> str:
+    """Read a required environment variable named by YAML."""
+    if not key:
+        raise SystemExit(f"{label} must name an environment variable")
+    value = env.get(key, "")
+    if not value:
+        raise SystemExit(f"missing environment variable {key} for {label}")
+    return value
+
+
+def _resolve_env_values(value: Any, env: Mapping[str, str], label: str) -> Any:
+    """Resolve exact ``${VAR}`` placeholders in nested provider values."""
+    if isinstance(value, str):
+        return _resolve_env_value(value, env, label)
+    if isinstance(value, Mapping):
+        return {
+            str(child_key): _resolve_env_values(child_value, env, f"{label}.{child_key}")
+            for child_key, child_value in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            _resolve_env_values(child_value, env, f"{label}[]")
+            for child_value in value
+        ]
+    return value
+
+
+def _resolve_env_value(value: str, env: Mapping[str, str], label: str) -> str:
+    """Resolve an exact ``${VAR}`` placeholder or return a literal string."""
+    if not value.startswith("${") or not value.endswith("}"):
+        return value
+    key = value[2:-1]
+    if not key:
+        raise SystemExit(f"{label} contains an empty environment placeholder")
+    resolved = env.get(key, "")
+    if not resolved:
+        raise SystemExit(f"missing environment variable {key} for {label}")
+    return resolved
+
+
+def _extract_response_text(response: Mapping[str, Any], path: str, *, label: str) -> str:
+    """Extract generated text from a JSON response by dotted path."""
+    current: Any = response
+    for part in path.split("."):
+        if isinstance(current, Mapping):
+            if part not in current:
+                raise SystemExit(f"{label} provider response missing {path}")
+            current = current[part]
+            continue
+        if isinstance(current, list):
+            try:
+                index = int(part)
+            except ValueError as exc:
+                raise SystemExit(f"{label} provider response path {path} is not valid") from exc
+            try:
+                current = current[index]
+            except IndexError as exc:
+                raise SystemExit(f"{label} provider response path {path} is out of range") from exc
+            continue
+        raise SystemExit(f"{label} provider response path {path} cannot be traversed")
+    if not isinstance(current, str) or not current.strip():
+        raise SystemExit(f"{label} provider response path {path} did not contain text")
+    return current.strip()
 
 
 def _merge_counters(

--- a/scripts/validate_phase2_labelled_requests.sh
+++ b/scripts/validate_phase2_labelled_requests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+export PYTHONPATH="${PWD}${PYTHONPATH:+:${PYTHONPATH}}"
+
+echo "phase2_labelled_requests validation start"
+git rev-parse --short HEAD
+pytest -q -ra \
+    tests/scripts/test_phase2_labelled_requests_cli.py \
+    tests/ds/test_phase2_labelled_requests.py \
+    tests/modules/test_phase2_labelled_request_metric_keys.py
+echo "phase2_labelled_requests validation ok"

--- a/tests/ds/test_phase2_labelled_requests.py
+++ b/tests/ds/test_phase2_labelled_requests.py
@@ -71,6 +71,26 @@ judge:
   route: private_pro
   model_id: ${PHASE2_JUDGE_MODEL_ID}
   profile: ${PHASE2_JUDGE_PROFILE}
+safety:
+  live_without_gate_max_candidates: 2
+providers:
+  draft:
+    adapter: mock
+    base_url_env: PHASE2_MODEL_X_BASE_URL
+    api_key_env: PHASE2_MODEL_X_API_KEY
+    endpoint_path: /v1/chat/completions
+    timeout_seconds: 10
+    response_text_path: choices.0.message.content
+  judge:
+    adapter: mock
+    base_url_env: PHASE2_JUDGE_BASE_URL
+    api_key_env: PHASE2_JUDGE_API_KEY
+    endpoint_path: /v1/chat/completions
+    timeout_seconds: 10
+    response_text_path: choices.0.message.content
+    payload_request_fields:
+      - route
+      - profile
 generation:
   max_new_tokens: 96
   temperature: 0.2
@@ -153,6 +173,13 @@ def test_loads_prompt_model_judge_generation_and_thresholds_from_yaml(tmp_path: 
     assert spec.judge.route == "private_pro"
     assert spec.judge.model_id == "${PHASE2_JUDGE_MODEL_ID}"
     assert spec.judge.profile == "${PHASE2_JUDGE_PROFILE}"
+    assert spec.live_without_gate_max_candidates == 2
+    assert spec.draft_provider.adapter == "mock"
+    assert spec.draft_provider.base_url_env == "PHASE2_MODEL_X_BASE_URL"
+    assert spec.draft_provider.endpoint_path == "/v1/chat/completions"
+    assert spec.draft_provider.response_text_path == "choices.0.message.content"
+    assert spec.judge_provider.adapter == "mock"
+    assert spec.judge_provider.payload_request_fields == ("route", "profile")
     assert spec.generation == {"max_new_tokens": 96, "temperature": 0.2, "top_p": 0.95}
     assert spec.wandb_namespace == PHASE2_LABELLED_REQUESTS
     assert spec.metric_keys == PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS
@@ -229,6 +256,79 @@ def test_spec_loader_rejects_malformed_phase2_specs(tmp_path: Path) -> None:
     with pytest.raises(Phase2LabelledRequestsSpecError, match="judge.route"):
         load_phase2_labelled_requests_spec(missing_judge_route)
 
+    missing_providers = _write_spec(tmp_path / "missing-providers.yaml")
+    missing_providers.write_text(
+        missing_providers.read_text(encoding="utf-8").replace(
+            """providers:
+  draft:
+    adapter: mock
+    base_url_env: PHASE2_MODEL_X_BASE_URL
+    api_key_env: PHASE2_MODEL_X_API_KEY
+    endpoint_path: /v1/chat/completions
+    timeout_seconds: 10
+    response_text_path: choices.0.message.content
+  judge:
+    adapter: mock
+    base_url_env: PHASE2_JUDGE_BASE_URL
+    api_key_env: PHASE2_JUDGE_API_KEY
+    endpoint_path: /v1/chat/completions
+    timeout_seconds: 10
+    response_text_path: choices.0.message.content
+    payload_request_fields:
+      - route
+      - profile
+""",
+            "",
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(Phase2LabelledRequestsSpecError, match="providers"):
+        load_phase2_labelled_requests_spec(missing_providers)
+
+    bad_provider = _write_spec(tmp_path / "bad-provider.yaml")
+    bad_provider.write_text(
+        bad_provider.read_text(encoding="utf-8").replace(
+            "    adapter: mock\n",
+            "    adapter: unknown\n",
+            1,
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(Phase2LabelledRequestsSpecError, match="providers.draft.adapter"):
+        load_phase2_labelled_requests_spec(bad_provider)
+
+    live_without_base_url = _write_spec(tmp_path / "live-without-base-url.yaml")
+    live_without_base_url.write_text(
+        live_without_base_url.read_text(encoding="utf-8")
+        .replace("    adapter: mock\n", "    adapter: openai-compatible\n", 1)
+        .replace("    base_url_env: PHASE2_MODEL_X_BASE_URL\n", "", 1),
+        encoding="utf-8",
+    )
+    with pytest.raises(Phase2LabelledRequestsSpecError, match="providers.draft.base_url_env"):
+        load_phase2_labelled_requests_spec(live_without_base_url)
+
+    malformed_payload_fields = _write_spec(tmp_path / "malformed-payload-fields.yaml")
+    malformed_payload_fields.write_text(
+        malformed_payload_fields.read_text(encoding="utf-8").replace(
+            "      - route\n      - profile",
+            "      - route\n      - 7",
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(Phase2LabelledRequestsSpecError, match="payload_request_fields"):
+        load_phase2_labelled_requests_spec(malformed_payload_fields)
+
+    malformed_live_gate = _write_spec(tmp_path / "malformed-live-gate.yaml")
+    malformed_live_gate.write_text(
+        malformed_live_gate.read_text(encoding="utf-8").replace(
+            "  live_without_gate_max_candidates: 2",
+            "  live_without_gate_max_candidates: many",
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(Phase2LabelledRequestsSpecError, match="live_without_gate_max_candidates"):
+        load_phase2_labelled_requests_spec(malformed_live_gate)
+
     missing_prompt_section = _write_spec(tmp_path / "missing-prompt-section.yaml")
     missing_prompt_section.write_text(
         missing_prompt_section.read_text(encoding="utf-8").replace(
@@ -286,6 +386,12 @@ def test_committed_phase2_labelled_requests_config_loads() -> None:
     assert spec.judge.route == "${PHASE2_JUDGE_ROUTE}"
     assert spec.judge.model_id == "${PHASE2_JUDGE_MODEL_ID}"
     assert spec.judge.profile == "${PHASE2_JUDGE_PROFILE}"
+    assert spec.live_without_gate_max_candidates == 3
+    assert spec.draft_provider.adapter == "mock"
+    assert spec.draft_provider.base_url_env == "PHASE2_MODEL_X_BASE_URL"
+    assert spec.judge_provider.adapter == "mock"
+    assert spec.judge_provider.base_url_env == "PHASE2_JUDGE_BASE_URL"
+    assert spec.judge_provider.payload_request_fields == ("route", "profile")
 
 
 def test_prompt_rendering_uses_yaml_templates_not_runtime_literals(tmp_path: Path) -> None:

--- a/tests/ds/test_phase2_labelled_requests.py
+++ b/tests/ds/test_phase2_labelled_requests.py
@@ -199,6 +199,17 @@ def test_spec_loader_rejects_malformed_phase2_specs(tmp_path: Path) -> None:
     with pytest.raises(Phase2LabelledRequestsSpecError, match="acceptance missing"):
         load_phase2_labelled_requests_spec(missing_threshold)
 
+    malformed_threshold = _write_spec(tmp_path / "malformed-threshold.yaml")
+    malformed_threshold.write_text(
+        malformed_threshold.read_text(encoding="utf-8").replace(
+            "  min_pro_accept_rate: 0.9\n",
+            "  min_pro_accept_rate: high\n",
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(Phase2LabelledRequestsSpecError, match="must be numeric"):
+        load_phase2_labelled_requests_spec(malformed_threshold)
+
 
 def test_committed_phase2_labelled_requests_config_loads() -> None:
     """The checked-in builder spec stays aligned with the metric registry."""
@@ -376,6 +387,22 @@ def test_pro_judge_result_parsing_requires_rest_api_field() -> None:
     assert result.invalid_json is True
     assert result.rest_api_list == ()
     assert "rest_api_list" in result.reason
+
+
+def test_pro_judge_result_parsing_requires_acceptance_boolean() -> None:
+    """A judge result without accepted or accept is malformed output."""
+    result = parse_pro_judge_result(
+        json.dumps({
+            "rest_api_list": ["/redfish/v1/Systems"],
+            "nonsense": False,
+            "reason": "fixture",
+        }),
+    )
+
+    assert result.accepted is False
+    assert result.invalid_json is True
+    assert result.rest_api_list == ()
+    assert "accepted" in result.reason
 
 
 @pytest.mark.parametrize(

--- a/tests/ds/test_phase2_labelled_requests.py
+++ b/tests/ds/test_phase2_labelled_requests.py
@@ -188,6 +188,69 @@ def test_spec_loader_rejects_malformed_phase2_specs(tmp_path: Path) -> None:
     with pytest.raises(Phase2LabelledRequestsSpecError, match="metric_keys"):
         load_phase2_labelled_requests_spec(wrong_metrics)
 
+    wrong_widths = _write_spec(tmp_path / "wrong-widths.yaml")
+    wrong_widths.write_text(
+        wrong_widths.read_text(encoding="utf-8").replace(
+            "sample_widths: [1, 2, 3]",
+            "sample_widths: [1, 2]",
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(Phase2LabelledRequestsSpecError, match="sample_widths"):
+        load_phase2_labelled_requests_spec(wrong_widths)
+
+    non_integer_widths = _write_spec(tmp_path / "non-integer-widths.yaml")
+    non_integer_widths.write_text(
+        non_integer_widths.read_text(encoding="utf-8").replace(
+            "sample_widths: [1, 2, 3]",
+            "sample_widths: [1, two, 3]",
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(Phase2LabelledRequestsSpecError, match="sample_widths"):
+        load_phase2_labelled_requests_spec(non_integer_widths)
+
+    wrong_namespace = _write_spec(tmp_path / "wrong-namespace.yaml")
+    wrong_namespace.write_text(
+        wrong_namespace.read_text(encoding="utf-8").replace(
+            "namespace: phase2_labelled_requests",
+            "namespace: wrong_phase2_namespace",
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(Phase2LabelledRequestsSpecError, match="wandb.namespace"):
+        load_phase2_labelled_requests_spec(wrong_namespace)
+
+    missing_judge_route = _write_spec(tmp_path / "missing-judge-route.yaml")
+    missing_judge_route.write_text(
+        missing_judge_route.read_text(encoding="utf-8").replace("  route: private_pro\n", ""),
+        encoding="utf-8",
+    )
+    with pytest.raises(Phase2LabelledRequestsSpecError, match="judge.route"):
+        load_phase2_labelled_requests_spec(missing_judge_route)
+
+    missing_prompt_section = _write_spec(tmp_path / "missing-prompt-section.yaml")
+    missing_prompt_section.write_text(
+        missing_prompt_section.read_text(encoding="utf-8").replace(
+            "  model_x_draft:",
+            "  model_x_missing:",
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(Phase2LabelledRequestsSpecError, match="model_x_draft"):
+        load_phase2_labelled_requests_spec(missing_prompt_section)
+
+    malformed_generation = _write_spec(tmp_path / "malformed-generation.yaml")
+    malformed_generation.write_text(
+        malformed_generation.read_text(encoding="utf-8").replace(
+            "generation:\n  max_new_tokens: 96\n  temperature: 0.2\n  top_p: 0.95\n",
+            "generation: []\n",
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(Phase2LabelledRequestsSpecError, match="generation"):
+        load_phase2_labelled_requests_spec(malformed_generation)
+
     missing_threshold = _write_spec(tmp_path / "missing-threshold.yaml")
     missing_threshold.write_text(
         missing_threshold.read_text(encoding="utf-8").replace(
@@ -238,10 +301,24 @@ def test_prompt_rendering_uses_yaml_templates_not_runtime_literals(tmp_path: Pat
     assert "/redfish/v1/Systems/1" in model_prompt
     assert "show both systems" in judge_prompt
 
-    source = Path("igc/ds/phase2_labelled_requests.py").read_text(encoding="utf-8")
-    assert "phase2 test model-x system prompt from YAML" not in source
-    assert "${PHASE1_MODEL_X_MODEL_ID}" not in source
-    assert "${PHASE2_JUDGE_MODEL_ID}" not in source
+    runtime_sources = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (
+            Path("igc/ds/phase2_labelled_requests.py"),
+            Path("scripts/build_phase2_labelled_requests.py"),
+        )
+    )
+    forbidden_literals = (
+        "phase2 test model-x system prompt from YAML",
+        "${PHASE1_MODEL_X_MODEL_ID}",
+        "${PHASE2_JUDGE_MODEL_ID}",
+        "Qwen/Qwen2.5",
+        "deepseek",
+        "You draft one concise",
+        "Return JSON with accepted",
+    )
+    for literal in forbidden_literals:
+        assert literal not in runtime_sources
 
 
 def test_sampling_accepts_only_k_1_2_3_and_preserves_record_payloads() -> None:
@@ -300,6 +377,18 @@ def test_pro_judge_result_parsing_accepts_plain_and_wrapped_json() -> None:
     assert wrapped.invalid_json is False
     assert wrapped.nonsense is False
     assert wrapped.order_evidence == "none"
+
+    rejected = parse_pro_judge_result(
+        _judge_json(
+            accepted=False,
+            rest_api_list=["/redfish/v1/A"],
+            nonsense=False,
+        ),
+    )
+    assert rejected.accepted is False
+    assert rejected.invalid_json is False
+    assert rejected.rest_api_list == ("/redfish/v1/A",)
+    assert rejected.nonsense is False
 
     invalid = parse_pro_judge_result("{not json")
     assert invalid.accepted is False
@@ -472,6 +561,10 @@ def test_builder_uses_injected_providers_and_counts_rejections(tmp_path: Path) -
     assert data["dataset"] == PHASE2_LABELLED_REQUESTS
     assert data["task"] == "text_to_rest_api_list"
     assert data["x"]["text"] == "show both sampled systems"
+    assert "records" not in data["x"]
+    assert len(data["x"]["json"]) == 2
+    assert data["x"]["rest_api_list"] == data["y_true"]["rest_api_list"]
+    assert set(data["x"]["allowed_methods"]) == set(data["y_true"]["rest_api_list"])
     assert data["y_true"]["order_evidence"] == "explicit_then"
     assert data["validation"]["set_coverage_preserved"] is True
     assert data["validation"]["review_judged"] is True
@@ -489,6 +582,7 @@ def test_builder_uses_injected_providers_and_counts_rejections(tmp_path: Path) -
     assert seen["draft"]["generation"]["max_new_tokens"] == 96
     assert seen["judge"]["model_id"] == "${PHASE2_JUDGE_MODEL_ID}"
     assert seen["judge"]["profile"] == "${PHASE2_JUDGE_PROFILE}"
+    assert seen["judge"]["route"] == "private_pro"
 
 
 def test_builder_returns_none_and_counts_rejection_on_set_mismatch(tmp_path: Path) -> None:
@@ -510,6 +604,7 @@ def test_builder_returns_none_and_counts_rejection_on_set_mismatch(tmp_path: Pat
     assert summary[_phase2_metric("draft_total")] == 1
     assert summary[_phase2_metric("accepted_total")] == 0
     assert summary[_phase2_metric("rejected_total")] == 1
+    assert summary[_phase2_metric("pro_accept_rate")] == 1.0
     assert summary[_phase2_metric("rest_api_set_match_rate")] == 0.0
 
 
@@ -547,6 +642,7 @@ def test_counter_summary_binds_semantic_metric_names() -> None:
         draft_total=7,
         accepted_total=5,
         rejected_total=2,
+        pro_accept_total=6,
         nonsense_total=1,
         invalid_json_total=2,
         rest_api_set_match_total=4,
@@ -567,7 +663,7 @@ def test_counter_summary_binds_semantic_metric_names() -> None:
     assert summary[_phase2_metric("rejected_total")] == 2
     assert summary[_phase2_metric("nonsense_rate")] == pytest.approx(1 / 7)
     assert summary[_phase2_metric("invalid_json_rate")] == pytest.approx(2 / 7)
-    assert summary[_phase2_metric("pro_accept_rate")] == pytest.approx(5 / 7)
+    assert summary[_phase2_metric("pro_accept_rate")] == pytest.approx(6 / 7)
     assert summary[_phase2_metric("rest_api_set_match_rate")] == pytest.approx(4 / 7)
     assert summary[_phase2_metric("empty_set_match_rate")] == pytest.approx(2 / 3)
     assert summary[_phase2_metric("sample_width", "k")] == 3

--- a/tests/ds/test_phase2_labelled_requests.py
+++ b/tests/ds/test_phase2_labelled_requests.py
@@ -1,0 +1,219 @@
+"""Offline tests for Phase 2 labelled request dataset plumbing.
+
+The tests pin the dataset-builder contract without model calls, W&B writes, GPU
+work, or live Redfish traffic.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+
+import pytest
+
+from igc.ds.phase2_labelled_requests import (
+    Phase2LabelledRequestCounters,
+    Phase2RestApiRecord,
+    load_phase2_labelled_requests_spec,
+    parse_pro_judge_result,
+    render_phase2_prompt,
+    rest_api_sets_equal,
+    sample_rest_api_records,
+)
+from igc.modules.base.metric_keys import phase_metric
+
+
+CONFIG_PATH = Path(__file__).parents[2] / "configs" / "phase2_labelled_requests.yaml"
+
+
+def _record(index: int, vendor: str = "dell") -> Phase2RestApiRecord:
+    """Build a small public-safe Redfish record fixture."""
+    rest_api = f"/redfish/v1/Systems/{index}"
+    return Phase2RestApiRecord(
+        rest_api=rest_api,
+        allowed_methods=("GET", "HEAD"),
+        json_body={
+            "@odata.id": rest_api,
+            "@odata.type": "#ComputerSystem.v1_20_0.ComputerSystem",
+            "Name": f"System {index}",
+        },
+        vendor=vendor,
+        source_corpus="unit_fixture",
+    )
+
+
+def test_prompt_spec_loading_uses_yaml_contract() -> None:
+    """The runtime spec comes from the YAML file under configs."""
+    spec = load_phase2_labelled_requests_spec(CONFIG_PATH)
+
+    assert spec.dataset_name == "phase2_labelled_requests"
+    assert spec.sample_widths == (1, 2, 3)
+    assert spec.wandb["namespace"] == "phase2_labelled_requests"
+    assert spec.model_x["artifact_sha"] == "fixture-model-x-sha256"
+    assert spec.judge["profile"] == "max_reasoning"
+    assert "draft_human_request" in spec.prompts
+    assert "pro_judge_set_match" in spec.prompts
+    assert spec.acceptance_thresholds["rest_api_set_match_rate_min"] == 0.98
+
+    sample = sample_rest_api_records(
+        [_record(1), _record(2)],
+        k=2,
+        rng=random.Random(3),
+        allowed_widths=spec.sample_widths,
+    )
+    prompt = render_phase2_prompt(spec, "draft_human_request", sample)
+
+    assert "/redfish/v1/Systems/1" in prompt
+    assert "/redfish/v1/Systems/2" in prompt
+    assert "fixture-model-x-sha256" not in prompt
+
+
+def test_sampling_supports_only_configured_widths_one_two_and_three() -> None:
+    """The builder samples one, two, or three REST API records without replacement."""
+    spec = load_phase2_labelled_requests_spec(CONFIG_PATH)
+    records = [_record(1), _record(2), _record(3), _record(4)]
+
+    for width in spec.sample_widths:
+        sample = sample_rest_api_records(
+            records,
+            k=width,
+            rng=random.Random(width),
+            allowed_widths=spec.sample_widths,
+        )
+        assert len(sample.records) == width
+        assert len(set(sample.rest_api_list)) == width
+        assert sample.sample_width == width
+
+    with pytest.raises(ValueError, match="sample width"):
+        sample_rest_api_records(
+            records,
+            k=4,
+            rng=random.Random(4),
+            allowed_widths=spec.sample_widths,
+        )
+
+
+def test_rest_api_set_comparison_is_unordered_and_empty_sets_match() -> None:
+    """Phase 2 judges REST API set equality, with empty set equal to empty set."""
+    assert rest_api_sets_equal(
+        ["/redfish/v1/Systems", "/redfish/v1/TaskService/Tasks"],
+        ["/redfish/v1/TaskService/Tasks", "/redfish/v1/Systems"],
+    )
+    assert rest_api_sets_equal([], [])
+    assert not rest_api_sets_equal(["/redfish/v1/Systems"], [])
+    assert not rest_api_sets_equal(["/redfish/v1/Systems"], ["/redfish/v1/Chassis"])
+
+
+def test_pro_judge_result_parser_handles_accept_reject_empty_and_invalid_json() -> None:
+    """Private judge output parsing is deterministic and side-effect free."""
+    accepted = parse_pro_judge_result(
+        json.dumps({
+            "accepted": True,
+            "rest_api_list": ["/redfish/v1/Systems", "/redfish/v1/Managers"],
+            "nonsense": False,
+            "reason": "The request names both resources.",
+        }),
+        expected_rest_apis=["/redfish/v1/Managers", "/redfish/v1/Systems"],
+    )
+    assert accepted.valid_json
+    assert accepted.accepted
+    assert accepted.pro_accept
+    assert accepted.rest_api_set_match
+    assert not accepted.empty_set_match
+
+    empty = parse_pro_judge_result(
+        json.dumps({
+            "accepted": True,
+            "rest_api_list": [],
+            "nonsense": False,
+        }),
+        expected_rest_apis=[],
+    )
+    assert empty.empty_set_match
+    assert empty.rest_api_set_match
+
+    nonsense = parse_pro_judge_result(
+        json.dumps({
+            "accepted": False,
+            "rest_api_list": [],
+            "nonsense": True,
+            "reason": "Draft text is not a request.",
+        }),
+        expected_rest_apis=["/redfish/v1/Systems"],
+    )
+    assert nonsense.valid_json
+    assert nonsense.nonsense
+    assert not nonsense.accepted
+
+    invalid = parse_pro_judge_result("{not json", expected_rest_apis=["/redfish/v1/Systems"])
+    assert invalid.invalid_json
+    assert not invalid.accepted
+    assert not invalid.pro_accept
+
+
+def test_nonsense_invalid_and_acceptance_counters_emit_phase2_metrics() -> None:
+    """Counters produce W&B-safe keys without opening a live W&B run."""
+    spec = load_phase2_labelled_requests_spec(CONFIG_PATH)
+    counters = Phase2LabelledRequestCounters()
+    accepted = parse_pro_judge_result(
+        json.dumps({
+            "accepted": True,
+            "rest_api_list": ["/redfish/v1/Systems"],
+            "nonsense": False,
+        }),
+        expected_rest_apis=["/redfish/v1/Systems"],
+    )
+    nonsense = parse_pro_judge_result(
+        json.dumps({
+            "accepted": False,
+            "rest_api_list": [],
+            "nonsense": True,
+        }),
+        expected_rest_apis=["/redfish/v1/Managers"],
+    )
+    invalid = parse_pro_judge_result("{bad", expected_rest_apis=["/redfish/v1/Chassis"])
+
+    counters.record_outcome(
+        accepted,
+        sample_width=1,
+        vendor="dell",
+        source_corpus="unit_fixture",
+        spec=spec,
+    )
+    counters.record_outcome(
+        nonsense,
+        sample_width=2,
+        vendor="hpe",
+        source_corpus="unit_fixture",
+        spec=spec,
+    )
+    counters.record_outcome(
+        invalid,
+        sample_width=3,
+        vendor="supermicro",
+        source_corpus="unit_fixture",
+        spec=spec,
+    )
+
+    metrics = counters.to_wandb_metrics(spec)
+    namespace = spec.wandb["namespace"]
+
+    assert metrics[phase_metric(namespace, "build", "draft_total")] == 3
+    assert metrics[phase_metric(namespace, "build", "accepted_total")] == 1
+    assert metrics[phase_metric(namespace, "build", "rejected_total")] == 2
+    assert metrics[phase_metric(namespace, "eval", "nonsense_rate")] == pytest.approx(1 / 3)
+    assert metrics[phase_metric(namespace, "eval", "invalid_json_rate")] == pytest.approx(1 / 3)
+    assert metrics[phase_metric(namespace, "eval", "pro_accept_rate")] == pytest.approx(1 / 3)
+    assert metrics[phase_metric(namespace, "eval", "rest_api_set_match_rate")] == pytest.approx(1 / 3)
+    assert metrics[phase_metric(namespace, "sample_width", "k")] == 3
+    assert metrics[phase_metric(namespace, "vendor", "source_corpus")] == (
+        "supermicro/unit_fixture"
+    )
+    assert metrics[phase_metric(namespace, "spec", "prompt_spec_version")] == spec.version
+    assert metrics[phase_metric(namespace, "model", "model_x_artifact_sha")] == (
+        "fixture-model-x-sha256"
+    )
+    assert metrics[phase_metric(namespace, "judge", "profile")] == "max_reasoning"

--- a/tests/ds/test_phase2_labelled_requests.py
+++ b/tests/ds/test_phase2_labelled_requests.py
@@ -1,0 +1,415 @@
+"""Offline tests for the Phase 2 labelled-request dataset plumbing.
+
+The module under test must keep prompts, model identifiers, judge routing,
+generation knobs, W&B keys, and acceptance thresholds in YAML/config values.
+Tests use tiny Redfish-shaped records and injected fake providers; they never
+call a model, W&B, a GPU, a Redfish host, or the network.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+
+import pytest
+
+from igc.ds.phase2_labelled_requests import (
+    PHASE2_LABELLED_REQUESTS,
+    Phase2LabelledRequestBuilder,
+    Phase2LabelledRequestCounters,
+    Phase2LabelledRequestsSpecError,
+    RestApiRecord,
+    compare_rest_api_sets,
+    empty_set_matches,
+    load_phase2_labelled_requests_spec,
+    parse_pro_judge_result,
+    render_model_x_prompt,
+    render_pro_judge_prompt,
+    sample_phase2_contexts,
+    to_minimal_phase3_input,
+)
+from igc.modules.base.metric_keys import (
+    PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS,
+    phase_metric,
+)
+
+
+def _record(index: int, methods: tuple[str, ...] = ("GET", "HEAD")) -> RestApiRecord:
+    """Build a tiny Redfish REST API record with source metadata."""
+    return RestApiRecord(
+        rest_api=f"/redfish/v1/Systems/{index}",
+        allowed_methods=methods,
+        json_body={
+            "@odata.id": f"/redfish/v1/Systems/{index}",
+            "@odata.type": "#ComputerSystem.v1_20_0.ComputerSystem",
+            "Name": f"System {index}",
+        },
+        vendor="fixture_vendor",
+        source_corpus="fixture_corpus",
+    )
+
+
+def _write_spec(path: Path) -> Path:
+    """Write a complete test YAML spec with distinctive literal values."""
+    path.write_text(
+        """
+dataset:
+  name: phase2_labelled_requests
+  prompt_spec_version: phase2-labelled-requests-test-v1
+sampling:
+  sample_widths: [1, 2, 3]
+model_x:
+  model_id: ${PHASE1_MODEL_X_MODEL_ID}
+  artifact_sha: ${PHASE1_MODEL_X_ARTIFACT_SHA}
+judge:
+  route: private_pro
+  model_id: ${PHASE2_JUDGE_MODEL_ID}
+  profile: ${PHASE2_JUDGE_PROFILE}
+generation:
+  max_new_tokens: 96
+  temperature: 0.2
+  top_p: 0.95
+prompts:
+  model_x_draft:
+    system: phase2 test model-x system prompt from YAML
+    template: |
+      Draft one operator request for these records:
+      {records_json}
+  pro_judge:
+    system: phase2 test pro judge system prompt from YAML
+    template: |
+      Judge whether this request maps to the same unordered REST API set.
+      Records:
+      {records_json}
+      Draft:
+      {draft_text}
+wandb:
+  namespace: phase2_labelled_requests
+  metric_keys:
+    - phase2_labelled_requests/draft_total
+    - phase2_labelled_requests/accepted_total
+    - phase2_labelled_requests/rejected_total
+    - phase2_labelled_requests/nonsense_rate
+    - phase2_labelled_requests/invalid_json_rate
+    - phase2_labelled_requests/pro_accept_rate
+    - phase2_labelled_requests/rest_api_set_match_rate
+    - phase2_labelled_requests/empty_set_match_rate
+    - phase2_labelled_requests/sample_width/k
+    - phase2_labelled_requests/vendor/source_corpus
+    - phase2_labelled_requests/prompt_spec_version
+    - phase2_labelled_requests/model_x/artifact_sha
+    - phase2_labelled_requests/judge/model
+    - phase2_labelled_requests/judge/profile
+acceptance:
+  min_pro_accept_rate: 0.9
+  min_rest_api_set_match_rate: 0.98
+  max_nonsense_rate: 0.01
+  max_invalid_json_rate: 0.01
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _judge_json(
+    *,
+    accepted: bool = True,
+    rest_api_list: list[str] | None = None,
+    nonsense: bool = False,
+    order_evidence: str = "none",
+) -> str:
+    """Return a compact fake Pro judge JSON response."""
+    return json.dumps(
+        {
+            "accepted": accepted,
+            "rest_api_list": [] if rest_api_list is None else rest_api_list,
+            "nonsense": nonsense,
+            "reason": "fixture",
+            "order_evidence": order_evidence,
+        },
+    )
+
+
+def _phase2_metric(name: str) -> str:
+    """Return a required Phase 2 labelled-request metric key."""
+    return phase_metric(PHASE2_LABELLED_REQUESTS, name)
+
+
+def test_loads_prompt_model_judge_generation_and_thresholds_from_yaml(tmp_path: Path) -> None:
+    """The Phase 2 spec loader keeps every runtime knob in YAML."""
+    spec = load_phase2_labelled_requests_spec(_write_spec(tmp_path / "phase2.yaml"))
+
+    assert spec.dataset_name == PHASE2_LABELLED_REQUESTS
+    assert spec.prompt_spec_version == "phase2-labelled-requests-test-v1"
+    assert spec.sample_widths == (1, 2, 3)
+    assert spec.model_x.model_id == "${PHASE1_MODEL_X_MODEL_ID}"
+    assert spec.judge.route == "private_pro"
+    assert spec.judge.profile == "${PHASE2_JUDGE_PROFILE}"
+    assert spec.generation == {"max_new_tokens": 96, "temperature": 0.2, "top_p": 0.95}
+    assert spec.wandb_namespace == PHASE2_LABELLED_REQUESTS
+    assert spec.metric_keys == PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS
+    assert spec.acceptance_thresholds["min_pro_accept_rate"] == 0.9
+
+
+def test_spec_loader_rejects_malformed_phase2_specs(tmp_path: Path) -> None:
+    """Spec validation fails closed for bad YAML shape and contract drift."""
+    not_mapping = tmp_path / "not-mapping.yaml"
+    not_mapping.write_text("- phase2_labelled_requests\n", encoding="utf-8")
+    with pytest.raises(Phase2LabelledRequestsSpecError, match="must be a mapping"):
+        load_phase2_labelled_requests_spec(not_mapping)
+
+    wrong_dataset = _write_spec(tmp_path / "wrong-dataset.yaml")
+    wrong_dataset.write_text(
+        wrong_dataset.read_text(encoding="utf-8").replace(
+            "name: phase2_labelled_requests",
+            "name: legacy_dataset",
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(Phase2LabelledRequestsSpecError, match="dataset.name"):
+        load_phase2_labelled_requests_spec(wrong_dataset)
+
+    wrong_metrics = _write_spec(tmp_path / "wrong-metrics.yaml")
+    wrong_metrics.write_text(
+        wrong_metrics.read_text(encoding="utf-8").replace(
+            "phase2_labelled_requests/draft_total",
+            "phase2_labelled_requests/draft_count",
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(Phase2LabelledRequestsSpecError, match="metric_keys"):
+        load_phase2_labelled_requests_spec(wrong_metrics)
+
+
+def test_committed_phase2_labelled_requests_config_loads() -> None:
+    """The checked-in builder spec stays aligned with the metric registry."""
+    spec = load_phase2_labelled_requests_spec("configs/phase2_labelled_requests.yaml")
+
+    assert spec.dataset_name == PHASE2_LABELLED_REQUESTS
+    assert spec.metric_keys == PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS
+    assert spec.sample_widths == (1, 2, 3)
+
+
+def test_prompt_rendering_uses_yaml_templates_not_runtime_literals(tmp_path: Path) -> None:
+    """Prompt text comes from the loaded spec and can be changed without code edits."""
+    spec = load_phase2_labelled_requests_spec(_write_spec(tmp_path / "phase2.yaml"))
+    records = (_record(1), _record(2))
+
+    model_prompt = render_model_x_prompt(spec, records)
+    judge_prompt = render_pro_judge_prompt(spec, records, "show both systems")
+
+    assert "phase2 test model-x system prompt from YAML" in model_prompt
+    assert "phase2 test pro judge system prompt from YAML" in judge_prompt
+    assert "/redfish/v1/Systems/1" in model_prompt
+    assert "show both systems" in judge_prompt
+
+    source = Path("igc/ds/phase2_labelled_requests.py").read_text(encoding="utf-8")
+    assert "phase2 test model-x system prompt from YAML" not in source
+    assert "${PHASE1_MODEL_X_MODEL_ID}" not in source
+    assert "${PHASE2_JUDGE_MODEL_ID}" not in source
+
+
+def test_sampling_accepts_only_k_1_2_3_and_preserves_record_payloads() -> None:
+    """The builder samples one, two, or three REST records with deterministic RNG."""
+    records = tuple(_record(index) for index in range(5))
+
+    for width in (1, 2, 3):
+        sampled = sample_phase2_contexts(records, k=width, rng=random.Random(7))
+        assert len(sampled) == width
+        assert all(record.rest_api.startswith("/redfish/v1/Systems/") for record in sampled)
+        assert all(record.allowed_methods == ("GET", "HEAD") for record in sampled)
+        assert all(record.json_body["@odata.id"] == record.rest_api for record in sampled)
+
+    first = sample_phase2_contexts(records, k=3, rng=random.Random(13))
+    second = sample_phase2_contexts(records, k=3, rng=random.Random(13))
+    assert [record.rest_api for record in first] == [record.rest_api for record in second]
+
+    with pytest.raises(ValueError, match="sample width"):
+        sample_phase2_contexts(records, k=0, rng=random.Random(1))
+    with pytest.raises(ValueError, match="sample width"):
+        sample_phase2_contexts(records, k=4, rng=random.Random(1))
+
+
+def test_unordered_set_comparison_and_empty_set_equality() -> None:
+    """API-set correctness ignores order unless a separate order signal says otherwise."""
+    expected = ["/redfish/v1/A", "/redfish/v1/B"]
+    predicted = ["/redfish/v1/B", "/redfish/v1/A"]
+
+    assert compare_rest_api_sets(expected, predicted)
+    assert not compare_rest_api_sets(expected, ["/redfish/v1/A"])
+    assert compare_rest_api_sets([], [])
+    assert empty_set_matches([], [])
+    assert not empty_set_matches([], ["/redfish/v1/A"])
+    assert not empty_set_matches(["/redfish/v1/A"], [])
+
+
+def test_pro_judge_result_parsing_accepts_plain_and_wrapped_json() -> None:
+    """The parser accepts expected judge JSON shapes and rejects malformed JSON safely."""
+    plain = parse_pro_judge_result(
+        _judge_json(
+            rest_api_list=["/redfish/v1/B", "/redfish/v1/A"],
+            order_evidence="explicit_then",
+        ),
+    )
+    assert plain.accepted is True
+    assert plain.rest_api_list == ("/redfish/v1/B", "/redfish/v1/A")
+    assert plain.order_evidence == "explicit_then"
+    assert plain.invalid_json is False
+
+    wrapped = parse_pro_judge_result(json.dumps({"y_pred": json.loads(_judge_json())}))
+    assert wrapped.accepted is True
+    assert wrapped.invalid_json is False
+
+    invalid = parse_pro_judge_result("{not json")
+    assert invalid.accepted is False
+    assert invalid.invalid_json is True
+    assert invalid.rest_api_list == ()
+
+
+def test_builder_uses_injected_providers_and_counts_rejections(tmp_path: Path) -> None:
+    """Offline build plumbing calls injected providers and summarizes draft quality."""
+    spec = load_phase2_labelled_requests_spec(_write_spec(tmp_path / "phase2.yaml"))
+    records = tuple(_record(index) for index in range(4))
+    seen: dict[str, dict] = {}
+
+    def draft_provider(request: dict) -> str:
+        """Return a valid human label and capture model routing details."""
+        seen["draft"] = request
+        return "show both sampled systems"
+
+    def judge_provider(request: dict) -> str:
+        """Accept exactly the sampled REST API set in a different order."""
+        seen["judge"] = request
+        expected = list(reversed(request["expected_rest_api_list"]))
+        return _judge_json(rest_api_list=expected)
+
+    builder = Phase2LabelledRequestBuilder(
+        spec,
+        draft_provider=draft_provider,
+        judge_provider=judge_provider,
+    )
+    row, counters = builder.build_one(records, k=2, rng=random.Random(3))
+
+    assert row is not None
+    data = row.to_dict()
+    assert data["dataset"] == PHASE2_LABELLED_REQUESTS
+    assert data["task"] == "text_to_rest_api_set"
+    assert data["x"]["text"] == "show both sampled systems"
+    assert data["validation"]["set_coverage_preserved"] is True
+    assert data["validation"]["review_judged"] is True
+    assert counters.summary()[_phase2_metric("draft_total")] == 1
+    assert counters.summary()[_phase2_metric("accepted_total")] == 1
+    assert counters.summary()[_phase2_metric("rest_api_set_match_rate")] == 1.0
+    assert seen["draft"]["model_id"] == "${PHASE1_MODEL_X_MODEL_ID}"
+    assert seen["draft"]["generation"]["max_new_tokens"] == 96
+    assert seen["judge"]["model_id"] == "${PHASE2_JUDGE_MODEL_ID}"
+    assert seen["judge"]["profile"] == "${PHASE2_JUDGE_PROFILE}"
+
+
+def test_builder_returns_none_and_counts_rejection_on_set_mismatch(tmp_path: Path) -> None:
+    """Rejected rows still produce namespaced counters for offline accounting."""
+    spec = load_phase2_labelled_requests_spec(_write_spec(tmp_path / "phase2.yaml"))
+    builder = Phase2LabelledRequestBuilder(
+        spec,
+        draft_provider=lambda request: "show the sampled system",
+        judge_provider=lambda request: _judge_json(
+            accepted=True,
+            rest_api_list=["/redfish/v1/Systems/not-sampled"],
+        ),
+    )
+
+    row, counters = builder.build_one((_record(1),), k=1, rng=random.Random(1))
+    summary = counters.summary()
+
+    assert row is None
+    assert summary[_phase2_metric("draft_total")] == 1
+    assert summary[_phase2_metric("accepted_total")] == 0
+    assert summary[_phase2_metric("rejected_total")] == 1
+    assert summary[_phase2_metric("rest_api_set_match_rate")] == 0.0
+
+
+def test_counters_track_nonsense_invalid_json_and_empty_set_matches() -> None:
+    """Counters expose the generation-quality metrics required for W&B."""
+    counters = Phase2LabelledRequestCounters()
+    counters.observe_draft("valid request")
+    counters.observe_judge(
+        parse_pro_judge_result(_judge_json(accepted=True, rest_api_list=[])),
+        expected_rest_api_list=(),
+    )
+    counters.observe_draft("???")
+    counters.observe_judge(
+        parse_pro_judge_result(_judge_json(accepted=False, nonsense=True)),
+        expected_rest_api_list=("/redfish/v1/A",),
+    )
+    counters.observe_draft("valid but bad judge")
+    counters.observe_judge(parse_pro_judge_result("not-json"), expected_rest_api_list=())
+
+    summary = counters.summary()
+    assert set(summary) <= set(PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS)
+    assert summary[_phase2_metric("draft_total")] == 3
+    assert summary[_phase2_metric("accepted_total")] == 1
+    assert summary[_phase2_metric("rejected_total")] == 2
+    assert summary[_phase2_metric("nonsense_rate")] == pytest.approx(1 / 3)
+    assert summary[_phase2_metric("invalid_json_rate")] == pytest.approx(1 / 3)
+    assert summary[_phase2_metric("pro_accept_rate")] == pytest.approx(1 / 3)
+    assert summary[_phase2_metric("rest_api_set_match_rate")] == pytest.approx(1 / 3)
+    assert summary[_phase2_metric("empty_set_match_rate")] == 1.0
+
+
+def test_phase2_labelled_request_wandb_keys_have_required_namespace_shape() -> None:
+    """Every Phase 2 labelled-request metric key stays under one namespace."""
+    keys = set(PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS)
+    expected = {
+        phase_metric(PHASE2_LABELLED_REQUESTS, "draft_total"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "accepted_total"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "rejected_total"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "nonsense_rate"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "invalid_json_rate"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "pro_accept_rate"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "rest_api_set_match_rate"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "empty_set_match_rate"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "sample_width", "k"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "vendor", "source_corpus"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "prompt_spec_version"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "model_x", "artifact_sha"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "judge", "model"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "judge", "profile"),
+    }
+
+    assert expected <= keys
+    assert all(key.startswith("phase2_labelled_requests/") for key in keys)
+
+
+def test_minimal_phase3_fixture_keeps_phase3_arguments_separate(tmp_path: Path) -> None:
+    """Phase 2 can hand text and APIs to Phase 3 without inventing call labels."""
+    spec = load_phase2_labelled_requests_spec(_write_spec(tmp_path / "phase2.yaml"))
+    records = (_record(1),)
+    builder = Phase2LabelledRequestBuilder(
+        spec,
+        draft_provider=lambda request: "show system one",
+        judge_provider=lambda request: _judge_json(rest_api_list=request["expected_rest_api_list"]),
+    )
+    row, _ = builder.build_one(records, k=1, rng=random.Random(1))
+
+    phase3_input = to_minimal_phase3_input(row)
+
+    assert phase3_input["text"] == "show system one"
+    assert phase3_input["rest_api_list"] == ["/redfish/v1/Systems/1"]
+    assert phase3_input["allowed_methods"]["/redfish/v1/Systems/1"] == ["GET", "HEAD"]
+    assert "calls" not in phase3_input
+    encoded = json.dumps(phase3_input)
+    assert '"method":' not in encoded
+    assert '"arguments":' not in encoded
+
+
+def test_minimal_phase3_fixture_rejects_missing_phase2_row() -> None:
+    """Phase 3 compatibility helpers fail before fabricating labels."""
+    with pytest.raises(ValueError, match="phase2 row is required"):
+        to_minimal_phase3_input(None)
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/modules/test_phase2_labelled_request_metric_keys.py
+++ b/tests/modules/test_phase2_labelled_request_metric_keys.py
@@ -1,0 +1,39 @@
+"""Metric-key registry tests for Phase 2 labelled-request generation.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from igc.modules.base.metric_keys import (
+    PHASE2_LABELLED_REQUESTS,
+    PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS,
+    phase_metric,
+)
+
+
+def test_phase2_labelled_request_registry_keeps_required_metric_names() -> None:
+    """Offline builder metrics keep the documented W&B key names."""
+    keys = set(PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS)
+
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "draft_total") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "accepted_total") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "rejected_total") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "nonsense_rate") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "invalid_json_rate") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "pro_accept_rate") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "rest_api_set_match_rate") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "empty_set_match_rate") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "sample_width", "k") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "vendor", "source_corpus") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "prompt_spec_version") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "model_x", "artifact_sha") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "judge", "model") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "judge", "profile") in keys
+
+
+def test_phase2_labelled_request_registry_uses_canonical_namespace() -> None:
+    """New Phase 2 labelled-request keys use only the canonical namespace."""
+    assert PHASE2_LABELLED_REQUESTS == "phase2_labelled_requests"
+    assert all(
+        key.startswith("phase2_labelled_requests/")
+        for key in PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS
+    )

--- a/tests/modules/test_phase2_labelled_request_metric_keys.py
+++ b/tests/modules/test_phase2_labelled_request_metric_keys.py
@@ -12,22 +12,25 @@ from igc.modules.base.metric_keys import (
 
 def test_phase2_labelled_request_registry_keeps_required_metric_names() -> None:
     """Offline builder metrics keep the documented W&B key names."""
-    keys = set(PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS)
+    expected = (
+        phase_metric(PHASE2_LABELLED_REQUESTS, "draft_total"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "accepted_total"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "rejected_total"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "nonsense_rate"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "invalid_json_rate"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "pro_accept_rate"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "rest_api_set_match_rate"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "empty_set_match_rate"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "sample_width", "k"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "vendor", "source_corpus"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "prompt_spec_version"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "model_x", "artifact_sha"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "judge", "model"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "judge", "profile"),
+    )
 
-    assert phase_metric(PHASE2_LABELLED_REQUESTS, "draft_total") in keys
-    assert phase_metric(PHASE2_LABELLED_REQUESTS, "accepted_total") in keys
-    assert phase_metric(PHASE2_LABELLED_REQUESTS, "rejected_total") in keys
-    assert phase_metric(PHASE2_LABELLED_REQUESTS, "nonsense_rate") in keys
-    assert phase_metric(PHASE2_LABELLED_REQUESTS, "invalid_json_rate") in keys
-    assert phase_metric(PHASE2_LABELLED_REQUESTS, "pro_accept_rate") in keys
-    assert phase_metric(PHASE2_LABELLED_REQUESTS, "rest_api_set_match_rate") in keys
-    assert phase_metric(PHASE2_LABELLED_REQUESTS, "empty_set_match_rate") in keys
-    assert phase_metric(PHASE2_LABELLED_REQUESTS, "sample_width", "k") in keys
-    assert phase_metric(PHASE2_LABELLED_REQUESTS, "vendor", "source_corpus") in keys
-    assert phase_metric(PHASE2_LABELLED_REQUESTS, "prompt_spec_version") in keys
-    assert phase_metric(PHASE2_LABELLED_REQUESTS, "model_x", "artifact_sha") in keys
-    assert phase_metric(PHASE2_LABELLED_REQUESTS, "judge", "model") in keys
-    assert phase_metric(PHASE2_LABELLED_REQUESTS, "judge", "profile") in keys
+    assert PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS == expected
+    assert len(PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS) == len(set(expected))
 
 
 def test_phase2_labelled_request_registry_uses_canonical_namespace() -> None:

--- a/tests/modules/test_phase2_labelled_request_metric_keys.py
+++ b/tests/modules/test_phase2_labelled_request_metric_keys.py
@@ -1,0 +1,39 @@
+"""Metric keys for Phase 2 labelled request dataset generation.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from igc.modules.base.metric_keys import (
+    PHASE2_LABELLED_REQUESTS,
+    PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS,
+    phase_metric,
+)
+
+
+def test_phase2_labelled_request_registry_keeps_required_metric_names() -> None:
+    """The offline builder has stable W&B key names for counters and metadata."""
+    keys = set(PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS)
+
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "build", "draft_total") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "build", "accepted_total") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "build", "rejected_total") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "nonsense_rate") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "invalid_json_rate") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "pro_accept_rate") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "rest_api_set_match_rate") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "eval", "empty_set_match_rate") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "sample_width", "k") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "vendor", "source_corpus") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "spec", "prompt_spec_version") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "model", "model_x_artifact_sha") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "judge", "model") in keys
+    assert phase_metric(PHASE2_LABELLED_REQUESTS, "judge", "profile") in keys
+
+
+def test_phase2_labelled_request_registry_uses_canonical_namespace() -> None:
+    """New Phase 2 labelled request keys use the canonical namespace only."""
+    assert PHASE2_LABELLED_REQUESTS == "phase2_labelled_requests"
+    assert all(
+        key.startswith("phase2_labelled_requests/")
+        for key in PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS
+    )

--- a/tests/scripts/test_phase2_labelled_requests_cli.py
+++ b/tests/scripts/test_phase2_labelled_requests_cli.py
@@ -384,6 +384,24 @@ def test_cli_live_provider_blocks_dataset_scale_without_gate(tmp_path: Path) -> 
         )
 
 
+def test_cli_one_sided_live_provider_override_blocks_dataset_scale_without_gate(
+    tmp_path: Path,
+) -> None:
+    """A single live adapter override still activates the dataset-scale gate."""
+    script = _load_script()
+
+    with pytest.raises(SystemExit, match="live provider runs"):
+        script.main(
+            _base_args(tmp_path, sample_width=1, count=4)
+            + [
+                "--draft-provider-adapter",
+                "openai-compatible",
+                "--judge-provider-adapter",
+                "mock",
+            ],
+        )
+
+
 def test_cli_live_override_requires_live_provider_config(tmp_path: Path) -> None:
     """CLI live overrides fail before HTTP when the YAML lacks live routing fields."""
     script = _load_script()

--- a/tests/scripts/test_phase2_labelled_requests_cli.py
+++ b/tests/scripts/test_phase2_labelled_requests_cli.py
@@ -384,6 +384,31 @@ def test_cli_live_provider_blocks_dataset_scale_without_gate(tmp_path: Path) -> 
         )
 
 
+@pytest.mark.parametrize(
+    "adapter_args",
+    (
+        ["--draft-provider-adapter", "openai-compatible"],
+        ["--judge-provider-adapter", "openai-compatible"],
+    ),
+)
+def test_cli_live_provider_override_blocks_dataset_scale_without_gate(
+    tmp_path: Path,
+    adapter_args: list[str],
+) -> None:
+    """One-sided live adapter overrides also require the explicit live gate."""
+    script = _load_script()
+    spec = script.load_phase2_labelled_requests_spec(
+        "configs/phase2_labelled_requests.yaml",
+    )
+    gated_count = spec.live_without_gate_max_candidates + 1
+
+    with pytest.raises(SystemExit, match="live provider runs"):
+        script.main(
+            _base_args(tmp_path, sample_width=1, count=gated_count)
+            + adapter_args,
+        )
+
+
 def test_cli_live_override_requires_live_provider_config(tmp_path: Path) -> None:
     """CLI live overrides fail before HTTP when the YAML lacks live routing fields."""
     script = _load_script()

--- a/tests/scripts/test_phase2_labelled_requests_cli.py
+++ b/tests/scripts/test_phase2_labelled_requests_cli.py
@@ -1,0 +1,332 @@
+"""Script tests for offline ``phase2_labelled_requests`` generation.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from igc.modules.base.metric_keys import (
+    PHASE2_LABELLED_REQUESTS,
+    PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS,
+    phase_metric,
+)
+
+SCRIPT = Path("scripts/build_phase2_labelled_requests.py")
+
+
+def _load_script() -> ModuleType:
+    """Load the script module for direct ``main(argv)`` testing."""
+    spec = importlib.util.spec_from_file_location("build_phase2_labelled_requests", SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_records(path: Path, count: int = 4) -> Path:
+    """Write tiny REST API record fixtures."""
+    rows = []
+    for index in range(count):
+        rows.append({
+            "rest_api": f"/redfish/v1/Systems/{index}",
+            "allowed_methods": ["get", "HEAD"],
+            "json": {
+                "@odata.id": f"/redfish/v1/Systems/{index}",
+                "@odata.type": "#ComputerSystem.v1_20_0.ComputerSystem",
+                "Name": f"System {index}",
+            },
+            "vendor": "fixture_vendor",
+            "source_corpus": "fixture_corpus",
+        })
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    """Read all non-blank JSONL rows."""
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _base_args(tmp_path: Path, *, sample_width: int = 2, count: int = 2) -> list[str]:
+    """Return common CLI args for fixture tests."""
+    return [
+        "--records-jsonl",
+        str(_write_records(tmp_path / "records.jsonl")),
+        "--output-jsonl",
+        str(tmp_path / "out" / "phase2_labelled_requests.jsonl"),
+        "--metrics-out",
+        str(tmp_path / "out" / "metrics.json"),
+        "--sample-width",
+        str(sample_width),
+        "--count",
+        str(count),
+        "--seed",
+        "11",
+    ]
+
+
+def _metric(group: str, name: str | None = None) -> str:
+    """Return a Phase 2 labelled-request metric key."""
+    return phase_metric(PHASE2_LABELLED_REQUESTS, group, name)
+
+
+def test_cli_mock_mode_writes_accepted_jsonl_and_metrics(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Mock providers produce accepted Phase 2 rows and registered metrics."""
+    script = _load_script()
+    output = tmp_path / "out" / "phase2_labelled_requests.jsonl"
+    metrics_path = tmp_path / "out" / "metrics.json"
+
+    code = script.main(_base_args(tmp_path, sample_width=3, count=2))
+    stdout = capsys.readouterr().out
+
+    assert code == 0
+    assert "dataset=phase2_labelled_requests" in stdout
+    assert "accepted=2" in stdout
+    assert f"output_jsonl={output}" in stdout
+    rows = _read_jsonl(output)
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert len(rows) == 2
+    assert rows[0]["phase"] == 2
+    assert rows[0]["dataset"] == PHASE2_LABELLED_REQUESTS
+    assert rows[0]["task"] == "text_to_rest_api_list"
+    assert rows[0]["x"]["text"].startswith("fixture request covering 3")
+    assert len(rows[0]["x"]["json"]) == 3
+    assert len(rows[0]["x"]["rest_api_list"]) == 3
+    assert rows[0]["x"]["allowed_methods"][rows[0]["x"]["rest_api_list"][0]][0] == "GET"
+    assert set(rows[0]["y_true"]["rest_api_list"]) == set(rows[0]["x"]["rest_api_list"])
+    assert rows[0]["validation"]["set_coverage_preserved"] is True
+    assert rows[0]["validation"]["review_judged"] is True
+    assert "calls" not in json.dumps(rows)
+    assert '"method":' not in json.dumps(rows)
+    assert '"arguments":' not in json.dumps(rows)
+    assert set(PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS) <= set(metrics)
+    assert metrics["dataset"] == PHASE2_LABELLED_REQUESTS
+    assert metrics[_metric("draft_total")] == 2
+    assert metrics[_metric("accepted_total")] == 2
+    assert metrics[_metric("rejected_total")] == 0
+    assert metrics[_metric("sample_width", "k")] == 3
+    assert metrics[_metric("vendor", "source_corpus")] == "fixture_vendor:fixture_corpus"
+    assert metrics["thresholds_pass"] is True
+
+
+@pytest.mark.parametrize("sample_width", (1, 2, 3))
+def test_cli_mock_mode_accepts_all_configured_sample_widths(
+    tmp_path: Path,
+    sample_width: int,
+) -> None:
+    """Mock mode accepts every configured sample width on a successful path."""
+    script = _load_script()
+    output = tmp_path / "out" / "phase2_labelled_requests.jsonl"
+    metrics_path = tmp_path / "out" / "metrics.json"
+
+    code = script.main(_base_args(tmp_path, sample_width=sample_width, count=1))
+
+    assert code == 0
+    rows = _read_jsonl(output)
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert len(rows) == 1
+    assert len(rows[0]["x"]["json"]) == sample_width
+    assert len(rows[0]["x"]["rest_api_list"]) == sample_width
+    assert metrics[_metric("sample_width", "k")] == sample_width
+
+
+def test_cli_file_providers_are_used_without_network(tmp_path: Path) -> None:
+    """Local provider fixture files control draft text and judge acceptance."""
+    script = _load_script()
+    drafts = tmp_path / "drafts.jsonl"
+    judges = tmp_path / "judges.jsonl"
+    output = tmp_path / "out" / "phase2_labelled_requests.jsonl"
+    metrics_path = tmp_path / "out" / "metrics.json"
+    drafts.write_text("show the sampled fixture systems\n", encoding="utf-8")
+    judges.write_text(
+        json.dumps({
+            "accepted": True,
+            "rest_api_list": ["/redfish/v1/Systems/3", "/redfish/v1/Systems/2"],
+            "nonsense": False,
+            "reason": "fixture",
+            "order_evidence": "none",
+        })
+        + "\n",
+        encoding="utf-8",
+    )
+
+    code = script.main(
+        _base_args(tmp_path, sample_width=2, count=1)
+        + [
+            "--provider-mode",
+            "file",
+            "--drafts-jsonl",
+            str(drafts),
+            "--judges-jsonl",
+            str(judges),
+        ],
+    )
+
+    assert code == 0
+    rows = _read_jsonl(output)
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert rows[0]["x"]["text"] == "show the sampled fixture systems"
+    assert set(rows[0]["y_true"]["rest_api_list"]) == {
+        "/redfish/v1/Systems/2",
+        "/redfish/v1/Systems/3",
+    }
+    assert metrics[_metric("accepted_total")] == 1
+
+
+def test_cli_rejects_mismatch_nonsense_and_invalid_judge_json(tmp_path: Path) -> None:
+    """Rejected candidates are omitted while aggregate counters still update."""
+    script = _load_script()
+    drafts = tmp_path / "drafts.jsonl"
+    judges = tmp_path / "judges.jsonl"
+    output = tmp_path / "out" / "phase2_labelled_requests.jsonl"
+    metrics_path = tmp_path / "out" / "metrics.json"
+    drafts.write_text("mismatch\nnonsense\ninvalid\n", encoding="utf-8")
+    judges.write_text(
+        "\n".join([
+            json.dumps({
+                "accepted": True,
+                "rest_api_list": ["/redfish/v1/not-sampled"],
+                "nonsense": False,
+            }),
+            json.dumps({
+                "accepted": False,
+                "rest_api_list": ["/redfish/v1/Systems/3"],
+                "nonsense": True,
+            }),
+            "not-json",
+        ])
+        + "\n",
+        encoding="utf-8",
+    )
+
+    code = script.main(
+        _base_args(tmp_path, sample_width=1, count=3)
+        + [
+            "--provider-mode",
+            "file",
+            "--drafts-jsonl",
+            str(drafts),
+            "--judges-jsonl",
+            str(judges),
+            "--allow-threshold-failure",
+        ],
+    )
+
+    assert code == 0
+    assert _read_jsonl(output) == []
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert metrics[_metric("draft_total")] == 3
+    assert metrics[_metric("accepted_total")] == 0
+    assert metrics[_metric("rejected_total")] == 3
+    assert metrics[_metric("nonsense_rate")] == pytest.approx(1 / 3)
+    assert metrics[_metric("invalid_json_rate")] == pytest.approx(1 / 3)
+    assert metrics[_metric("pro_accept_rate")] == pytest.approx(1 / 3)
+    assert metrics[_metric("rest_api_set_match_rate")] == pytest.approx(1 / 3)
+    assert metrics["thresholds_pass"] is False
+
+
+def test_cli_fixture_jsonl_validation_reports_line_numbers(tmp_path: Path) -> None:
+    """Bad input rows fail with line-numbered validation messages."""
+    script = _load_script()
+    records = tmp_path / "bad-records.jsonl"
+    records.write_text('{"rest_api": "/redfish/v1/A"}\n', encoding="utf-8")
+
+    with pytest.raises(SystemExit, match=r"bad-records\.jsonl:1: allowed_methods"):
+        script.main([
+            "--records-jsonl",
+            str(records),
+            "--output-jsonl",
+            str(tmp_path / "out.jsonl"),
+            "--metrics-out",
+            str(tmp_path / "metrics.json"),
+            "--sample-width",
+            "1",
+        ])
+
+    records.write_text('{"rest_api": "/redfish/v1/A", "allowed_methods": [], "json": {}}\nnot-json\n')
+    with pytest.raises(SystemExit, match=r"bad-records\.jsonl:2: invalid JSON"):
+        script.load_rest_api_records(records)
+
+
+def test_cli_seed_and_sample_width_are_deterministic(tmp_path: Path) -> None:
+    """The same seed and width produce byte-identical output."""
+    script = _load_script()
+    first = tmp_path / "first" / "phase2_labelled_requests.jsonl"
+    second = tmp_path / "second" / "phase2_labelled_requests.jsonl"
+    first_metrics = tmp_path / "first" / "metrics.json"
+    second_metrics = tmp_path / "second" / "metrics.json"
+    records = _write_records(tmp_path / "records.jsonl")
+
+    common = [
+        "--records-jsonl",
+        str(records),
+        "--sample-width",
+        "2",
+        "--count",
+        "3",
+        "--seed",
+        "19",
+    ]
+    assert script.main(common + ["--output-jsonl", str(first), "--metrics-out", str(first_metrics)]) == 0
+    assert script.main(common + ["--output-jsonl", str(second), "--metrics-out", str(second_metrics)]) == 0
+
+    assert first.read_text(encoding="utf-8") == second.read_text(encoding="utf-8")
+    assert first_metrics.read_text(encoding="utf-8") == second_metrics.read_text(encoding="utf-8")
+    with pytest.raises(SystemExit, match="sample-width"):
+        script.main(common + ["--sample-width", "4", "--output-jsonl", str(first), "--metrics-out", str(first_metrics)])
+
+
+def test_cli_threshold_failure_returns_nonzero_after_writing_metrics(tmp_path: Path) -> None:
+    """Threshold failures are explicit and do not prevent artifact inspection."""
+    script = _load_script()
+    drafts = tmp_path / "drafts.jsonl"
+    judges = tmp_path / "judges.jsonl"
+    metrics_path = tmp_path / "out" / "metrics.json"
+    drafts.write_text("mismatch\n", encoding="utf-8")
+    judges.write_text(
+        json.dumps({
+            "accepted": True,
+            "rest_api_list": ["/redfish/v1/not-sampled"],
+            "nonsense": False,
+        })
+        + "\n",
+        encoding="utf-8",
+    )
+
+    code = script.main(
+        _base_args(tmp_path, sample_width=1, count=1)
+        + [
+            "--provider-mode",
+            "file",
+            "--drafts-jsonl",
+            str(drafts),
+            "--judges-jsonl",
+            str(judges),
+        ],
+    )
+
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert code == 2
+    assert metrics["thresholds_pass"] is False
+    assert metrics[_metric("accepted_total")] == 0
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/scripts/test_phase2_labelled_requests_cli.py
+++ b/tests/scripts/test_phase2_labelled_requests_cli.py
@@ -191,6 +191,223 @@ def test_cli_file_providers_are_used_without_network(tmp_path: Path) -> None:
     assert metrics[_metric("accepted_total")] == 1
 
 
+def test_cli_config_provider_mode_uses_yaml_mock_adapters(tmp_path: Path) -> None:
+    """Default config mode uses the checked-in mock adapters without fixture files."""
+    script = _load_script()
+    output = tmp_path / "out" / "phase2_labelled_requests.jsonl"
+    metrics_path = tmp_path / "out" / "metrics.json"
+
+    code = script.main(_base_args(tmp_path, sample_width=1, count=1))
+
+    rows = _read_jsonl(output)
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert code == 0
+    assert rows[0]["x"]["text"].startswith("fixture request covering 1")
+    assert metrics[_metric("accepted_total")] == 1
+
+
+def test_cli_split_provider_adapter_overrides(tmp_path: Path) -> None:
+    """Draft and judge adapters can be overridden independently from YAML config."""
+    script = _load_script()
+    drafts = tmp_path / "drafts.jsonl"
+    output = tmp_path / "out" / "phase2_labelled_requests.jsonl"
+    metrics_path = tmp_path / "out" / "metrics.json"
+    drafts.write_text("inspect the selected system\n", encoding="utf-8")
+
+    code = script.main(
+        _base_args(tmp_path, sample_width=1, count=1)
+        + [
+            "--draft-provider-adapter",
+            "file",
+            "--drafts-jsonl",
+            str(drafts),
+            "--judge-provider-adapter",
+            "mock",
+        ],
+    )
+
+    rows = _read_jsonl(output)
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert code == 0
+    assert rows[0]["x"]["text"] == "inspect the selected system"
+    assert metrics[_metric("accepted_total")] == 1
+
+
+def test_cli_openai_compatible_provider_uses_fake_http_and_env_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Live provider mode is testable through injected fake HTTP transport."""
+    script = _load_script()
+    calls: list[dict] = []
+
+    monkeypatch.setenv("PHASE1_MODEL_X_MODEL_ID", "restored-model-x")
+    monkeypatch.setenv("PHASE2_JUDGE_MODEL_ID", "private-pro")
+    monkeypatch.setenv("PHASE2_JUDGE_ROUTE", "private-pro-route")
+    monkeypatch.setenv("PHASE2_JUDGE_PROFILE", "think-max")
+    monkeypatch.setenv("PHASE2_MODEL_X_BASE_URL", "http://model-x.invalid")
+    monkeypatch.setenv("PHASE2_JUDGE_BASE_URL", "http://judge.invalid")
+    monkeypatch.setenv("PHASE2_MODEL_X_API_KEY", "draft-token")
+    monkeypatch.setenv("PHASE2_JUDGE_API_KEY", "judge-token")
+
+    def fake_transport(url: str, payload: dict, headers: dict, timeout: float) -> dict:
+        """Capture request shape and return OpenAI-compatible fixture JSON."""
+        calls.append({
+            "url": url,
+            "payload": payload,
+            "headers": headers,
+            "timeout": timeout,
+        })
+        if payload["model"] == "restored-model-x":
+            return {"choices": [{"message": {"content": "show the sampled fixture system"}}]}
+        assert payload["model"] == "private-pro"
+        assert payload["route"] == "private-pro-route"
+        assert payload["profile"] == "think-max"
+        prompt = payload["messages"][0]["content"]
+        sampled = [
+            f"/redfish/v1/Systems/{index}"
+            for index in range(4)
+            if f"/redfish/v1/Systems/{index}" in prompt
+        ]
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps({
+                            "accepted": True,
+                            "rest_api_list": sampled,
+                            "nonsense": False,
+                            "reason": "fixture",
+                            "order_evidence": "none",
+                        }),
+                    },
+                },
+            ],
+        }
+
+    monkeypatch.setattr(script, "_urlopen_json_transport", fake_transport)
+    output = tmp_path / "out" / "phase2_labelled_requests.jsonl"
+    metrics_path = tmp_path / "out" / "metrics.json"
+
+    code = script.main(
+        _base_args(tmp_path, sample_width=1, count=1)
+        + [
+            "--provider-mode",
+            "openai-compatible",
+        ],
+    )
+
+    rows = _read_jsonl(output)
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert code == 0
+    assert len(calls) == 2
+    assert calls[0]["url"] == "http://model-x.invalid/v1/chat/completions"
+    assert calls[0]["headers"]["Authorization"] == "Bearer draft-token"
+    assert calls[0]["payload"]["model"] == "restored-model-x"
+    assert calls[0]["payload"]["max_new_tokens"] == 96
+    assert calls[1]["url"] == "http://judge.invalid/v1/chat/completions"
+    assert calls[1]["headers"]["Authorization"] == "Bearer judge-token"
+    assert rows[0]["x"]["text"] == "show the sampled fixture system"
+    assert rows[0]["y_true"]["rest_api_list"] == rows[0]["x"]["rest_api_list"]
+    assert metrics[_metric("accepted_total")] == 1
+
+
+def test_cli_live_provider_gate_flag_allows_larger_fake_http_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The explicit live gate flag allows above-cap fake HTTP validation."""
+    script = _load_script()
+    monkeypatch.setenv("PHASE1_MODEL_X_MODEL_ID", "restored-model-x")
+    monkeypatch.setenv("PHASE2_JUDGE_MODEL_ID", "private-pro")
+    monkeypatch.setenv("PHASE2_JUDGE_ROUTE", "private-pro-route")
+    monkeypatch.setenv("PHASE2_JUDGE_PROFILE", "think-max")
+    monkeypatch.setenv("PHASE2_MODEL_X_BASE_URL", "http://model-x.invalid")
+    monkeypatch.setenv("PHASE2_JUDGE_BASE_URL", "http://judge.invalid")
+
+    def fake_transport(url: str, payload: dict, headers: dict, timeout: float) -> dict:
+        """Return valid provider JSON without opening the network."""
+        _ = (url, headers, timeout)
+        if payload["model"] == "restored-model-x":
+            return {"choices": [{"message": {"content": "show the sampled fixture system"}}]}
+        prompt = payload["messages"][0]["content"]
+        sampled = [
+            f"/redfish/v1/Systems/{index}"
+            for index in range(4)
+            if f"/redfish/v1/Systems/{index}" in prompt
+        ]
+        return {
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps({
+                            "accepted": True,
+                            "rest_api_list": sampled,
+                            "nonsense": False,
+                        }),
+                    },
+                },
+            ],
+        }
+
+    monkeypatch.setattr(script, "_urlopen_json_transport", fake_transport)
+    output = tmp_path / "out" / "phase2_labelled_requests.jsonl"
+    metrics_path = tmp_path / "out" / "metrics.json"
+
+    code = script.main(
+        _base_args(tmp_path, sample_width=1, count=4)
+        + [
+            "--provider-mode",
+            "openai-compatible",
+            "--live-provider-gate-passed",
+        ],
+    )
+
+    rows = _read_jsonl(output)
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert code == 0
+    assert len(rows) == 4
+    assert metrics[_metric("accepted_total")] == 4
+
+
+def test_cli_live_provider_blocks_dataset_scale_without_gate(tmp_path: Path) -> None:
+    """Live provider mode refuses larger runs until the explicit gate flag is passed."""
+    script = _load_script()
+
+    with pytest.raises(SystemExit, match="live provider runs"):
+        script.main(
+            _base_args(tmp_path, sample_width=1, count=4)
+            + [
+                "--provider-mode",
+                "openai-compatible",
+            ],
+        )
+
+
+def test_cli_live_override_requires_live_provider_config(tmp_path: Path) -> None:
+    """CLI live overrides fail before HTTP when the YAML lacks live routing fields."""
+    script = _load_script()
+    spec_path = tmp_path / "phase2-without-provider-fields.yaml"
+    spec_text = Path("configs/phase2_labelled_requests.yaml").read_text(encoding="utf-8")
+    spec_path.write_text(
+        spec_text
+        .replace("    base_url_env: PHASE2_MODEL_X_BASE_URL\n", "", 1)
+        .replace("    endpoint_path: /v1/chat/completions\n", "", 1),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit, match="providers.draft.base_url_env"):
+        script.main(
+            _base_args(tmp_path, sample_width=1, count=1)
+            + [
+                "--spec",
+                str(spec_path),
+                "--provider-mode",
+                "openai-compatible",
+            ],
+        )
+
+
 def test_cli_rejects_mismatch_nonsense_and_invalid_judge_json(tmp_path: Path) -> None:
     """Rejected candidates are omitted while aggregate counters still update."""
     script = _load_script()
@@ -261,7 +478,10 @@ def test_cli_fixture_jsonl_validation_reports_line_numbers(tmp_path: Path) -> No
             "1",
         ])
 
-    records.write_text('{"rest_api": "/redfish/v1/A", "allowed_methods": [], "json": {}}\nnot-json\n')
+    records.write_text(
+        '{"rest_api": "/redfish/v1/A", "allowed_methods": [], "json": {}}\nnot-json\n',
+        encoding="utf-8",
+    )
     with pytest.raises(SystemExit, match=r"bad-records\.jsonl:2: invalid JSON"):
         script.load_rest_api_records(records)
 
@@ -285,13 +505,27 @@ def test_cli_seed_and_sample_width_are_deterministic(tmp_path: Path) -> None:
         "--seed",
         "19",
     ]
-    assert script.main(common + ["--output-jsonl", str(first), "--metrics-out", str(first_metrics)]) == 0
-    assert script.main(common + ["--output-jsonl", str(second), "--metrics-out", str(second_metrics)]) == 0
+    assert script.main(
+        common + ["--output-jsonl", str(first), "--metrics-out", str(first_metrics)],
+    ) == 0
+    assert script.main(
+        common + ["--output-jsonl", str(second), "--metrics-out", str(second_metrics)],
+    ) == 0
 
     assert first.read_text(encoding="utf-8") == second.read_text(encoding="utf-8")
     assert first_metrics.read_text(encoding="utf-8") == second_metrics.read_text(encoding="utf-8")
     with pytest.raises(SystemExit, match="sample-width"):
-        script.main(common + ["--sample-width", "4", "--output-jsonl", str(first), "--metrics-out", str(first_metrics)])
+        script.main(
+            common
+            + [
+                "--sample-width",
+                "4",
+                "--output-jsonl",
+                str(first),
+                "--metrics-out",
+                str(first_metrics),
+            ],
+        )
 
 
 def test_cli_threshold_failure_returns_nonzero_after_writing_metrics(tmp_path: Path) -> None:


### PR DESCRIPTION
Connects the Phase 2 labelled-request builder to live model_x/judge providers via YAML-owned config: CLI plumbing, live provider gate (dataset-scale runs require the explicit gate, including one-sided adapter overrides), metric registry keys, and judge parse hardening. No hardcoded prompts or model IDs.

Evidence:
- Brain reviews: 4736bed4b5be6fc7 (NO BLOCKING FINDINGS at 199fd59); delta test commit reviewed separately
- Remote slot2 validation (igc-phase1-pretrain, GPUs hidden): focused pytest 49 passed, ruff Python-only pass clean, git diff --check clean
- Unblocks queue item P2-LABELS-002