### PR TITLE
Rename Phase 3 inference handoff helper to inference_ordered_goals_json

### DIFF
--- a/igc/ds/rest_goal_contract.py
+++ b/igc/ds/rest_goal_contract.py
@@ -460,7 +460,7 @@ def _comparison_rate(matches: int, total: int) -> float:
     return matches / total
 
 
-def inference_target_calls_json(row: Mapping[str, Any]) -> dict[str, Any]:
+def inference_ordered_goals_json(row: Mapping[str, Any]) -> dict[str, Any]:
     """Build the combined inference JSON handoff from a Phase 3 row.
 
     :param row: row from :func:`build_ordered_call_row`.

--- a/scripts/build_phase3_argument_smoke.py
+++ b/scripts/build_phase3_argument_smoke.py
@@ -29,7 +29,7 @@ from igc.ds.rest_goal_contract import (
     RedfishContext,
     build_ordered_call_row,
     evaluate_ordered_calls_y_pred,
-    inference_target_calls_json,
+    inference_ordered_goals_json,
     render_ordered_call_example,
 )
 from igc.modules.base.metric_keys import PHASE3_ARGUMENT_EXTRACT, phase_metric
@@ -319,7 +319,7 @@ def build_phase3_argument_smoke(
             },
             "y_pred_raw": raw_prediction,
             "evaluation": evaluation,
-            "inference": inference_target_calls_json(row),
+            "inference": inference_ordered_goals_json(row),
         })
 
     summary = aggregate_phase3_argument_smoke_metrics(spec, evaluations)

--- a/scripts/validate_phase3_ordered_goals_helper.sh
+++ b/scripts/validate_phase3_ordered_goals_helper.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Focused remote validation for the Phase 3 ordered-goals handoff helper.
+set -euo pipefail
+
+export KMP_DUPLICATE_LIB_OK=TRUE
+export OMP_NUM_THREADS=1
+export TRANSFORMERS_OFFLINE=1
+export HF_DATASETS_OFFLINE=1
+
+python -m pytest -q \
+    tests/ds/test_rest_goal_contract.py \
+    tests/scripts/test_phase3_argument_smoke.py
+
+bash -n scripts/validate_phase3_ordered_goals_helper.sh
+
+ruff check \
+    igc/ds/rest_goal_contract.py \
+    scripts/build_phase3_argument_smoke.py \
+    tests/ds/test_rest_goal_contract.py \
+    tests/scripts/test_phase3_argument_smoke.py
+
+git diff --check

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -22,7 +22,7 @@ from igc.ds.rest_goal_contract import (
     build_d1_rest_api_list_row,
     build_ordered_call_row,
     evaluate_ordered_calls_y_pred,
-    inference_target_calls_json,
+    inference_ordered_goals_json,
     parse_ordered_calls_y_pred,
     parse_rest_api_list_y_pred,
     render_ordered_call_example,
@@ -749,7 +749,7 @@ def test_rendered_and_inference_outputs_preserve_multi_item_order() -> None:
     }
     assert [
         call["rest_api"]
-        for call in inference_target_calls_json(phase3)["ordered_goals"]
+        for call in inference_ordered_goals_json(phase3)["ordered_goals"]
     ] == [
         "/redfish/v1/TaskService/Tasks",
         "/redfish/v1/Systems",
@@ -769,13 +769,13 @@ def test_inference_json_uses_ordered_goals_shape() -> None:
         rest_api_list=("/redfish/v1/TaskService/Tasks",),
     )
 
-    assert inference_target_calls_json(row) == {
+    assert inference_ordered_goals_json(row) == {
         "text": "check task queue",
         "ordered_goals": row["y_true"]["calls"],
     }
 
 
-def test_inference_target_calls_json_preserves_mutation_arguments() -> None:
+def test_inference_ordered_goals_json_preserves_mutation_arguments() -> None:
     """The inference handoff keeps explicit non-GET arguments unchanged."""
     context = _context(
         "/redfish/v1/Systems/1/Bios/Settings",
@@ -797,7 +797,7 @@ def test_inference_target_calls_json_preserves_mutation_arguments() -> None:
         },
     )
 
-    assert inference_target_calls_json(row) == {
+    assert inference_ordered_goals_json(row) == {
         "text": "set bios boot mode to Uefi",
         "ordered_goals": [{
             "rest_api": "/redfish/v1/Systems/1/Bios/Settings",


### PR DESCRIPTION
PR #119 renamed the Phase 3 inference handoff JSON key to ordered_goals but left the helper named inference_target_calls_json. Renames the function to match the contract at the definition, its consumer scripts/build_phase3_argument_smoke.py, and all test references; the negative assertion that the old target_calls key stays absent from inference JSON is kept.

No target_calls identifier remains outside that assertion (grep-verified). Gate for merge: GitHub CI on this PR.