### PR TITLE
Require committed .gitattributes LFS rules in slot artifact push guard

### DIFF
--- a/scripts/lfs_push_from_slot.sh
+++ b/scripts/lfs_push_from_slot.sh
@@ -40,18 +40,18 @@ cd "$REPO_ROOT"
 CUR_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 [ "$CUR_BRANCH" = "main" ] || note "current branch is '$CUR_BRANCH' (a data/* branch will be created)"
 
-# 1. Verify each artifact exists and is LFS-tracked. This happens before the
-# git-lfs binary check so a path that would become a normal Git blob fails even
-# on hosts where git-lfs is not installed yet.
+# 1. Verify each artifact exists and is LFS-tracked by committed attributes.
+# This happens before the git-lfs binary check so a path that would become a
+# normal Git blob fails even on hosts where git-lfs is not installed yet.
 for path in "$@"; do
   [ -e "$path" ] || die "no such artifact: $path"
-  if ! git check-attr filter -- "$path" 2>/dev/null | grep -q 'filter: lfs'; then
+  if ! git check-attr --source HEAD filter -- "$path" 2>/dev/null | grep -q 'filter: lfs'; then
     ext="$(basename "$path" | sed 's/^[^.]*//')"
     pattern_note="an exact path"
     if [ -n "$ext" ]; then
       pattern_note="an exact path or extension pattern such as '${ext}'"
     fi
-    die "'$path' is not matched by an LFS filter in .gitattributes.
+    die "'$path' is not matched by a committed LFS filter in HEAD .gitattributes.
 Add ${pattern_note} via PR, then rerun.
 Refusing to stage this artifact as a normal Git object."
   fi

--- a/scripts/validate_lfs_push_from_slot.sh
+++ b/scripts/validate_lfs_push_from_slot.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Focused validation for the slot-side LFS artifact push helper.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+./tests/shell/test_lfs_push_from_slot.sh
+
+if ! command -v bats >/dev/null 2>&1; then
+  if command -v apt-get >/dev/null 2>&1 && [ "$(id -u)" = "0" ]; then
+    apt-get update -qq
+    apt-get install -y --no-install-recommends bats
+  fi
+fi
+
+command -v bats >/dev/null 2>&1 || {
+  echo "ERROR: bats is required for tests/bats/lfs_push_from_slot.bats" >&2
+  exit 2
+}
+
+bats tests/bats/lfs_push_from_slot.bats

--- a/tests/bats/lfs_push_from_slot.bats
+++ b/tests/bats/lfs_push_from_slot.bats
@@ -20,8 +20,59 @@ setup() {
         _ "${tmp}" "${REPO_ROOT}"
 
     [ "$status" -ne 0 ]
-    [[ "$output" == *"not matched by an LFS filter"* ]]
+    [[ "$output" == *"not matched by a committed LFS filter"* ]]
     [[ "$output" == *"Refusing to stage this artifact as a normal Git object."* ]]
+    [ "$(git -C "${tmp}" symbolic-ref --short HEAD)" = "${before_branch}" ]
+}
+
+@test "slot LFS push ignores uncommitted gitattributes filters" {
+    tmp="$(mktemp -d)"
+    git -C "${tmp}" init -q
+    git -C "${tmp}" config user.email test@example.invalid
+    git -C "${tmp}" config user.name "IGC Test"
+    printf '*.safetensors filter=lfs diff=lfs merge=lfs -text\n' >"${tmp}/.gitattributes"
+    git -C "${tmp}" add .gitattributes
+    git -C "${tmp}" commit -q -m "add committed lfs attributes"
+    printf '*.bin filter=lfs diff=lfs merge=lfs -text\n' >>"${tmp}/.gitattributes"
+    printf 'payload\n' >"${tmp}/raw.bin"
+    before_branch="$(git -C "${tmp}" symbolic-ref --short HEAD)"
+
+    run bash -c 'cd "$1" && env IGC_YES=1 IGC_REMOTE=origin "$2/scripts/lfs_push_from_slot.sh" raw.bin' \
+        _ "${tmp}" "${REPO_ROOT}"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not matched by a committed LFS filter"* ]]
+    [[ "$output" == *"Refusing to stage this artifact as a normal Git object."* ]]
+    [ "$(git -C "${tmp}" symbolic-ref --short HEAD)" = "${before_branch}" ]
+}
+
+@test "slot LFS push accepts committed gitattributes filters before git-lfs gate" {
+    tmp="$(mktemp -d)"
+    git -C "${tmp}" init -q
+    git -C "${tmp}" config user.email test@example.invalid
+    git -C "${tmp}" config user.name "IGC Test"
+    printf '*.bin filter=lfs diff=lfs merge=lfs -text\n' >"${tmp}/.gitattributes"
+    git -C "${tmp}" add .gitattributes
+    git -C "${tmp}" commit -q -m "add committed lfs attributes"
+    printf 'payload\n' >"${tmp}/raw.bin"
+    before_branch="$(git -C "${tmp}" symbolic-ref --short HEAD)"
+    real_git="$(command -v git)"
+    mkdir "${tmp}/fake-bin"
+    cat >"${tmp}/fake-bin/git" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "lfs" ] && [ "\${2:-}" = "version" ]; then
+    exit 127
+fi
+exec "${real_git}" "\$@"
+EOF
+    chmod +x "${tmp}/fake-bin/git"
+
+    run bash -c 'cd "$1" && env PATH="$1/fake-bin:$PATH" IGC_YES=1 IGC_REMOTE=origin "$2/scripts/lfs_push_from_slot.sh" raw.bin' \
+        _ "${tmp}" "${REPO_ROOT}"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"git-lfs not found"* ]]
+    [[ "$output" != *"not matched by a committed LFS filter"* ]]
     [ "$(git -C "${tmp}" symbolic-ref --short HEAD)" = "${before_branch}" ]
 }
 

--- a/tests/shell/test_lfs_push_from_slot.sh
+++ b/tests/shell/test_lfs_push_from_slot.sh
@@ -20,6 +20,7 @@ git -C "$tmp" config user.name "IGC Test"
 printf '*.safetensors filter=lfs diff=lfs merge=lfs -text\n' >"$tmp/.gitattributes"
 git -C "$tmp" add .gitattributes
 git -C "$tmp" commit -q -m "add lfs attributes"
+printf '*.bin filter=lfs diff=lfs merge=lfs -text\n' >>"$tmp/.gitattributes"
 printf 'payload\n' >"$tmp/raw.bin"
 before_branch="$(git -C "$tmp" symbolic-ref --short HEAD)"
 
@@ -39,8 +40,49 @@ if [ "$status" -eq 0 ]; then
     exit 1
 fi
 
-grep -q "not matched by an LFS filter" "$out"
+grep -q "not matched by a committed LFS filter" "$out"
 grep -q "Refusing to stage this artifact as a normal Git object." "$out"
 test "$(git -C "$tmp" symbolic-ref --short HEAD)" = "$before_branch"
+
+tracked="$tmp/tracked"
+mkdir "$tracked"
+git -C "$tracked" init -q
+git -C "$tracked" config user.email test@example.invalid
+git -C "$tracked" config user.name "IGC Test"
+printf '*.bin filter=lfs diff=lfs merge=lfs -text\n' >"$tracked/.gitattributes"
+git -C "$tracked" add .gitattributes
+git -C "$tracked" commit -q -m "add committed lfs attributes"
+printf 'payload\n' >"$tracked/raw.bin"
+tracked_branch="$(git -C "$tracked" symbolic-ref --short HEAD)"
+real_git="$(command -v git)"
+mkdir "$tracked/fake-bin"
+cat >"$tracked/fake-bin/git" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "lfs" ] && [ "\${2:-}" = "version" ]; then
+    exit 127
+fi
+exec "$real_git" "\$@"
+EOF
+chmod +x "$tracked/fake-bin/git"
+
+tracked_out="$tracked/lfs_push.out"
+set +e
+(
+    cd "$tracked"
+    PATH="$tracked/fake-bin:$PATH" IGC_YES=1 IGC_REMOTE=origin \
+        "$repo_root/scripts/lfs_push_from_slot.sh" raw.bin
+) >"$tracked_out" 2>&1
+tracked_status=$?
+set -e
+
+cat "$tracked_out"
+
+if [ "$tracked_status" -eq 0 ]; then
+    echo "expected lfs_push_from_slot.sh to stop at the git-lfs availability gate" >&2
+    exit 1
+fi
+
+grep -q "git-lfs not found" "$tracked_out"
+test "$(git -C "$tracked" symbolic-ref --short HEAD)" = "$tracked_branch"
 
 git diff --check


### PR DESCRIPTION
`scripts/lfs_push_from_slot.sh` (defined there; run on GB300 slots to push reviewed model artifacts as Git LFS pointers) previously checked LFS tracking with `git check-attr filter`, which also honors uncommitted working-tree `.gitattributes` edits. An operator could add a local attribute line, get the artifact approved for a data branch, and open a PR that omits the tracking rule — landing a raw blob.

Changes:
- The guard now uses `git check-attr --source HEAD filter`, so only *committed* `.gitattributes` rules in HEAD can approve an artifact; the refusal message names the committed-filter requirement.
- New `scripts/validate_lfs_push_from_slot.sh` wrapper runs the focused shell test plus the bats suite (installs bats in the per-agent container when missing).
- Tests: uncommitted-attribute rejection (shell + bats), and a committed-attribute positive case proving the run proceeds past the filter check to the `git-lfs` availability gate (git-lfs stubbed out via a fake `git` shim).

Validation: remote slot2 CPU-only container run (`igc-dev-lfs-attr-head-guard5`) — focused shell test and 4 bats tests passed, `remote_dev_ok`. No laptop test run (CI is the gate).