### PR TITLE
Require matching row keys in Phase 1 golden comparisons

### DIFF
--- a/igc/modules/train/phase1_golden.py
+++ b/igc/modules/train/phase1_golden.py
@@ -82,6 +82,7 @@ class ArtifactMetrics:
     top_k_rows: int
     total_generated_tokens: int
     total_latency_sec: float
+    row_keys: tuple[str, ...]
     sequence_lengths: list[int] = field(default_factory=list)
     padding_ratios: list[float] = field(default_factory=list)
     latencies_sec: list[float] = field(default_factory=list)
@@ -270,6 +271,7 @@ def evaluate_prediction_jsonl(
     """Evaluate one Phase 1 prediction JSONL artifact."""
     raw_rows = load_prediction_rows(path)
     records = [normalize_prediction_row(row, index) for index, row in enumerate(raw_rows)]
+    _validate_unique_row_keys(records, role=role)
     metrics = _metrics_from_records(
         role=role,
         records=records,
@@ -301,6 +303,7 @@ def _metrics_from_records(
         top_k_rows=sum(1 for record in records if record.top_k_match is not None),
         total_generated_tokens=sum(record.generated_tokens or 0 for record in records),
         total_latency_sec=sum(record.latency_sec or 0.0 for record in records),
+        row_keys=tuple(record.key for record in records),
     )
     metrics.latencies_sec.extend(
         record.latency_sec for record in records if record.latency_sec is not None
@@ -365,6 +368,7 @@ def compare_prediction_artifacts(
     ece_bins: int = 10,
 ) -> dict[str, Any]:
     """Compare baseline and ``model_x`` metrics."""
+    _validate_comparable_artifact_keys(baseline, model)
     baseline_metrics = baseline.to_metric_dict(ece_bins=ece_bins)
     model_metrics = model.to_metric_dict(ece_bins=ece_bins)
     delta: dict[str, float | None] = {}
@@ -380,6 +384,39 @@ def compare_prediction_artifacts(
         "row_count_delta": model.row_count - baseline.row_count,
         "delta": delta,
     }
+
+
+def _validate_unique_row_keys(records: Iterable[PredictionRecord], *, role: str) -> None:
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for record in records:
+        if record.key in seen:
+            duplicates.add(record.key)
+        seen.add(record.key)
+    if duplicates:
+        preview = ", ".join(sorted(str(key) for key in duplicates)[:5])
+        raise Phase1GoldenError(f"{role}: duplicate prediction row keys: {preview}")
+
+
+def _validate_comparable_artifact_keys(
+    baseline: ArtifactMetrics,
+    model: ArtifactMetrics,
+) -> None:
+    baseline_keys = set(baseline.row_keys)
+    model_keys = set(model.row_keys)
+    missing_from_model = sorted(baseline_keys - model_keys)
+    missing_from_baseline = sorted(model_keys - baseline_keys)
+    if not missing_from_model and not missing_from_baseline:
+        return
+    details = []
+    if missing_from_model:
+        details.append("missing from model_x: " + ", ".join(missing_from_model[:5]))
+    if missing_from_baseline:
+        details.append("missing from baseline: " + ", ".join(missing_from_baseline[:5]))
+    raise Phase1GoldenError(
+        "baseline and model_x prediction artifacts cover different row keys; "
+        + "; ".join(details)
+    )
 
 
 def build_phase1_golden_payload(

--- a/igc/modules/train/phase1_golden.py
+++ b/igc/modules/train/phase1_golden.py
@@ -2,7 +2,8 @@
 
 This module consumes already-produced Phase 1 prediction JSONL artifacts. It
 does not load a model, touch a GPU, call W&B, or read corpora. Rows are matched
-by an explicit row id when present, otherwise by JSONL position.
+by an explicit row id when present, otherwise by JSONL position plus a stable
+fingerprint of non-prediction row identity.
 
 Author:
 Mus mbayramo@stanford.edu
@@ -394,8 +395,9 @@ def _validate_unique_row_keys(records: Iterable[PredictionRecord], *, role: str)
             duplicates.add(record.key)
         seen.add(record.key)
     if duplicates:
-        preview = ", ".join(sorted(str(key) for key in duplicates)[:5])
-        raise Phase1GoldenError(f"{role}: duplicate prediction row keys: {preview}")
+        raise Phase1GoldenError(
+            f"{role}: duplicate prediction row keys ({len(duplicates)} duplicate keys)"
+        )
 
 
 def _validate_comparable_artifact_keys(
@@ -410,9 +412,9 @@ def _validate_comparable_artifact_keys(
         return
     details = []
     if missing_from_model:
-        details.append("missing from model_x: " + ", ".join(missing_from_model[:5]))
+        details.append(f"missing from model_x: {len(missing_from_model)}")
     if missing_from_baseline:
-        details.append("missing from baseline: " + ", ".join(missing_from_baseline[:5]))
+        details.append(f"missing from baseline: {len(missing_from_baseline)}")
     raise Phase1GoldenError(
         "baseline and model_x prediction artifacts cover different row keys; "
         + "; ".join(details)
@@ -603,7 +605,20 @@ def _row_key(row: Mapping[str, Any], index: int) -> str:
         row,
         (("id",), ("row_id",), ("sample_id",), ("example_id",), ("uid",)),
     )
-    return str(value) if value is not None else str(index)
+    if value is not None:
+        return f"id:{value}"
+    target = _target_json(row)
+    rest_api = _rest_api(row, target)
+    identity = {
+        "rest_api": rest_api,
+        "target_json": target,
+    }
+    fingerprint = hashlib.sha256(
+        json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str).encode(
+            "utf-8"
+        )
+    ).hexdigest()[:16]
+    return f"position:{index}:identity:{fingerprint}"
 
 
 def _odata_id_match(prediction: JsonValue | None, rest_api: str) -> bool | None:

--- a/scripts/validate_phase1_golden_row_guard.sh
+++ b/scripts/validate_phase1_golden_row_guard.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Focused CPU-only validation for Phase 1 golden row-key guard changes.
+set -euo pipefail
+
+if conda env list | awk '{print $1}' | grep -qx 'igc-dev'; then
+    py=(conda run -n igc-dev python)
+    lint=(conda run -n igc-dev ruff)
+else
+    py=(python)
+    if command -v ruff >/dev/null 2>&1; then
+        lint=(ruff)
+    elif command -v uv >/dev/null 2>&1; then
+        lint=(uvx ruff)
+    else
+        echo "BLOCKED: ruff is unavailable in this validation container" >&2
+        exit 2
+    fi
+fi
+
+env \
+    PYTHONFAULTHANDLER=1 \
+    KMP_DUPLICATE_LIB_OK=TRUE \
+    OMP_NUM_THREADS=1 \
+    TRANSFORMERS_OFFLINE=1 \
+    HF_DATASETS_OFFLINE=1 \
+    "${py[@]}" -m pytest -q \
+    tests/modules/train/test_phase1_golden.py \
+    tests/scripts/test_phase1_inference_gate.py \
+    -rA
+
+"${lint[@]}" check \
+    igc/modules/train/phase1_golden.py \
+    tests/modules/train/test_phase1_golden.py \
+    scripts/phase1_inference_gate.py \
+    tests/scripts/test_phase1_inference_gate.py

--- a/tests/modules/train/test_phase1_golden.py
+++ b/tests/modules/train/test_phase1_golden.py
@@ -137,8 +137,11 @@ def test_phase1_golden_rejects_mismatched_artifact_row_keys(tmp_path: Path) -> N
         ],
     )
 
-    with pytest.raises(Phase1GoldenError, match="different row keys"):
+    with pytest.raises(Phase1GoldenError, match="different row keys") as excinfo:
         build_phase1_golden_payload(baseline_jsonl=baseline, model_jsonl=model)
+
+    assert "baseline-only" not in str(excinfo.value)
+    assert "model-only" not in str(excinfo.value)
 
 
 def test_phase1_golden_row_keys_do_not_expand_public_payload(tmp_path: Path) -> None:
@@ -175,13 +178,55 @@ def test_phase1_golden_rejects_duplicate_row_keys(tmp_path: Path) -> None:
     path = _write_jsonl(
         tmp_path / "duplicates.jsonl",
         [
-            _row(rest_api, _target(rest_api, "1"), id="duplicate"),
-            _row(rest_api, _target(rest_api, "1"), id="duplicate"),
+            _row(rest_api, _target(rest_api, "1"), id="raw-row-id"),
+            _row(rest_api, _target(rest_api, "1"), id="raw-row-id"),
         ],
     )
 
-    with pytest.raises(Phase1GoldenError, match="duplicate prediction row keys"):
+    with pytest.raises(Phase1GoldenError, match="duplicate prediction row keys") as excinfo:
         evaluate_prediction_jsonl(path, role="model_x")
+
+    assert "raw-row-id" not in str(excinfo.value)
+
+
+def test_phase1_golden_rejects_reordered_positional_rows(tmp_path: Path) -> None:
+    """Rows without explicit ids must still describe the same positional examples."""
+    rest_a = "/redfish/v1/Systems/1"
+    rest_b = "/redfish/v1/Systems/2"
+    baseline = _write_jsonl(
+        tmp_path / "baseline.jsonl",
+        [
+            _row(rest_a, _target(rest_a, "1")),
+            _row(rest_b, _target(rest_b, "2")),
+        ],
+    )
+    model = _write_jsonl(
+        tmp_path / "model_x.jsonl",
+        [
+            _row(rest_b, _target(rest_b, "2")),
+            _row(rest_a, _target(rest_a, "1")),
+        ],
+    )
+
+    with pytest.raises(Phase1GoldenError, match="different row keys"):
+        build_phase1_golden_payload(baseline_jsonl=baseline, model_jsonl=model)
+
+
+def test_phase1_golden_rejects_mixed_explicit_and_positional_keys(tmp_path: Path) -> None:
+    """An explicit-id artifact cannot be compared against positional rows."""
+    rest_api = "/redfish/v1/Systems/1"
+    target = _target(rest_api, "1")
+    baseline = _write_jsonl(
+        tmp_path / "baseline.jsonl",
+        [_row(rest_api, target, id="row-a")],
+    )
+    model = _write_jsonl(
+        tmp_path / "model_x.jsonl",
+        [_row(rest_api, target)],
+    )
+
+    with pytest.raises(Phase1GoldenError, match="different row keys"):
+        build_phase1_golden_payload(baseline_jsonl=baseline, model_jsonl=model)
 
 
 def test_prediction_parser_accepts_fenced_json_fragment() -> None:

--- a/tests/modules/train/test_phase1_golden.py
+++ b/tests/modules/train/test_phase1_golden.py
@@ -196,15 +196,31 @@ def test_phase1_golden_rejects_reordered_positional_rows(tmp_path: Path) -> None
     baseline = _write_jsonl(
         tmp_path / "baseline.jsonl",
         [
-            _row(rest_a, _target(rest_a, "1")),
-            _row(rest_b, _target(rest_b, "2")),
+            {
+                "x": {"rest_api": rest_a, "json": _target(rest_a, "1")},
+                "y_true": {"json": _target(rest_a, "1")},
+                "y_pred": {"json": _target(rest_a, "1")},
+            },
+            {
+                "x": {"rest_api": rest_b, "json": _target(rest_b, "2")},
+                "y_true": {"json": _target(rest_b, "2")},
+                "y_pred": {"json": _target(rest_b, "2")},
+            },
         ],
     )
     model = _write_jsonl(
         tmp_path / "model_x.jsonl",
         [
-            _row(rest_b, _target(rest_b, "2")),
-            _row(rest_a, _target(rest_a, "1")),
+            {
+                "x": {"rest_api": rest_b, "json": _target(rest_b, "2")},
+                "y_true": {"json": _target(rest_b, "2")},
+                "y_pred": {"json": _target(rest_b, "2")},
+            },
+            {
+                "x": {"rest_api": rest_a, "json": _target(rest_a, "1")},
+                "y_true": {"json": _target(rest_a, "1")},
+                "y_pred": {"json": _target(rest_a, "1")},
+            },
         ],
     )
 

--- a/tests/modules/train/test_phase1_golden.py
+++ b/tests/modules/train/test_phase1_golden.py
@@ -110,6 +110,80 @@ def test_build_phase1_golden_payload_compares_baseline_and_model(tmp_path: Path)
     assert "sha256" in payload["evidence"]["model_x"]["artifact"]
 
 
+def test_phase1_golden_rejects_mismatched_artifact_row_keys(tmp_path: Path) -> None:
+    """Baseline/model_x deltas fail closed when row ids do not describe the same rows."""
+    rest_api = "/redfish/v1/Systems/1"
+    target = _target(rest_api, "1")
+    baseline = _write_jsonl(
+        tmp_path / "baseline.jsonl",
+        [
+            {
+                "id": "baseline-only",
+                "x": {"rest_api": rest_api, "json": target},
+                "y_true": {"json": target},
+                "y_pred": {"json": {"@odata.id": rest_api, "Name": "Wrong"}},
+            }
+        ],
+    )
+    model = _write_jsonl(
+        tmp_path / "model_x.jsonl",
+        [
+            {
+                "id": "model-only",
+                "x": {"rest_api": rest_api, "json": target},
+                "y_true": {"json": target},
+                "y_pred": {"json": target},
+            }
+        ],
+    )
+
+    with pytest.raises(Phase1GoldenError, match="different row keys"):
+        build_phase1_golden_payload(baseline_jsonl=baseline, model_jsonl=model)
+
+
+def test_phase1_golden_row_keys_do_not_expand_public_payload(tmp_path: Path) -> None:
+    """Row-key bookkeeping is internal and not part of metric/evidence JSON."""
+    rest_a = "/redfish/v1/Systems/1"
+    rest_b = "/redfish/v1/Systems/2"
+    baseline = _write_jsonl(
+        tmp_path / "baseline.jsonl",
+        [
+            _row(rest_a, _target(rest_a, "1"), id="row-a"),
+            _row(rest_b, _target(rest_b, "2"), id="row-b"),
+        ],
+    )
+    model = _write_jsonl(
+        tmp_path / "model_x.jsonl",
+        [
+            _row(rest_b, _target(rest_b, "2"), id="row-b"),
+            _row(rest_a, _target(rest_a, "1"), id="row-a"),
+        ],
+    )
+
+    payload = build_phase1_golden_payload(baseline_jsonl=baseline, model_jsonl=model)
+    rendered = json.dumps(payload)
+
+    assert "row_keys" not in rendered
+    assert "row-a" not in rendered
+    assert "row-b" not in rendered
+    assert payload["comparison"]["row_count_delta"] == 0
+
+
+def test_phase1_golden_rejects_duplicate_row_keys(tmp_path: Path) -> None:
+    """Duplicate explicit ids are ambiguous and cannot feed acceptance evidence."""
+    rest_api = "/redfish/v1/Systems/1"
+    path = _write_jsonl(
+        tmp_path / "duplicates.jsonl",
+        [
+            _row(rest_api, _target(rest_api, "1"), id="duplicate"),
+            _row(rest_api, _target(rest_api, "1"), id="duplicate"),
+        ],
+    )
+
+    with pytest.raises(Phase1GoldenError, match="duplicate prediction row keys"):
+        evaluate_prediction_jsonl(path, role="model_x")
+
+
 def test_prediction_parser_accepts_fenced_json_fragment() -> None:
     """Model outputs wrapped in text still parse when they contain one JSON object."""
     parsed, ok, error = parse_json_value('prefix ```json\n{"a": 1}\n``` suffix')


### PR DESCRIPTION
The Phase 1 golden acceptance helper compared baseline and model_x prediction artifacts without requiring both sides to cover the same explicit row keys, so mismatched or partially-overlapping artifacts could still produce comparison deltas. Hardens the row matching so both artifacts must cover identical row keys before deltas are trusted, and adds a regression proving row keys do not leak into public payload JSON.

- igc/modules/train/phase1_golden.py: explicit row-key coverage check
- scripts/validate_phase1_golden_row_guard.sh: focused validation wrapper
- tests/modules/train/test_phase1_golden.py: row-key mismatch + serialization regressions

Prior validation (board): remote slot2 CPU-only container ran the wrapper — 14 passed, ruff all checks passed. Gate for merge: GitHub CI on this PR.