### PR TITLE
Fix sampled HTTP method passed to mock server in REST envs

### DIFF
--- a/igc/envs/rest_gym_base.py
+++ b/igc/envs/rest_gym_base.py
@@ -114,7 +114,9 @@ class RestApiBaseEnv(gym.Env):
         Sampling from action space.
         :return: Tuple containing random observation and method
         """
-        rest_api, supported_method, supported_method = self._discovered_rest_api.sample_rest_api()
+        rest_api, supported_method, _action_one_hot = (
+            self._discovered_rest_api.sample_rest_api()
+        )
         response = self._mock_rest.request(rest_api, supported_method)
         if 200 <= response.status_code <= 300:
             observation = response.json()

--- a/igc/envs/rest_gym_batch_env.py
+++ b/igc/envs/rest_gym_batch_env.py
@@ -142,7 +142,9 @@ class VectorizedRestApiEnv(VectorEnv, RestApiBaseEnv):
         Sampling from action space.
         :return: Tuple containing random observation and method
         """
-        rest_api, supported_method, supported_method = self._discovered_rest_api.sample_rest_api()
+        rest_api, supported_method, _action_one_hot = (
+            self._discovered_rest_api.sample_rest_api()
+        )
         response = self._mock_rest.request(rest_api, supported_method)
         if 200 <= response.status_code <= 300:
             observation = response.json()

--- a/igc/envs/rest_gym_env.py
+++ b/igc/envs/rest_gym_env.py
@@ -116,7 +116,9 @@ class RestApiEnv(gym.Env):
         Sampling from action space.
         :return: Tuple containing random observation and method
         """
-        rest_api, supported_method, supported_method = self._discovered_rest_api.sample_rest_api()
+        rest_api, supported_method, _action_one_hot = (
+            self._discovered_rest_api.sample_rest_api()
+        )
         response = self._mock_rest.request(rest_api, supported_method)
         if 200 <= response.status_code <= 300:
             observation = response.json()

--- a/tests/envs/test_rest_gym_batch_env_boundary.py
+++ b/tests/envs/test_rest_gym_batch_env_boundary.py
@@ -75,6 +75,9 @@ class TinyRestMapping(RestMappingInterface):
         action[self._uris.index(rest_api)] = 1.0
         return action
 
+    def sample_rest_api(self) -> tuple[str, str, torch.Tensor]:
+        return SYSTEM_URI, HttpMethod.GET.value, self.action_for(SYSTEM_URI)
+
 
 @pytest.fixture
 def vector_env(tmp_path: Path) -> VectorizedRestApiEnv:
@@ -118,6 +121,16 @@ def test_vector_reset_and_step_preserve_batch_axes(vector_env: VectorizedRestApi
     assert terminated.shape == (2,)
     assert truncated.shape == (2,)
     assert len(infos) == 2
+
+
+def test_vector_sample_observation_uses_sampled_http_method(
+    vector_env: VectorizedRestApiEnv,
+):
+    """Vector sample_observation passes the method string, not one-hot action."""
+    observation = vector_env.sample_observation()
+
+    expected = vector_env.encoder.encode(json.dumps({"@odata.id": SYSTEM_URI}))
+    assert torch.equal(observation, expected)
 
 
 def test_vector_step_limit_sets_truncated_not_terminal(vector_env: VectorizedRestApiEnv):

--- a/tests/envs/test_rest_gym_env_reset_step.py
+++ b/tests/envs/test_rest_gym_env_reset_step.py
@@ -11,8 +11,10 @@ from pathlib import Path
 
 import pytest
 
+import igc.envs.rest_gym_base as rest_gym_base
 import igc.envs.rest_gym_env as rest_gym_env
 import torch
+from igc.envs.rest_gym_base import RestApiBaseEnv
 from igc.envs.rest_gym_env import GoalTypeState, RestApiEnv
 from igc.envs.rest_mock_server import MockServer
 from igc.interfaces.rest_mapping_interface import RestMappingInterface
@@ -85,6 +87,9 @@ class TinyRestMapping(RestMappingInterface):
         action[self._uris.index(rest_api)] = 1.0
         return action
 
+    def sample_rest_api(self) -> tuple[str, str, torch.Tensor]:
+        return SYSTEM_URI, "GET", self.action_for(SYSTEM_URI)
+
 
 @pytest.fixture
 def rest_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> RestApiEnv:
@@ -145,6 +150,40 @@ def test_step_get_known_resource_returns_success_observation(rest_env: RestApiEn
     assert rest_env.step_count == 1
     assert torch.equal(observation, rest_env.encoder.encode(json.dumps(SYSTEM_PAYLOAD)))
     assert torch.equal(rest_env.last_observation, observation)
+
+
+def test_sample_observation_uses_sampled_http_method(rest_env: RestApiEnv):
+    """sample_observation passes the sampled method, not the one-hot tensor."""
+    observation = rest_env.sample_observation()
+
+    system_json = json.dumps(SYSTEM_PAYLOAD)
+    assert torch.equal(observation, rest_env.encoder.encode(system_json))
+    assert system_json in rest_env.encoder.calls
+
+
+def test_base_sample_observation_uses_sampled_http_method(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The base env keeps the sampled method separate from the action vector."""
+    system_path = tmp_path / "system.json"
+    system_path.write_text(json.dumps(SYSTEM_PAYLOAD), encoding="utf-8")
+    mapping = TinyRestMapping({SYSTEM_URI: system_path})
+    monkeypatch.setattr(rest_gym_base, "RestBaseEncoder", StubEncoder)
+
+    env = RestApiBaseEnv(
+        args=argparse.Namespace(raw_data_dir=str(tmp_path)),
+        model=None,
+        tokenizer=None,
+        discovered_rest_api=mapping,
+        max_episode=5,
+    )
+
+    observation = env.sample_observation()
+
+    system_json = json.dumps(SYSTEM_PAYLOAD)
+    assert torch.equal(observation, env.encoder.encode(system_json))
+    assert system_json in env.encoder.calls
 
 
 def test_step_http_500_returns_terminal_error_observation(rest_env: RestApiEnv):


### PR DESCRIPTION
sample_observation() in all three REST gym env implementations unpacked the sampled action so the one-hot action tensor was passed to MockServer.request() as the HTTP method. Keeps the sampled one-hot separate from the sampled method string before the request call.

- igc/envs/rest_gym_env.py, rest_gym_base.py, rest_gym_batch_env.py: pass the method, not the tensor
- tests/envs/test_rest_gym_env_reset_step.py, test_rest_gym_batch_env_boundary.py: regressions pinning the method argument

Prior validation (board): focused pytest 11 passed, 1 xfailed; touched-file ruff passed. Gate for merge: GitHub CI on this PR.