### PR TITLE
Add Phase 3 argument-extractor smoke spec and CLI

### DIFF
--- a/configs/inference/phase3_argument_extractor_smoke.yaml
+++ b/configs/inference/phase3_argument_extractor_smoke.yaml
@@ -1,0 +1,42 @@
+profile:
+  name: phase3_argument_extractor_smoke
+  prompt_spec_version: phase3-argument-extractor-smoke-v1
+  task: text_and_rest_api_list_to_calls
+  base_weights_role: goal_extractor
+  weights_role: argument_extractor
+  renderer: render_ordered_call_example
+
+smoke:
+  fixtures:
+    - read_only_ordered_get
+    - patch_with_arguments
+  provider_modes:
+    - mock
+    - file
+
+wandb:
+  namespace: phase3_argument_extraction
+  metric_keys:
+    - phase3_argument_extraction/eval/call_ordered_exact_match_rate
+    - phase3_argument_extraction/eval/call_order_correct_rate
+    - phase3_argument_extraction/eval/rest_api_exact_match_rate
+    - phase3_argument_extraction/eval/allowed_methods_exact_match_rate
+    - phase3_argument_extraction/eval/method_exact_match_rate
+    - phase3_argument_extraction/eval/arguments_json_parse_rate
+    - phase3_argument_extraction/eval/arguments_exact_match_rate
+    - phase3_argument_extraction/eval/invalid_method_rate
+    - phase3_argument_extraction/eval/readonly_empty_arguments_rate
+    - phase3_argument_extraction/smoke/rows_total
+    - phase3_argument_extraction/smoke/parsed_total
+    - phase3_argument_extraction/smoke/accepted_total
+    - phase3_argument_extraction/smoke/prompt_spec_version
+    - phase3_argument_extraction/smoke/weights_role
+
+acceptance:
+  min_call_ordered_exact_match_rate: 1.0
+  min_call_order_correct_rate: 1.0
+  min_method_exact_match_rate: 1.0
+  min_arguments_json_parse_rate: 1.0
+  min_arguments_exact_match_rate: 1.0
+  min_readonly_empty_arguments_rate: 1.0
+  max_invalid_method_rate: 0.0

--- a/docs/phase_3.md
+++ b/docs/phase_3.md
@@ -216,5 +216,33 @@ The combined inference JSON should be easy to test:
 }
 ```
 
+## Offline Smoke Profile
+
+`configs/inference/phase3_argument_extractor_smoke.yaml` defines the first
+runnable `argument_extractor` smoke profile. It is a tiny offline profile for
+the existing ordered-call contract, not a training or GPU launch profile. The
+profile locks `weights_role: argument_extractor`, the
+`text_and_rest_api_list_to_calls` task, the `render_ordered_call_example`
+renderer, and acceptance thresholds for ordered calls, method validity,
+argument JSON, and read-only empty arguments.
+
+Run the smoke through `scripts/build_phase3_argument_smoke.py`. In default mock
+mode it renders two built-in fixtures: a read-only ordered GET/HEAD sequence and
+a PATCH row with explicit arguments. File mode accepts one local fake
+`argument_extractor` JSON prediction per fixture via `--predictions-jsonl`.
+Both modes write JSONL row evidence plus metrics JSON; neither mode loads model
+weights, opens W&B, downloads corpora, calls Redfish, or uses a GPU.
+
+Example:
+
+```bash
+python scripts/build_phase3_argument_smoke.py \
+  --output-jsonl /tmp/phase3_argument_smoke.jsonl \
+  --metrics-out /tmp/phase3_argument_smoke_metrics.json
+```
+
+Do not launch the bounded GPU smoke until this profile, runner, and offline
+gates pass in the approved remote CPU-only validation environment.
+
 Author:
 Mus mbayramo@stanford.edu

--- a/igc/ds/rest_goal_contract.py
+++ b/igc/ds/rest_goal_contract.py
@@ -334,6 +334,132 @@ def parse_ordered_calls_y_pred(y_pred: Mapping[str, Any] | str) -> list[dict[str
     return parsed
 
 
+def evaluate_ordered_calls_y_pred(
+    row: Mapping[str, Any],
+    y_pred: Mapping[str, Any] | str,
+) -> dict[str, Any]:
+    """Evaluate one Phase 3 prediction against a row's ordered calls.
+
+    :param row: row from :func:`build_ordered_call_row`.
+    :param y_pred: model output as a mapping or JSON string.
+    :return: parse status plus strict ordered-call comparison metrics.
+    """
+    expected_calls = list(row["y_true"]["calls"])
+    try:
+        predicted_calls = parse_ordered_calls_y_pred(y_pred)
+    except json.JSONDecodeError as exc:
+        return _failed_ordered_call_evaluation(expected_calls, f"invalid_json: {exc.msg}")
+    except ValueError as exc:
+        return _failed_ordered_call_evaluation(expected_calls, str(exc))
+    return evaluate_ordered_calls(expected_calls, predicted_calls)
+
+
+def evaluate_ordered_calls(
+    expected_calls: Sequence[Mapping[str, Any]],
+    predicted_calls: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Compare expected and predicted Phase 3 calls without truncating extras.
+
+    :param expected_calls: target call sequence.
+    :param predicted_calls: parsed prediction call sequence.
+    :return: strict ordered-call comparison metrics.
+    """
+    expected = [dict(call) for call in expected_calls]
+    predicted = [dict(call) for call in predicted_calls]
+    comparison_count = max(len(expected), len(predicted))
+    paired_count = min(len(expected), len(predicted))
+
+    rest_api_matches = 0
+    allowed_methods_matches = 0
+    method_matches = 0
+    argument_matches = 0
+    for index in range(paired_count):
+        expected_call = expected[index]
+        predicted_call = predicted[index]
+        if predicted_call.get("rest_api") == expected_call.get("rest_api"):
+            rest_api_matches += 1
+        if predicted_call.get("allowed_methods") == expected_call.get("allowed_methods"):
+            allowed_methods_matches += 1
+        if predicted_call.get("method") == expected_call.get("method"):
+            method_matches += 1
+        if predicted_call.get("arguments") == expected_call.get("arguments"):
+            argument_matches += 1
+
+    readonly_expected = [
+        call
+        for call in expected
+        if str(call.get("method", "")).upper() in ("GET", "HEAD")
+    ]
+    readonly_empty_matches = 0
+    for index, expected_call in enumerate(expected[:paired_count]):
+        expected_method = str(expected_call.get("method", "")).upper()
+        predicted_call = predicted[index]
+        predicted_method = str(predicted_call.get("method", "")).upper()
+        if (
+            expected_method in ("GET", "HEAD")
+            and predicted_method in ("GET", "HEAD")
+            and not predicted_call.get("arguments")
+        ):
+            readonly_empty_matches += 1
+
+    ordered_exact = expected == predicted
+    return {
+        "parsed": True,
+        "parse_error": "",
+        "expected_call_count": len(expected),
+        "predicted_call_count": len(predicted),
+        "call_count_match": len(expected) == len(predicted),
+        "call_ordered_exact_match": ordered_exact,
+        "call_ordered_exact_match_rate": 1.0 if ordered_exact else 0.0,
+        "call_order_correct_rate": _comparison_rate(rest_api_matches, comparison_count),
+        "rest_api_exact_match_rate": _comparison_rate(rest_api_matches, comparison_count),
+        "allowed_methods_exact_match_rate": _comparison_rate(
+            allowed_methods_matches,
+            comparison_count,
+        ),
+        "method_exact_match_rate": _comparison_rate(method_matches, comparison_count),
+        "arguments_exact_match_rate": _comparison_rate(argument_matches, comparison_count),
+        "arguments_json_parse_rate": 1.0,
+        "invalid_method_rate": 0.0,
+        "readonly_empty_arguments_rate": _comparison_rate(
+            readonly_empty_matches,
+            len(readonly_expected),
+        ),
+    }
+
+
+def _failed_ordered_call_evaluation(
+    expected_calls: Sequence[Mapping[str, Any]],
+    parse_error: str,
+) -> dict[str, Any]:
+    """Return a zeroed comparison result for an unparseable Phase 3 prediction."""
+    invalid_method = "not in allowed_methods" in parse_error
+    return {
+        "parsed": False,
+        "parse_error": parse_error,
+        "expected_call_count": len(expected_calls),
+        "predicted_call_count": 0,
+        "call_count_match": False,
+        "call_ordered_exact_match": False,
+        "call_ordered_exact_match_rate": 0.0,
+        "call_order_correct_rate": 0.0,
+        "rest_api_exact_match_rate": 0.0,
+        "allowed_methods_exact_match_rate": 0.0,
+        "method_exact_match_rate": 0.0,
+        "arguments_exact_match_rate": 0.0,
+        "arguments_json_parse_rate": 0.0,
+        "invalid_method_rate": 1.0 if invalid_method else 0.0,
+        "readonly_empty_arguments_rate": 0.0,
+    }
+
+
+def _comparison_rate(matches: int, total: int) -> float:
+    """Return a comparison rate, treating two empty sequences as a perfect match."""
+    if total == 0:
+        return 1.0
+    return matches / total
+
+
 def inference_target_calls_json(row: Mapping[str, Any]) -> dict[str, Any]:
     """Build the combined inference JSON handoff from a Phase 3 row.
 

--- a/scripts/build_phase3_argument_smoke.py
+++ b/scripts/build_phase3_argument_smoke.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+"""Run the offline Phase 3 method/argument extraction smoke.
+
+The runner is spec-driven and provider-injected. It uses tiny built-in
+fixtures, renders them through the ordered-goal contract, and parses fake model
+outputs from either deterministic mock mode or a local JSONL file. It never
+loads model weights, opens W&B, downloads corpora, calls Redfish, or uses a GPU.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+import yaml
+
+# Running as ``python scripts/build_phase3_argument_smoke.py`` puts scripts/ on
+# sys.path; add the repo root so ``import igc`` works without editable install.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from igc.ds.rest_goal_contract import (
+    RedfishContext,
+    build_ordered_call_row,
+    evaluate_ordered_calls_y_pred,
+    inference_target_calls_json,
+    render_ordered_call_example,
+)
+from igc.modules.base.metric_keys import PHASE3_ARGUMENT_EXTRACT, phase_metric
+
+PHASE3_ARGUMENT_SMOKE = "phase3_argument_extractor_smoke"
+
+_CALL_ORDERED_EXACT_KEY = phase_metric(
+    PHASE3_ARGUMENT_EXTRACT,
+    "eval",
+    "call_ordered_exact_match_rate",
+)
+_CALL_ORDER_CORRECT_KEY = phase_metric(
+    PHASE3_ARGUMENT_EXTRACT,
+    "eval",
+    "call_order_correct_rate",
+)
+_REST_API_EXACT_KEY = phase_metric(PHASE3_ARGUMENT_EXTRACT, "eval", "rest_api_exact_match_rate")
+_ALLOWED_METHODS_EXACT_KEY = phase_metric(
+    PHASE3_ARGUMENT_EXTRACT,
+    "eval",
+    "allowed_methods_exact_match_rate",
+)
+_METHOD_EXACT_KEY = phase_metric(PHASE3_ARGUMENT_EXTRACT, "eval", "method_exact_match_rate")
+_ARGS_PARSE_KEY = phase_metric(PHASE3_ARGUMENT_EXTRACT, "eval", "arguments_json_parse_rate")
+_ARGS_EXACT_KEY = phase_metric(PHASE3_ARGUMENT_EXTRACT, "eval", "arguments_exact_match_rate")
+_INVALID_METHOD_KEY = phase_metric(PHASE3_ARGUMENT_EXTRACT, "eval", "invalid_method_rate")
+_READONLY_EMPTY_KEY = phase_metric(
+    PHASE3_ARGUMENT_EXTRACT,
+    "eval",
+    "readonly_empty_arguments_rate",
+)
+_ROWS_TOTAL_KEY = phase_metric(PHASE3_ARGUMENT_EXTRACT, "smoke", "rows_total")
+_PARSED_TOTAL_KEY = phase_metric(PHASE3_ARGUMENT_EXTRACT, "smoke", "parsed_total")
+_ACCEPTED_TOTAL_KEY = phase_metric(PHASE3_ARGUMENT_EXTRACT, "smoke", "accepted_total")
+_PROMPT_SPEC_VERSION_KEY = phase_metric(
+    PHASE3_ARGUMENT_EXTRACT,
+    "smoke",
+    "prompt_spec_version",
+)
+_WEIGHTS_ROLE_KEY = phase_metric(PHASE3_ARGUMENT_EXTRACT, "smoke", "weights_role")
+
+_RATE_KEYS = (
+    _CALL_ORDERED_EXACT_KEY,
+    _CALL_ORDER_CORRECT_KEY,
+    _REST_API_EXACT_KEY,
+    _ALLOWED_METHODS_EXACT_KEY,
+    _METHOD_EXACT_KEY,
+    _ARGS_PARSE_KEY,
+    _ARGS_EXACT_KEY,
+    _INVALID_METHOD_KEY,
+    _READONLY_EMPTY_KEY,
+)
+
+PredictionProvider = Callable[[dict[str, Any]], str]
+
+
+class Phase3ArgumentSmokeSpecError(ValueError):
+    """Raised when the Phase 3 smoke YAML spec is invalid."""
+
+
+@dataclass(frozen=True)
+class Phase3ArgumentSmokeSpec:
+    """Loaded YAML contract for the Phase 3 argument-extractor smoke."""
+
+    profile_name: str
+    prompt_spec_version: str
+    task: str
+    base_weights_role: str
+    weights_role: str
+    renderer: str
+    fixtures: tuple[str, ...]
+    provider_modes: tuple[str, ...]
+    wandb_namespace: str
+    metric_keys: tuple[str, ...]
+    acceptance_thresholds: Mapping[str, float]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--spec",
+        default="configs/inference/phase3_argument_extractor_smoke.yaml",
+        help="YAML smoke profile with fixtures, metric keys, and thresholds.",
+    )
+    parser.add_argument(
+        "--output-jsonl",
+        required=True,
+        help="Destination JSONL for rendered fixture rows and prediction results.",
+    )
+    parser.add_argument(
+        "--metrics-out",
+        required=True,
+        help="Destination JSON file for aggregate smoke metrics.",
+    )
+    parser.add_argument(
+        "--provider-mode",
+        choices=("mock", "file"),
+        default="mock",
+        help="Use deterministic exact-match fake outputs or local prediction fixtures.",
+    )
+    parser.add_argument(
+        "--predictions-jsonl",
+        default="",
+        help="Provider-mode file: one raw argument_extractor JSON prediction per fixture.",
+    )
+    parser.add_argument(
+        "--allow-threshold-failure",
+        action="store_true",
+        help="Write artifacts and exit 0 even when YAML thresholds fail.",
+    )
+    return parser.parse_args(argv)
+
+
+def load_phase3_argument_smoke_spec(path: str | Path) -> Phase3ArgumentSmokeSpec:
+    """Load and validate the Phase 3 argument smoke YAML spec."""
+    spec_path = Path(path)
+    try:
+        raw = yaml.safe_load(spec_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise Phase3ArgumentSmokeSpecError(f"cannot read spec {spec_path}: {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise Phase3ArgumentSmokeSpecError(f"cannot parse YAML in {spec_path}: {exc}") from exc
+    if not isinstance(raw, Mapping):
+        raise Phase3ArgumentSmokeSpecError("Phase 3 argument smoke spec must be a mapping")
+
+    profile = _mapping(raw, "profile", required=True)
+    smoke = _mapping(raw, "smoke", required=True)
+    wandb = _mapping(raw, "wandb", required=True)
+    acceptance = _mapping(raw, "acceptance", required=True)
+
+    profile_name = _required_string(profile, "name", "profile.name")
+    if profile_name != PHASE3_ARGUMENT_SMOKE:
+        raise Phase3ArgumentSmokeSpecError(
+            f"profile.name must be {PHASE3_ARGUMENT_SMOKE!r}",
+        )
+    task = _required_string(profile, "task", "profile.task")
+    if task != "text_and_rest_api_list_to_calls":
+        raise Phase3ArgumentSmokeSpecError(
+            "profile.task must be 'text_and_rest_api_list_to_calls'",
+        )
+    weights_role = _required_string(profile, "weights_role", "profile.weights_role")
+    if weights_role != "argument_extractor":
+        raise Phase3ArgumentSmokeSpecError("profile.weights_role must be 'argument_extractor'")
+    renderer = _required_string(profile, "renderer", "profile.renderer")
+    if renderer != "render_ordered_call_example":
+        raise Phase3ArgumentSmokeSpecError(
+            "profile.renderer must be 'render_ordered_call_example'",
+        )
+
+    fixtures = tuple(str(item) for item in _sequence(smoke, "fixtures"))
+    if fixtures != ("read_only_ordered_get", "patch_with_arguments"):
+        raise Phase3ArgumentSmokeSpecError(
+            "smoke.fixtures must be read_only_ordered_get and patch_with_arguments",
+        )
+    provider_modes = tuple(str(item) for item in _sequence(smoke, "provider_modes"))
+    if provider_modes != ("mock", "file"):
+        raise Phase3ArgumentSmokeSpecError("smoke.provider_modes must be mock and file")
+
+    wandb_namespace = _required_string(wandb, "namespace", "wandb.namespace")
+    if wandb_namespace != PHASE3_ARGUMENT_EXTRACT:
+        raise Phase3ArgumentSmokeSpecError(
+            f"wandb.namespace must be {PHASE3_ARGUMENT_EXTRACT!r}",
+        )
+    metric_keys = tuple(str(item) for item in _sequence(wandb, "metric_keys"))
+    missing_metrics = sorted(set(_expected_metric_keys()) - set(metric_keys))
+    if missing_metrics:
+        raise Phase3ArgumentSmokeSpecError(
+            f"wandb.metric_keys missing required keys: {', '.join(missing_metrics)}",
+        )
+
+    thresholds = _acceptance_thresholds(acceptance)
+    return Phase3ArgumentSmokeSpec(
+        profile_name=profile_name,
+        prompt_spec_version=_required_string(
+            profile,
+            "prompt_spec_version",
+            "profile.prompt_spec_version",
+        ),
+        task=task,
+        base_weights_role=_required_string(
+            profile,
+            "base_weights_role",
+            "profile.base_weights_role",
+        ),
+        weights_role=weights_role,
+        renderer=renderer,
+        fixtures=fixtures,
+        provider_modes=provider_modes,
+        wandb_namespace=wandb_namespace,
+        metric_keys=metric_keys,
+        acceptance_thresholds=thresholds,
+    )
+
+
+def default_phase3_smoke_rows() -> tuple[dict[str, Any], ...]:
+    """Return the tiny offline fixtures used by the smoke runner."""
+    systems = RedfishContext(
+        rest_api="/redfish/v1/Systems",
+        allowed_methods=("GET", "HEAD"),
+        json={
+            "@odata.id": "/redfish/v1/Systems",
+            "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+            "Members": [{"@odata.id": "/redfish/v1/Systems/System.Embedded.1"}],
+            "Members@odata.count": 1,
+            "Name": "Computer System Collection",
+        },
+    )
+    tasks = RedfishContext(
+        rest_api="/redfish/v1/TaskService/Tasks",
+        allowed_methods=("GET", "HEAD"),
+        json={
+            "@odata.id": "/redfish/v1/TaskService/Tasks",
+            "@odata.type": "#TaskCollection.TaskCollection",
+            "Members": [],
+            "Members@odata.count": 0,
+            "Name": "Task Collection",
+        },
+    )
+    bios_settings = RedfishContext(
+        rest_api="/redfish/v1/Systems/System.Embedded.1/Bios/Settings",
+        allowed_methods=("GET", "PATCH"),
+        json={
+            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios/Settings",
+            "Attributes": {"BootMode": "LegacyBios"},
+        },
+    )
+
+    return (
+        build_ordered_call_row(
+            text="check the task queue, then list the available computer systems",
+            contexts=(systems, tasks),
+            rest_api_list=("/redfish/v1/TaskService/Tasks", "/redfish/v1/Systems"),
+        ),
+        build_ordered_call_row(
+            text="set the embedded system bios boot mode to Uefi",
+            contexts=(bios_settings,),
+            rest_api_list=("/redfish/v1/Systems/System.Embedded.1/Bios/Settings",),
+            method_by_api={
+                "/redfish/v1/Systems/System.Embedded.1/Bios/Settings": "PATCH",
+            },
+            arguments_by_api={
+                "/redfish/v1/Systems/System.Embedded.1/Bios/Settings": {
+                    "Attributes": {"BootMode": "Uefi"},
+                },
+            },
+        ),
+    )
+
+
+def build_phase3_argument_smoke(
+    *,
+    spec: Phase3ArgumentSmokeSpec,
+    rows: Sequence[Mapping[str, Any]],
+    prediction_provider: PredictionProvider,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Render rows, parse fake predictions, and aggregate smoke metrics."""
+    artifacts: list[dict[str, Any]] = []
+    evaluations: list[dict[str, Any]] = []
+
+    for row_index, row in enumerate(rows):
+        rendered = render_ordered_call_example(row)
+        request = {
+            "row_index": row_index,
+            "profile": spec.profile_name,
+            "prompt_spec_version": spec.prompt_spec_version,
+            "weights_role": spec.weights_role,
+            "prompt": rendered.prompt,
+            "target_json": rendered.target_json,
+            "expected_calls": list(row["y_true"]["calls"]),
+        }
+        raw_prediction = prediction_provider(request)
+        evaluation = evaluate_ordered_calls_y_pred(row, raw_prediction)
+        evaluations.append(evaluation)
+        artifacts.append({
+            "dataset": spec.profile_name,
+            "prompt_spec_version": spec.prompt_spec_version,
+            "task": spec.task,
+            "row_index": row_index,
+            "x": dict(row["x"]),
+            "y_true": dict(row["y_true"]),
+            "rendered": {
+                "renderer": spec.renderer,
+                "target_char_start": rendered.target_char_start,
+                "prompt_char_count": len(rendered.prompt),
+                "target_json": rendered.target_json,
+            },
+            "y_pred_raw": raw_prediction,
+            "evaluation": evaluation,
+            "inference": inference_target_calls_json(row),
+        })
+
+    summary = aggregate_phase3_argument_smoke_metrics(spec, evaluations)
+    return artifacts, summary
+
+
+def aggregate_phase3_argument_smoke_metrics(
+    spec: Phase3ArgumentSmokeSpec,
+    evaluations: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Aggregate row-level evaluation records into spec metric keys."""
+    rows_total = len(evaluations)
+    summary: dict[str, Any] = {
+        "dataset": spec.profile_name,
+        "task": spec.task,
+        _ROWS_TOTAL_KEY: rows_total,
+        _PARSED_TOTAL_KEY: sum(1 for item in evaluations if item.get("parsed")),
+        _ACCEPTED_TOTAL_KEY: sum(
+            1
+            for item in evaluations
+            if item.get("call_ordered_exact_match")
+        ),
+        _PROMPT_SPEC_VERSION_KEY: spec.prompt_spec_version,
+        _WEIGHTS_ROLE_KEY: spec.weights_role,
+    }
+    for key in _RATE_KEYS:
+        field = key.rsplit("/", 1)[-1]
+        summary[key] = _average(float(item.get(field, 0.0)) for item in evaluations)
+    summary["thresholds_pass"] = phase3_argument_smoke_thresholds_pass(spec, summary)
+    return summary
+
+
+def phase3_argument_smoke_thresholds_pass(
+    spec: Phase3ArgumentSmokeSpec,
+    summary: Mapping[str, Any],
+) -> bool:
+    """Return true when aggregate smoke metrics satisfy YAML thresholds."""
+    thresholds = spec.acceptance_thresholds
+    return (
+        float(summary.get(_CALL_ORDERED_EXACT_KEY, 0.0))
+        >= thresholds["min_call_ordered_exact_match_rate"]
+        and float(summary.get(_CALL_ORDER_CORRECT_KEY, 0.0))
+        >= thresholds["min_call_order_correct_rate"]
+        and float(summary.get(_METHOD_EXACT_KEY, 0.0))
+        >= thresholds["min_method_exact_match_rate"]
+        and float(summary.get(_ARGS_PARSE_KEY, 0.0))
+        >= thresholds["min_arguments_json_parse_rate"]
+        and float(summary.get(_ARGS_EXACT_KEY, 0.0))
+        >= thresholds["min_arguments_exact_match_rate"]
+        and float(summary.get(_READONLY_EMPTY_KEY, 0.0))
+        >= thresholds["min_readonly_empty_arguments_rate"]
+        and float(summary.get(_INVALID_METHOD_KEY, 1.0))
+        <= thresholds["max_invalid_method_rate"]
+    )
+
+
+def write_jsonl(path: Path, rows: Iterable[Mapping[str, Any]]) -> int:
+    """Write JSONL rows and return the number written."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    count = 0
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(dict(row), sort_keys=True))
+            handle.write("\n")
+            count += 1
+    return count
+
+
+def write_metrics(path: Path, summary: Mapping[str, Any]) -> None:
+    """Write aggregate smoke metrics JSON."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(dict(summary), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint.
+
+    :return: process-style exit code.
+    """
+    args = parse_args(argv)
+    spec = load_phase3_argument_smoke_spec(args.spec)
+    prediction_provider = _prediction_provider(args)
+    artifacts, metrics = build_phase3_argument_smoke(
+        spec=spec,
+        rows=default_phase3_smoke_rows(),
+        prediction_provider=prediction_provider,
+    )
+    rows_written = write_jsonl(Path(args.output_jsonl), artifacts)
+    write_metrics(Path(args.metrics_out), metrics)
+    print(
+        f"wrote dataset={metrics['dataset']} "
+        f"rows={rows_written} "
+        f"accepted={metrics[_ACCEPTED_TOTAL_KEY]} "
+        f"thresholds_pass={metrics['thresholds_pass']} "
+        f"output_jsonl={args.output_jsonl} "
+        f"metrics_out={args.metrics_out}"
+    )
+    if not metrics["thresholds_pass"] and not args.allow_threshold_failure:
+        return 2
+    return 0
+
+
+def _prediction_provider(args: argparse.Namespace) -> PredictionProvider:
+    """Return the fake prediction provider selected by CLI flags."""
+    if args.provider_mode == "mock":
+        return _mock_prediction_provider
+    if not args.predictions_jsonl:
+        raise SystemExit("--predictions-jsonl is required for provider-mode file")
+    return _JsonLineProvider(Path(args.predictions_jsonl), label="prediction")
+
+
+def _mock_prediction_provider(request: dict[str, Any]) -> str:
+    """Return an exact-match fake argument_extractor output."""
+    return json.dumps({"calls": request["expected_calls"]}, sort_keys=True)
+
+
+class _JsonLineProvider:
+    """Sequential fake provider backed by non-blank local JSONL text lines."""
+
+    def __init__(self, path: Path, *, label: str) -> None:
+        """Load fake provider lines."""
+        self._path = path
+        self._label = label
+        self._lines = [
+            line.strip()
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        self._index = 0
+        if not self._lines:
+            raise SystemExit(f"{path}: no {label} provider lines found")
+
+    def __call__(self, request: dict[str, Any]) -> str:
+        """Return the next provider line."""
+        _ = request
+        if self._index >= len(self._lines):
+            raise SystemExit(f"{self._path}: not enough {self._label} provider lines")
+        line = self._lines[self._index]
+        self._index += 1
+        return line
+
+
+def _expected_metric_keys() -> tuple[str, ...]:
+    """Return the metric keys required from the YAML profile."""
+    return _RATE_KEYS + (
+        _ROWS_TOTAL_KEY,
+        _PARSED_TOTAL_KEY,
+        _ACCEPTED_TOTAL_KEY,
+        _PROMPT_SPEC_VERSION_KEY,
+        _WEIGHTS_ROLE_KEY,
+    )
+
+
+def _acceptance_thresholds(raw: Mapping[str, Any]) -> dict[str, float]:
+    """Validate and normalize acceptance thresholds."""
+    required = {
+        "min_call_ordered_exact_match_rate",
+        "min_call_order_correct_rate",
+        "min_method_exact_match_rate",
+        "min_arguments_json_parse_rate",
+        "min_arguments_exact_match_rate",
+        "min_readonly_empty_arguments_rate",
+        "max_invalid_method_rate",
+    }
+    missing = sorted(required - set(raw))
+    if missing:
+        raise Phase3ArgumentSmokeSpecError(
+            f"acceptance missing required keys: {', '.join(missing)}",
+        )
+    thresholds: dict[str, float] = {}
+    for key, value in raw.items():
+        try:
+            thresholds[str(key)] = float(value)
+        except (TypeError, ValueError) as exc:
+            raise Phase3ArgumentSmokeSpecError(f"acceptance.{key} must be numeric") from exc
+    return thresholds
+
+
+def _mapping(source: Mapping[str, Any], key: str, *, required: bool = False) -> Mapping[str, Any]:
+    """Read a nested mapping from a YAML dictionary."""
+    value = source.get(key)
+    if value is None and not required:
+        return {}
+    if not isinstance(value, Mapping):
+        raise Phase3ArgumentSmokeSpecError(f"{key} must be a mapping")
+    return value
+
+
+def _sequence(source: Mapping[str, Any], key: str) -> Sequence[Any]:
+    """Read a sequence from a YAML dictionary."""
+    value = source.get(key)
+    if not isinstance(value, (list, tuple)):
+        raise Phase3ArgumentSmokeSpecError(f"{key} must be a sequence")
+    return value
+
+
+def _required_string(source: Mapping[str, Any], key: str, label: str) -> str:
+    """Read a required non-empty string from a YAML dictionary."""
+    value = source.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise Phase3ArgumentSmokeSpecError(f"{label} must be a non-empty string")
+    return value
+
+
+def _average(values: Iterable[float]) -> float:
+    """Return the average of an iterable, or zero when it is empty."""
+    values_list = list(values)
+    if not values_list:
+        return 0.0
+    return sum(values_list) / len(values_list)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -21,6 +21,7 @@ from igc.ds.rest_goal_contract import (
     RedfishContext,
     build_d1_rest_api_list_row,
     build_ordered_call_row,
+    evaluate_ordered_calls_y_pred,
     inference_target_calls_json,
     parse_ordered_calls_y_pred,
     parse_rest_api_list_y_pred,
@@ -1023,6 +1024,66 @@ def test_ordered_calls_parser_rejects_readonly_arguments() -> None:
                     "arguments": {"PowerState": "On"},
                 }],
             })
+
+
+def test_ordered_call_evaluation_counts_extra_predictions_as_failures() -> None:
+    """Phase 3 evaluation must not hide extra predictions by zipping shorter lists."""
+    systems = _context(
+        "/redfish/v1/Systems",
+        ("GET", "HEAD"),
+        {"@odata.id": "/redfish/v1/Systems"},
+    )
+    tasks = _context(
+        "/redfish/v1/TaskService/Tasks",
+        ("GET", "HEAD"),
+        {"@odata.id": "/redfish/v1/TaskService/Tasks"},
+    )
+    row = build_ordered_call_row(
+        text="check tasks, then list systems",
+        contexts=(systems, tasks),
+        rest_api_list=("/redfish/v1/TaskService/Tasks", "/redfish/v1/Systems"),
+    )
+    predicted_calls = list(row["y_true"]["calls"]) + [row["y_true"]["calls"][0]]
+
+    evaluation = evaluate_ordered_calls_y_pred(row, {"calls": predicted_calls})
+
+    assert evaluation["parsed"] is True
+    assert evaluation["expected_call_count"] == 2
+    assert evaluation["predicted_call_count"] == 3
+    assert evaluation["call_count_match"] is False
+    assert evaluation["call_ordered_exact_match_rate"] == 0.0
+    assert evaluation["method_exact_match_rate"] == pytest.approx(2 / 3)
+
+
+def test_ordered_call_evaluation_reports_invalid_method_parse_failure() -> None:
+    """Invalid predicted methods become explicit evaluation failures."""
+    context = _context(
+        "/redfish/v1/Systems",
+        ("GET", "HEAD"),
+        {"@odata.id": "/redfish/v1/Systems"},
+    )
+    row = build_ordered_call_row(
+        text="list systems",
+        contexts=(context,),
+        rest_api_list=("/redfish/v1/Systems",),
+    )
+
+    evaluation = evaluate_ordered_calls_y_pred(
+        row,
+        {
+            "calls": [{
+                "rest_api": "/redfish/v1/Systems",
+                "allowed_methods": ["GET", "HEAD"],
+                "method": "PATCH",
+                "arguments": {},
+            }],
+        },
+    )
+
+    assert evaluation["parsed"] is False
+    assert "not in allowed_methods" in evaluation["parse_error"]
+    assert evaluation["arguments_json_parse_rate"] == 0.0
+    assert evaluation["invalid_method_rate"] == 1.0
 
 
 def test_wandb_metric_keys_are_stage_scoped_and_not_m3_names() -> None:

--- a/tests/scripts/test_phase3_argument_smoke.py
+++ b/tests/scripts/test_phase3_argument_smoke.py
@@ -1,0 +1,225 @@
+"""Script tests for the offline Phase 3 argument extraction smoke.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from igc.modules.base.metric_keys import PHASE3_ARGUMENT_EXTRACT, phase_metric
+
+SCRIPT = Path("scripts/build_phase3_argument_smoke.py")
+
+
+def _load_script() -> ModuleType:
+    """Load the script module for direct ``main(argv)`` testing."""
+    spec = importlib.util.spec_from_file_location("build_phase3_argument_smoke", SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _base_args(tmp_path: Path) -> list[str]:
+    """Return common CLI args for fixture tests."""
+    return [
+        "--output-jsonl",
+        str(tmp_path / "out" / "phase3_argument_smoke.jsonl"),
+        "--metrics-out",
+        str(tmp_path / "out" / "metrics.json"),
+    ]
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    """Read all non-blank JSONL rows."""
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _metric(group: str, name: str | None = None) -> str:
+    """Return a Phase 3 argument-extraction metric key."""
+    return phase_metric(PHASE3_ARGUMENT_EXTRACT, group, name)
+
+
+def _exact_prediction_lines(script: ModuleType) -> str:
+    """Return exact fake predictions for the built-in smoke rows."""
+    return "".join(
+        json.dumps({"calls": row["y_true"]["calls"]}, sort_keys=True) + "\n"
+        for row in script.default_phase3_smoke_rows()
+    )
+
+
+def test_cli_mock_mode_writes_rendered_rows_and_metrics(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Mock mode parses exact fake predictions and writes registered smoke metrics."""
+    script = _load_script()
+    output = tmp_path / "out" / "phase3_argument_smoke.jsonl"
+    metrics_path = tmp_path / "out" / "metrics.json"
+
+    code = script.main(_base_args(tmp_path))
+    stdout = capsys.readouterr().out
+
+    assert code == 0
+    assert "dataset=phase3_argument_extractor_smoke" in stdout
+    assert "accepted=2" in stdout
+    assert f"output_jsonl={output}" in stdout
+    rows = _read_jsonl(output)
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert len(rows) == 2
+    assert rows[0]["task"] == "text_and_rest_api_list_to_calls"
+    assert rows[0]["rendered"]["renderer"] == "render_ordered_call_example"
+    assert rows[0]["rendered"]["target_char_start"] == rows[0]["rendered"]["prompt_char_count"]
+    assert json.loads(rows[0]["rendered"]["target_json"]) == rows[0]["y_true"]
+    assert "ordered_goals" in rows[0]["inference"]
+    assert "target_calls" not in rows[0]["inference"]
+    assert rows[0]["inference"]["ordered_goals"] == rows[0]["y_true"]["calls"]
+    patch_call = rows[1]["inference"]["ordered_goals"][0]
+    assert patch_call["method"] == "PATCH"
+    assert patch_call["arguments"] == {"Attributes": {"BootMode": "Uefi"}}
+    assert metrics["dataset"] == "phase3_argument_extractor_smoke"
+    assert metrics[_metric("smoke", "rows_total")] == 2
+    assert metrics[_metric("smoke", "parsed_total")] == 2
+    assert metrics[_metric("smoke", "accepted_total")] == 2
+    assert metrics[_metric("smoke", "weights_role")] == "argument_extractor"
+    assert metrics[_metric("eval", "call_ordered_exact_match_rate")] == 1.0
+    assert metrics[_metric("eval", "method_exact_match_rate")] == 1.0
+    assert metrics[_metric("eval", "arguments_exact_match_rate")] == 1.0
+    assert metrics[_metric("eval", "readonly_empty_arguments_rate")] == 1.0
+    assert metrics["thresholds_pass"] is True
+
+
+def test_cli_file_provider_uses_local_fake_predictions(tmp_path: Path) -> None:
+    """File mode stays offline and accepts local exact-match prediction fixtures."""
+    script = _load_script()
+    predictions = tmp_path / "predictions.jsonl"
+    output = tmp_path / "out" / "phase3_argument_smoke.jsonl"
+    metrics_path = tmp_path / "out" / "metrics.json"
+    predictions.write_text(_exact_prediction_lines(script), encoding="utf-8")
+
+    code = script.main(
+        _base_args(tmp_path)
+        + [
+            "--provider-mode",
+            "file",
+            "--predictions-jsonl",
+            str(predictions),
+        ],
+    )
+
+    assert code == 0
+    rows = _read_jsonl(output)
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert rows[0]["evaluation"]["parsed"] is True
+    assert rows[1]["evaluation"]["call_ordered_exact_match"] is True
+    assert metrics[_metric("smoke", "accepted_total")] == 2
+
+
+def test_cli_extra_predicted_call_fails_ordered_exact_match(tmp_path: Path) -> None:
+    """Extra predicted calls are counted as failures, not hidden by zipped compare."""
+    script = _load_script()
+    rows = script.default_phase3_smoke_rows()
+    extra_calls = list(rows[0]["y_true"]["calls"]) + [rows[0]["y_true"]["calls"][0]]
+    predictions = tmp_path / "predictions.jsonl"
+    predictions.write_text(
+        json.dumps({"calls": extra_calls}, sort_keys=True)
+        + "\n"
+        + json.dumps({"calls": rows[1]["y_true"]["calls"]}, sort_keys=True)
+        + "\n",
+        encoding="utf-8",
+    )
+    metrics_path = tmp_path / "out" / "metrics.json"
+
+    code = script.main(
+        _base_args(tmp_path)
+        + [
+            "--provider-mode",
+            "file",
+            "--predictions-jsonl",
+            str(predictions),
+            "--allow-threshold-failure",
+        ],
+    )
+
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert code == 0
+    assert metrics[_metric("eval", "call_ordered_exact_match_rate")] == 0.5
+    assert metrics[_metric("smoke", "accepted_total")] == 1
+    assert metrics["thresholds_pass"] is False
+
+
+def test_cli_invalid_method_returns_nonzero_after_writing_metrics(tmp_path: Path) -> None:
+    """Invalid fake predictions fail thresholds while still writing inspectable artifacts."""
+    script = _load_script()
+    rows = script.default_phase3_smoke_rows()
+    bad_calls = [dict(call) for call in rows[0]["y_true"]["calls"]]
+    bad_calls[0]["method"] = "PATCH"
+    predictions = tmp_path / "predictions.jsonl"
+    predictions.write_text(
+        json.dumps({"calls": bad_calls}, sort_keys=True)
+        + "\n"
+        + json.dumps({"calls": rows[1]["y_true"]["calls"]}, sort_keys=True)
+        + "\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "out" / "phase3_argument_smoke.jsonl"
+    metrics_path = tmp_path / "out" / "metrics.json"
+
+    code = script.main(
+        _base_args(tmp_path)
+        + [
+            "--provider-mode",
+            "file",
+            "--predictions-jsonl",
+            str(predictions),
+        ],
+    )
+
+    rows_out = _read_jsonl(output)
+    metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert code == 2
+    assert rows_out[0]["evaluation"]["parsed"] is False
+    assert "not in allowed_methods" in rows_out[0]["evaluation"]["parse_error"]
+    assert metrics[_metric("eval", "invalid_method_rate")] == 0.5
+    assert metrics[_metric("smoke", "parsed_total")] == 1
+    assert metrics["thresholds_pass"] is False
+
+
+def test_cli_file_provider_requires_predictions_file(tmp_path: Path) -> None:
+    """File mode must name the local fake prediction JSONL."""
+    script = _load_script()
+
+    with pytest.raises(SystemExit, match="predictions-jsonl"):
+        script.main(_base_args(tmp_path) + ["--provider-mode", "file"])
+
+
+def test_spec_validation_rejects_wrong_weights_role(tmp_path: Path) -> None:
+    """The smoke profile is locked to the argument_extractor role."""
+    script = _load_script()
+    spec_path = tmp_path / "bad.yaml"
+    spec_text = Path("configs/inference/phase3_argument_extractor_smoke.yaml").read_text(
+        encoding="utf-8",
+    )
+    spec_path.write_text(
+        spec_text.replace("weights_role: argument_extractor", "weights_role: model_x"),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(script.Phase3ArgumentSmokeSpecError, match="weights_role"):
+        script.load_phase3_argument_smoke_spec(spec_path)
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
Adds the runnable Phase 3 method/argument smoke surface: phase3_argument_extractor smoke spec plus CLI, stacked on the ordered_goals contract that landed in #119.

Evidence:
- Brain review 48b344eedfc856f7: NO BLOCKING FINDINGS at head d17f8ea
- Remote slot2 CPU-only validation (igc-dev-p3-arg-smoke-runner): git diff --check clean, focused pytest 46 passed, ruff on touched files passed
- Unblocks queue item P3-SMOKE-002