### PR TITLE
Block empty-fleet dashboard summaries in NV72 launch preflight

### DIFF
--- a/igc/shared/nv72_preflight.py
+++ b/igc/shared/nv72_preflight.py
@@ -19,6 +19,22 @@ import sys
 from typing import List, Optional, Tuple
 
 
+def _required_int_count(
+        section: dict,
+        key: str,
+        *,
+        context: str,
+        reasons: List[str],
+        min_value: int = 0,
+) -> Optional[int]:
+    """Read a dashboard count field, rejecting missing or nonsensical values."""
+    value = section.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value < min_value:
+        reasons.append(f"{context} has invalid {key}: {value!r}")
+        return None
+    return value
+
+
 def evaluate_state(
         state: dict,
         require_endpoint: Optional[str] = None,
@@ -36,16 +52,24 @@ def evaluate_state(
     roce = summaries.get("roce") or {}
     if not roce:
         reasons.append("state has no summaries.roce section (dashboard degraded?)")
-    elif roce.get("rdma_active") != roce.get("nodes"):
-        reasons.append(
-            f"RoCE degraded: rdma_active {roce.get('rdma_active')}/{roce.get('nodes')}")
+    else:
+        nodes = _required_int_count(
+            roce, "nodes", context="summaries.roce", reasons=reasons, min_value=1)
+        rdma_active = _required_int_count(
+            roce, "rdma_active", context="summaries.roce", reasons=reasons)
+        if nodes is not None and rdma_active is not None and rdma_active != nodes:
+            reasons.append(f"RoCE degraded: rdma_active {rdma_active}/{nodes}")
 
     mount = summaries.get("models_mount") or {}
     if not mount:
         reasons.append("state has no summaries.models_mount section")
-    elif mount.get("mounted") != mount.get("nodes"):
-        reasons.append(
-            f"/models mount degraded: mounted {mount.get('mounted')}/{mount.get('nodes')}")
+    else:
+        nodes = _required_int_count(
+            mount, "nodes", context="summaries.models_mount", reasons=reasons, min_value=1)
+        mounted = _required_int_count(
+            mount, "mounted", context="summaries.models_mount", reasons=reasons)
+        if nodes is not None and mounted is not None and mounted != nodes:
+            reasons.append(f"/models mount degraded: mounted {mounted}/{nodes}")
 
     if require_endpoint is not None:
         endpoints = (state.get("model_endpoints") or {}).get(require_endpoint) or []

--- a/tests/shared/test_nv72_preflight.py
+++ b/tests/shared/test_nv72_preflight.py
@@ -73,4 +73,30 @@ def test_empty_state_blocks_on_missing_sections():
     assert len(reasons) == 2  # roce + models_mount sections missing
 
 
+def test_zero_node_summaries_block():
+    """Equal zero counts are not a healthy fleet."""
+    ok, reasons = evaluate_state({
+        "summaries": {
+            "roce": {"rdma_active": 0, "nodes": 0},
+            "models_mount": {"mounted": 0, "nodes": 0},
+        }
+    })
+    assert not ok
+    assert any("summaries.roce" in reason and "nodes" in reason for reason in reasons)
+    assert any("summaries.models_mount" in reason and "nodes" in reason for reason in reasons)
+
+
+def test_malformed_summary_counts_block():
+    """Dashboard count fields must be real integer counts."""
+    ok, reasons = evaluate_state({
+        "summaries": {
+            "roce": {"rdma_active": "18", "nodes": 18},
+            "models_mount": {"mounted": True, "nodes": 18},
+        }
+    })
+    assert not ok
+    assert any("rdma_active" in reason for reason in reasons)
+    assert any("mounted" in reason for reason in reasons)
+
+
 # Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
Dashboard summaries with zero nodes (rdma_active=0,nodes=0; mounted=0,nodes=0) passed the GB300 launch preflight because equal counts compared healthy. Validates the summary count fields before comparing health totals, so empty zero-node fleets and malformed count fields block launch instead of passing.

- igc/shared/nv72_preflight.py: count-field validation before health comparison
- tests/shared/test_nv72_preflight.py: zero-node and malformed-count regressions

Prior validation (board): focused pytest 8 passed; touched-file ruff passed. Gate for merge: GitHub CI on this PR.