### PR TITLE
Fail Phase 1 run when report.json emission fails

### DIFF
--- a/igc/modules/llm_train_state_encoder.py
+++ b/igc/modules/llm_train_state_encoder.py
@@ -179,6 +179,64 @@ def validation_loss(value: Union[ValidationMetrics, float]) -> float:
     return float("inf")
 
 
+def emit_final_run_report(
+        *,
+        trainer_args,
+        dataset,
+        final_epoch_loss,
+        epochs_done: int,
+        optimizer_steps: int,
+        best_eval: float,
+        validation_result: Union[ValidationMetrics, float],
+        started_at: str,
+        ended_at: str,
+        wall_clock_sec: float,
+        checkpoint_path: str,
+        output_dir: str) -> str:
+    """Build and write the final training ``report.json``.
+
+    Report emission is part of the Phase 1 acceptance evidence, so construction
+    or write failures propagate to the caller instead of being downgraded to a
+    warning.
+
+    :param trainer_args: Parsed training args used to populate the manifest.
+    :param dataset: Dataset object, optionally exposing ``run_manifest_fields``.
+    :param final_epoch_loss: Last epoch average loss, or ``None`` if no epoch ran.
+    :param epochs_done: Number of completed epochs.
+    :param optimizer_steps: Number of optimizer steps taken in this run.
+    :param best_eval: Best validation metric observed by the trainer.
+    :param validation_result: Last validation result used for report metrics.
+    :param started_at: ISO-like run start timestamp.
+    :param ended_at: ISO-like run end timestamp.
+    :param wall_clock_sec: Run duration in seconds.
+    :param checkpoint_path: Final checkpoint path recorded in the manifest.
+    :param output_dir: Directory where ``report.json`` is written.
+    :return: Path to the written report.
+    """
+    from igc.modules.train.emit import build_run_bundle, emit_run_report
+
+    manifest_fields = getattr(dataset, "run_manifest_fields", None)
+    bundle = build_run_bundle(
+        vars(trainer_args),
+        training={
+            "final_epoch_loss": final_epoch_loss,
+            "epochs_done": epochs_done,
+            "optimizer_steps": optimizer_steps,
+            "best_eval": best_eval,
+        },
+        metrics={
+            "eval/accuracy": validation_accuracy(validation_result),
+            "eval/loss": validation_loss(validation_result),
+        },
+        dataset_fields=manifest_fields() if callable(manifest_fields) else None,
+        started_at=started_at,
+        ended_at=ended_at,
+        wall_clock_sec=wall_clock_sec,
+        checkpoint_path=checkpoint_path,
+    )
+    return emit_run_report(bundle, output_dir)
+
+
 def resolve_early_stopping(spec) -> Tuple[int, float]:
     """Resolve the early-stopping knobs from the run spec.
 
@@ -1056,34 +1114,24 @@ class LlmEmbeddingsTrainer(LlmModule):
         self._save_final_checkpoint()
 
         # Emit the self-describing run report (report.json) next to the checkpoint so
-        # every run is comparable through igc.modules.train.report.compare(). Emission
-        # must never take down a finished training run, hence the broad guard.
+        # every run is comparable through igc.modules.train.report.compare(). Report
+        # emission is a hard Phase 1 evidence gate: failures propagate.
         if self.is_rank_zero():
-            try:
-                from igc.modules.train.emit import build_run_bundle, emit_run_report
-                manifest_fields = getattr(self.dataset, "run_manifest_fields", None)
-                bundle = build_run_bundle(
-                    vars(self._trainer_args),
-                    training={
-                        "final_epoch_loss": final_epoch_loss,
-                        "epochs_done": epochs_done,
-                        "optimizer_steps": global_opt_steps,
-                        "best_eval": self._best_validation_metric,
-                    },
-                    metrics={
-                        "eval/accuracy": validation_accuracy(validation_result),
-                        "eval/loss": validation_loss(validation_result),
-                    },
-                    dataset_fields=manifest_fields() if callable(manifest_fields) else None,
-                    started_at=run_started_at,
-                    ended_at=time.strftime("%Y-%m-%dT%H:%M:%S"),
-                    wall_clock_sec=round(time.time() - run_started_clock, 1),
-                    checkpoint_path=str(self._module_checkpoint_dir or ""),
-                )
-                report_path = emit_run_report(bundle, str(self._module_checkpoint_dir or "."))
-                self.logger.info(f"Run report written: {report_path}")
-            except Exception as report_err:  # noqa: BLE001 — report loss < run loss
-                self.logger.warning(f"run-report emission failed: {report_err}")
+            report_path = emit_final_run_report(
+                trainer_args=self._trainer_args,
+                dataset=self.dataset,
+                final_epoch_loss=final_epoch_loss,
+                epochs_done=epochs_done,
+                optimizer_steps=global_opt_steps,
+                best_eval=self._best_validation_metric,
+                validation_result=validation_result,
+                started_at=run_started_at,
+                ended_at=time.strftime("%Y-%m-%dT%H:%M:%S"),
+                wall_clock_sec=round(time.time() - run_started_clock, 1),
+                checkpoint_path=str(self._module_checkpoint_dir or ""),
+                output_dir=str(self._module_checkpoint_dir or "."),
+            )
+            self.logger.info(f"Run report written: {report_path}")
 
         del train_dataloader
         del eval_dataloader

--- a/igc/modules/train/emit.py
+++ b/igc/modules/train/emit.py
@@ -2,9 +2,8 @@
 Run-report emission: turn a finished training run into a ResultBundle on disk.
 
 Called only from ``LlmEmbeddingsTrainer._train`` (``igc/modules/llm_train_state_encoder.py``)
-at end of run, on rank zero, inside a broad try/except so a report failure only warns and
-never fails a finished training run. It exists so every run leaves a machine-readable
-``report.json`` for the comparison tooling.
+at end of run, on rank zero. Report failures propagate because the Phase 1 acceptance
+gate requires a machine-readable ``report.json`` for the comparison tooling.
 
 The trainer calls :func:`build_run_bundle` with its parsed spec and end-of-run stats,
 then :func:`emit_run_report` writes ``report.json`` into the run's output directory —

--- a/tests/modules/test_llm_train_state_encoder_report.py
+++ b/tests/modules/test_llm_train_state_encoder_report.py
@@ -1,0 +1,77 @@
+"""Offline regression tests for LLM trainer report emission."""
+
+from argparse import Namespace
+import json
+
+import pytest
+
+from igc.modules.llm_train_state_encoder import ValidationMetrics, emit_final_run_report
+
+
+class _DatasetWithManifest:
+    """Tiny dataset double that exposes the trainer's report-manifest hook."""
+
+    @staticmethod
+    def run_manifest_fields():
+        return {"data_manifest": "fixture-manifest", "eval_split": "fixture-heldout"}
+
+
+def _trainer_args() -> Namespace:
+    return Namespace(
+        model_type="fixture-model",
+        profile="phase1_fixture",
+        use_peft=False,
+        max_train_steps=1,
+        seq_len=128,
+    )
+
+
+def test_final_report_emission_propagates_write_failure(monkeypatch, tmp_path):
+    """A report write error is a hard failure, not a rank-zero warning."""
+    import igc.modules.train.emit as emit
+
+    def fail_emit(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(emit, "emit_run_report", fail_emit)
+
+    with pytest.raises(OSError, match="disk full"):
+        emit_final_run_report(
+            trainer_args=_trainer_args(),
+            dataset=_DatasetWithManifest(),
+            final_epoch_loss=1.25,
+            epochs_done=1,
+            optimizer_steps=1,
+            best_eval=0.5,
+            validation_result=ValidationMetrics(loss=0.25, accuracy=97.5),
+            started_at="2026-07-16T01:36:00",
+            ended_at="2026-07-16T01:37:00",
+            wall_clock_sec=60.0,
+            checkpoint_path=str(tmp_path),
+            output_dir=str(tmp_path),
+        )
+
+
+def test_final_report_emission_preserves_accuracy_and_loss_metrics(tmp_path):
+    """The hard-fail helper keeps the current Phase 1 report metric keys."""
+    report_path = emit_final_run_report(
+        trainer_args=_trainer_args(),
+        dataset=_DatasetWithManifest(),
+        final_epoch_loss=1.25,
+        epochs_done=1,
+        optimizer_steps=2,
+        best_eval=0.25,
+        validation_result=ValidationMetrics(loss=0.25, accuracy=97.5),
+        started_at="2026-07-16T01:36:00",
+        ended_at="2026-07-16T01:37:00",
+        wall_clock_sec=60.0,
+        checkpoint_path=str(tmp_path),
+        output_dir=str(tmp_path),
+    )
+
+    report = json.loads((tmp_path / "report.json").read_text(encoding="utf-8"))
+    assert report_path == str(tmp_path / "report.json")
+    assert report["metrics"]["eval/accuracy"] == 97.5
+    assert report["metrics"]["eval/loss"] == 0.25
+    assert report["manifest"]["data_manifest"] == "fixture-manifest"
+    assert report["manifest"]["eval_split"] == "fixture-heldout"


### PR DESCRIPTION
The trainer caught every final report-emission exception and downgraded it to a warning, even though Phase 1 acceptance requires a machine-readable report.json. Extracts report construction/write into a focused helper called directly on rank zero so emission failures fail the run, preserving the current eval/accuracy and eval/loss report metrics.

- igc/modules/llm_train_state_encoder.py: report emission helper, hard-fail on rank zero
- igc/modules/train/emit.py: emission error no longer swallowed
- tests/modules/test_llm_train_state_encoder_report.py: hard-fail + metrics-preserved regressions

Prior validation (board): focused pytest 2 passed; touched-file ruff passed. Merges cleanly onto current main (checked with merge-tree). Gate for merge: GitHub CI on this PR.