### PR TITLE
Clamp scheduler epochs/steps for zero-work resumes

### DIFF
--- a/igc/modules/llm_train_state_encoder.py
+++ b/igc/modules/llm_train_state_encoder.py
@@ -117,6 +117,49 @@ def optimizer_steps_per_epoch(num_micro_batches: int, accum_steps: int) -> int:
     return -(-num_micro_batches // accum_steps)
 
 
+def remaining_epochs(num_epochs: int, last_epoch: int) -> int:
+    """Epochs a (possibly resumed) run still owes, floored at zero.
+
+    A relaunch can resume from a checkpoint already at/beyond the target epoch
+    count (the epoch loop then runs zero iterations); the raw subtraction goes
+    negative for checkpoints from a longer prior run.
+
+    :param num_epochs: configured target epoch count for the run.
+    :param last_epoch: epochs already completed per the loaded checkpoint.
+    :return: ``max(0, num_epochs - last_epoch)``.
+    """
+    return max(0, int(num_epochs) - int(last_epoch))
+
+
+def scheduler_epoch_args(
+        num_epochs: int,
+        last_epoch: int,
+        num_micro_batches: int,
+        accum_steps: int,
+) -> tuple:
+    """Positive ``(epochs, steps_per_epoch)`` for scheduler construction.
+
+    OneCycleLR rejects ``epochs=0`` and ``steps_per_epoch=0``, so a resume over
+    a completed checkpoint — or an empty per-rank dataloader under
+    ``drop_last=True`` — crashed scheduler creation before the (no-op) epoch
+    loop could reach end-of-train finalization (the slot2 Phase 1 prebuild hit
+    exactly this: ``ValueError: Expected positive integer epochs, but got 0``).
+    Nothing steps the scheduler in those degenerate runs, so clamping both
+    values to at least 1 yields a valid never-consumed schedule while the real
+    remaining-work values pass through unchanged.
+
+    :param num_epochs: configured target epoch count for the run.
+    :param last_epoch: epochs already completed per the loaded checkpoint.
+    :param num_micro_batches: train dataloader length for one epoch.
+    :param accum_steps: gradient accumulation steps (coerced to >= 1).
+    :return: ``(epochs, steps_per_epoch)``, each floored at 1.
+    """
+    return (
+        max(1, remaining_epochs(num_epochs, last_epoch)),
+        max(1, optimizer_steps_per_epoch(num_micro_batches, accum_steps)),
+    )
+
+
 def measure_grad_norm(model) -> float:
     """Measure (never clip) the current global gradient norm.
 
@@ -696,6 +739,13 @@ class LlmEmbeddingsTrainer(LlmModule):
         )
 
         last_epoch = checkpoint_state.last_epoch
+        # A checkpoint at/beyond the target epoch count means the epoch loop
+        # below runs zero iterations: the run proceeds straight to end-of-train
+        # finalization (save/report), it must not crash in scheduler creation.
+        if remaining_epochs(self.num_epochs, last_epoch) == 0:
+            self.logger.info(
+                f"Rank {self.rank}: checkpoint already at epoch {last_epoch} "
+                f">= target {self.num_epochs}; no epochs left — finalizing only.")
         # Legacy runs seed best tracking from the checkpoint's accuracy channel. Phase 1
         # selects by validation loss, so a fresh run starts at +inf until the first eval.
         validation_result = ValidationMetrics(
@@ -714,10 +764,13 @@ class LlmEmbeddingsTrainer(LlmModule):
                 f"Rank {self.rank} resumed best validation metric "
                 f"{self._best_validation_metric} "
                 f"({'loss' if self._select_best_by_eval_loss else 'accuracy'} mode).")
-        self._trainer_args.epochs = self.num_epochs - last_epoch
         _accum = max(1, int(getattr(self._trainer_args, "gradient_accumulation_steps", 1)))
-        self._trainer_args.steps_per_epoch = optimizer_steps_per_epoch(
-            len(train_dataloader), _accum)
+        # Clamped to >= 1 so OneCycleLR construction survives degenerate runs
+        # (completed-checkpoint resume, empty per-rank dataloader) that step the
+        # scheduler zero times; real remaining work passes through unchanged.
+        self._trainer_args.epochs, self._trainer_args.steps_per_epoch = (
+            scheduler_epoch_args(
+                self.num_epochs, last_epoch, len(train_dataloader), _accum))
 
         self.logger.info(
             f"Rank {self.rank}: Data loader created: "

--- a/tests/modules/test_resume_epoch_guard.py
+++ b/tests/modules/test_resume_epoch_guard.py
@@ -1,0 +1,67 @@
+"""
+Offline regression for the resumed-run scheduler-argument guard.
+
+Pins ``remaining_epochs`` and ``scheduler_epoch_args``: a relaunch that resumes
+from a checkpoint already at or beyond the configured epoch target owes zero
+epochs, and scheduler construction must receive positive ``epochs`` /
+``steps_per_epoch`` anyway (OneCycleLR raises ``ValueError: Expected positive
+integer epochs, but got 0`` — the slot2 Phase 1 prebuild crash) while the
+zero-iteration epoch loop still falls through to end-of-train finalization
+(save/report — behavior pinned by tests/gpu/test_m1_train_step_live.py). Pure
+logic — no torch models, no GPU, no network.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+from igc.modules.llm_train_state_encoder import (
+    optimizer_steps_per_epoch,
+    remaining_epochs,
+    scheduler_epoch_args,
+)
+
+
+def test_fresh_run_owes_all_epochs():
+    """A fresh run (no checkpoint) owes the full configured epoch count."""
+    assert remaining_epochs(3, 0) == 3
+
+
+def test_mid_run_resume_owes_the_tail():
+    """Resuming a partially trained run owes only the unfinished epochs."""
+    assert remaining_epochs(3, 2) == 1
+
+
+def test_completed_checkpoint_owes_zero():
+    """A checkpoint exactly at the target owes 0 remaining epochs."""
+    assert remaining_epochs(3, 3) == 0
+
+
+def test_checkpoint_beyond_target_owes_zero_not_negative():
+    """A checkpoint from a longer prior run must floor at 0, never negative."""
+    assert remaining_epochs(3, 5) == 0
+
+
+def test_empty_dataloader_reports_zero_steps():
+    """drop_last on a sub-batch dataset yields 0 raw optimizer steps."""
+    assert optimizer_steps_per_epoch(0, 4) == 0
+
+
+def test_scheduler_args_pass_real_work_through_unchanged():
+    """Genuine remaining work reaches the scheduler exactly as computed."""
+    # 2 epochs left, 10 micro-batches at accum 4 -> ceil(10/4) = 3 opt steps.
+    assert scheduler_epoch_args(3, 1, 10, 4) == (2, 3)
+
+
+def test_scheduler_args_clamp_completed_resume_to_valid_schedule():
+    """A completed-checkpoint resume yields a valid (never stepped) schedule."""
+    # The slot2 prebuild crash: remaining epochs 0 must become 1 for OneCycleLR;
+    # the epoch loop still runs range(3, 3) == zero iterations.
+    assert scheduler_epoch_args(3, 3, 10, 4) == (1, 3)
+
+
+def test_scheduler_args_clamp_empty_dataloader_to_valid_schedule():
+    """An empty per-rank dataloader yields steps_per_epoch=1, not a crash."""
+    assert scheduler_epoch_args(1, 0, 0, 4) == (1, 1)
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
The slot2 Phase 1 rsLoRA relaunch (phase1-7b-rslora-r32-slot2-20260715) failed in prebuild: resuming over a completed checkpoint made `_train` compute `epochs = num_epochs - last_epoch = 0`, and OneCycleLR construction raised `ValueError: Expected positive integer epochs, but got 0` before the (zero-iteration) epoch loop could reach end-of-train finalization.

- New pure helpers `remaining_epochs` (floored at 0) and `scheduler_epoch_args` (both scheduler args floored at 1): a completed-checkpoint resume or an empty per-rank dataloader now yields a valid, never-stepped schedule instead of a crash, and the run falls through the empty epoch loop to normal finalization (save/report).
- First revision used an early `return`, which broke the zero-epoch end-of-train contract pinned by `tests/gpu/test_m1_train_step_live.py` (save_model/save_finetuned still called) — CI caught it; this clamp version preserves that contract.
- Offline regression tests for both helpers, including the exact slot2 case and the pass-through of genuine remaining work.

Gate: ruff clean on touched files; validation via PR CI (local test runs suspended on this machine — binding operator directive 2026-07-16).

Failure evidence: `/models/igc/phase1_runs/phase1-7b-rslora-r32-slot2-20260715/prebuild.log`.