### PR TITLE
Fail slot LFS push before staging non-LFS artifacts

### DIFF
--- a/docs/NODE_ARTIFACTS.md
+++ b/docs/NODE_ARTIFACTS.md
@@ -22,8 +22,9 @@ scripts/lfs_push_from_slot.sh models/model_x/adapter.safetensors # push a review
 
 It:
 
-1. verifies the artifact is matched by an LFS filter (warns if `.gitattributes` won't catch it —
-   add the pattern via a PR first, so the file lands as an LFS object, not a huge git blob);
+1. verifies the artifact is matched by an LFS filter and fails before staging if
+   `.gitattributes` will not catch it. Add the pattern via a PR first, so the
+   file lands as an LFS object, not a huge git blob;
 2. creates a `data/<basename>-<UTC>` branch, stages **only** the given paths (never `git add -A`),
    commits, `git lfs push`es the objects, and pushes the branch;
 3. prints the **PR URL** — integration is PR-only, so the artifact branch is reviewed and merged

--- a/scripts/lfs_push_from_slot.sh
+++ b/scripts/lfs_push_from_slot.sh
@@ -40,7 +40,24 @@ cd "$REPO_ROOT"
 CUR_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 [ "$CUR_BRANCH" = "main" ] || note "current branch is '$CUR_BRANCH' (a data/* branch will be created)"
 
-# 1. Ensure git-lfs is available (no OS change unless opted in).
+# 1. Verify each artifact exists and is LFS-tracked. This happens before the
+# git-lfs binary check so a path that would become a normal Git blob fails even
+# on hosts where git-lfs is not installed yet.
+for path in "$@"; do
+  [ -e "$path" ] || die "no such artifact: $path"
+  if ! git check-attr filter -- "$path" 2>/dev/null | grep -q 'filter: lfs'; then
+    ext="$(basename "$path" | sed 's/^[^.]*//')"
+    pattern_note="an exact path"
+    if [ -n "$ext" ]; then
+      pattern_note="an exact path or extension pattern such as '${ext}'"
+    fi
+    die "'$path' is not matched by an LFS filter in .gitattributes.
+Add ${pattern_note} via PR, then rerun.
+Refusing to stage this artifact as a normal Git object."
+  fi
+done
+
+# 2. Ensure git-lfs is available (no OS change unless opted in).
 ensure_lfs() {
   if git lfs version >/dev/null 2>&1; then
     LFS_RUN=(git lfs)
@@ -71,16 +88,6 @@ ensure_lfs() {
   esac
 }
 ensure_lfs "$@"
-
-# 2. Verify each artifact exists and is LFS-tracked (warn if .gitattributes won't catch it).
-for path in "$@"; do
-  [ -e "$path" ] || die "no such artifact: $path"
-  if ! git check-attr filter -- "$path" 2>/dev/null | grep -q 'filter: lfs'; then
-    note "WARNING: '$path' is not matched by an LFS filter in .gitattributes — it would commit as
-       a normal (large) git object. Add a pattern to .gitattributes first (via PR), e.g.
-       '$(basename "$path" | sed 's/^[^.]*//')' or the exact path, then rerun."
-  fi
-done
 
 # 3. Confirm the push (large, outbound).
 STAMP="$(date -u +%Y%m%dT%H%M%SZ)"

--- a/tests/bats/lfs_push_from_slot.bats
+++ b/tests/bats/lfs_push_from_slot.bats
@@ -5,6 +5,24 @@ setup() {
     export REPO_ROOT
 }
 
+@test "slot LFS push refuses artifacts not covered by an LFS filter" {
+    tmp="$(mktemp -d)"
+    git -C "${tmp}" init -q
+    git -C "${tmp}" config user.email test@example.invalid
+    git -C "${tmp}" config user.name "IGC Test"
+    printf '*.safetensors filter=lfs diff=lfs merge=lfs -text\n' >"${tmp}/.gitattributes"
+    printf 'payload\n' >"${tmp}/raw.bin"
+    before_branch="$(git -C "${tmp}" symbolic-ref --short HEAD)"
+
+    run bash -c 'cd "$1" && env IGC_YES=1 IGC_REMOTE=origin "$2/scripts/lfs_push_from_slot.sh" raw.bin' \
+        _ "${tmp}" "${REPO_ROOT}"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not matched by an LFS filter"* ]]
+    [[ "$output" == *"Refusing to stage this artifact as a normal Git object."* ]]
+    [ "$(git -C "${tmp}" symbolic-ref --short HEAD)" = "${before_branch}" ]
+}
+
 @test "model adapter safetensors files are tracked by Git LFS" {
     run git -C "${REPO_ROOT}" check-attr filter -- models/model_x/adapter.safetensors
 

--- a/tests/bats/lfs_push_from_slot.bats
+++ b/tests/bats/lfs_push_from_slot.bats
@@ -11,6 +11,8 @@ setup() {
     git -C "${tmp}" config user.email test@example.invalid
     git -C "${tmp}" config user.name "IGC Test"
     printf '*.safetensors filter=lfs diff=lfs merge=lfs -text\n' >"${tmp}/.gitattributes"
+    git -C "${tmp}" add .gitattributes
+    git -C "${tmp}" commit -q -m "add lfs attributes"
     printf 'payload\n' >"${tmp}/raw.bin"
     before_branch="$(git -C "${tmp}" symbolic-ref --short HEAD)"
 

--- a/tests/shell/test_lfs_push_from_slot.sh
+++ b/tests/shell/test_lfs_push_from_slot.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Focused regression for scripts/lfs_push_from_slot.sh.
+#
+# Runs without network or git-lfs: the unsafe-path failure must happen before
+# the helper checks for a git-lfs binary, creates a data branch, or stages files.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+bash -n scripts/lfs_push_from_slot.sh
+
+tmp="$(mktemp -d)"
+cleanup() { rm -rf "$tmp"; }
+trap cleanup EXIT
+
+git -C "$tmp" init -q
+git -C "$tmp" config user.email test@example.invalid
+git -C "$tmp" config user.name "IGC Test"
+printf '*.safetensors filter=lfs diff=lfs merge=lfs -text\n' >"$tmp/.gitattributes"
+printf 'payload\n' >"$tmp/raw.bin"
+before_branch="$(git -C "$tmp" symbolic-ref --short HEAD)"
+
+out="$tmp/lfs_push.out"
+set +e
+(
+    cd "$tmp"
+    IGC_YES=1 IGC_REMOTE=origin "$repo_root/scripts/lfs_push_from_slot.sh" raw.bin
+) >"$out" 2>&1
+status=$?
+set -e
+
+cat "$out"
+
+if [ "$status" -eq 0 ]; then
+    echo "expected lfs_push_from_slot.sh to reject non-LFS artifact" >&2
+    exit 1
+fi
+
+grep -q "not matched by an LFS filter" "$out"
+grep -q "Refusing to stage this artifact as a normal Git object." "$out"
+test "$(git -C "$tmp" symbolic-ref --short HEAD)" = "$before_branch"
+
+git diff --check

--- a/tests/shell/test_lfs_push_from_slot.sh
+++ b/tests/shell/test_lfs_push_from_slot.sh
@@ -18,6 +18,8 @@ git -C "$tmp" init -q
 git -C "$tmp" config user.email test@example.invalid
 git -C "$tmp" config user.name "IGC Test"
 printf '*.safetensors filter=lfs diff=lfs merge=lfs -text\n' >"$tmp/.gitattributes"
+git -C "$tmp" add .gitattributes
+git -C "$tmp" commit -q -m "add lfs attributes"
 printf 'payload\n' >"$tmp/raw.bin"
 before_branch="$(git -C "$tmp" symbolic-ref --short HEAD)"
 


### PR DESCRIPTION
scripts/lfs_push_from_slot.sh now hard-fails before the git-lfs binary check, branch creation, or staging when a supplied artifact path is not matched by an LFS filter in .gitattributes; previously it only warned, which could commit bulky weights as normal git blobs. Adds a focused shell regression plus a bats test, and updates docs/NODE_ARTIFACTS.md.

Evidence:
- Remote slot2 CPU-only validation (igc-dev-codex-lfs-hardfail-testfix): helper rejected raw.bin with the refusal message, focused test returned remote_dev_ok
- Includes the testfix for the prior fixture (unborn-repo HEAD failure)