### PR TITLE
Rename Phase 3 inference handoff key to ordered_goals

### DIFF
--- a/igc/ds/rest_goal_contract.py
+++ b/igc/ds/rest_goal_contract.py
@@ -338,11 +338,11 @@ def inference_target_calls_json(row: Mapping[str, Any]) -> dict[str, Any]:
     """Build the combined inference JSON handoff from a Phase 3 row.
 
     :param row: row from :func:`build_ordered_call_row`.
-    :return: ``{"text": ..., "target_calls": [...]}``.
+    :return: ``{"text": ..., "ordered_goals": [...]}``.
     """
     return {
         "text": str(row["x"]["text"]),        # Operator sentence tied to the call sequence.
-        "target_calls": list(row["y_true"]["calls"]),  # Ordered calls for the RL handoff.
+        "ordered_goals": list(row["y_true"]["calls"]),  # Ordered calls for the RL handoff.
     }
 
 

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -748,15 +748,15 @@ def test_rendered_and_inference_outputs_preserve_multi_item_order() -> None:
     }
     assert [
         call["rest_api"]
-        for call in inference_target_calls_json(phase3)["target_calls"]
+        for call in inference_target_calls_json(phase3)["ordered_goals"]
     ] == [
         "/redfish/v1/TaskService/Tasks",
         "/redfish/v1/Systems",
     ]
 
 
-def test_inference_json_uses_target_calls_shape() -> None:
-    """The combined inference handoff uses target_calls with Phase 3 call fields."""
+def test_inference_json_uses_ordered_goals_shape() -> None:
+    """The combined inference handoff uses documented ordered_goals call fields."""
     context = _context(
         "/redfish/v1/TaskService/Tasks",
         ("GET", "HEAD"),
@@ -770,7 +770,7 @@ def test_inference_json_uses_target_calls_shape() -> None:
 
     assert inference_target_calls_json(row) == {
         "text": "check task queue",
-        "target_calls": row["y_true"]["calls"],
+        "ordered_goals": row["y_true"]["calls"],
     }
 
 
@@ -798,7 +798,7 @@ def test_inference_target_calls_json_preserves_mutation_arguments() -> None:
 
     assert inference_target_calls_json(row) == {
         "text": "set bios boot mode to Uefi",
-        "target_calls": [{
+        "ordered_goals": [{
             "rest_api": "/redfish/v1/Systems/1/Bios/Settings",
             "allowed_methods": ["GET", "PATCH"],
             "method": "PATCH",


### PR DESCRIPTION
The combined Phase 3 inference JSON handoff now emits the documented ordered_goals key (was target_calls), matching the Phase 3 ordered method/argument contract in docs/phase_3.md. Tests updated to pin the documented shape, including multi-item order and mutation-argument preservation.

Evidence:
- Completes queue item P3-SPEC-001; codex/phase3-arg-smoke-runner stacks on this branch