### PR TITLE
Make bench_hot_paths.py runnable by direct file path

### DIFF
--- a/scripts/bench_hot_paths.py
+++ b/scripts/bench_hot_paths.py
@@ -19,13 +19,21 @@ Mus mbayramo@stanford.edu
 """
 from __future__ import annotations
 
+# ruff: noqa: E402
+
 import argparse
 import cProfile
 import io
 import json
 import pstats
+import sys
 import time
+from pathlib import Path
 from typing import Callable, Dict, List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from igc.ds.sources import RedfishFixtureSource, TrustLevel
 from igc.ds.sources.candidate_features import build_candidate_cache

--- a/tests/scripts/test_bench_hot_paths_cli.py
+++ b/tests/scripts/test_bench_hot_paths_cli.py
@@ -1,0 +1,33 @@
+"""CLI smoke tests for ``scripts/bench_hot_paths.py``.
+
+The benchmark is documented as a file-path command, so it must be runnable from
+the repository root without relying on an installed package or manual
+``PYTHONPATH``.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "bench_hot_paths.py"
+
+
+def test_bench_hot_paths_help_runs_from_repo_root() -> None:
+    """Path-based invocation reaches argparse instead of failing on imports."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--help"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "--section" in result.stdout


### PR DESCRIPTION
Running scripts/bench_hot_paths.py by file path failed on igc imports before argparse was reached. Adds repo-root bootstrapping to the script and a subprocess CLI regression proving path-based --help reaches argparse.

- scripts/bench_hot_paths.py: repo-root sys.path bootstrap
- tests/scripts/test_bench_hot_paths_cli.py: subprocess --help regression

Prior validation (board): focused pytest 1 passed; ruff passed; direct `python scripts/bench_hot_paths.py --section rl` and `--section rl --profile` both exit 0 with benchmark rows. Gate for merge: GitHub CI on this PR.