### PR TITLE
Align docker-test and smoke-ladder docs with the make gate invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ profile-rl: ## Profile only the RL training hot paths
 	$(PYTHON) scripts/bench_hot_paths.py --section rl --profile
 
 docker-test: ## Build the CPU test image and run the gate inside it
-	docker build -f docker/Dockerfile.test -t igc-test:cpu . && docker run --rm igc-test:cpu pytest -q
+	docker build -f docker/Dockerfile.test -t igc-test:cpu . && docker run --rm igc-test:cpu python -m pytest -q
 
 docker-push: ## Build and push the CPU test image (requires DOCKER_REPO=<user>/igc-test)
 	@test "$${DOCKER_REPO}" || (echo "ERROR: set DOCKER_REPO, e.g. DOCKER_REPO=youruser/igc-test make docker-push"; exit 1)

--- a/docs/SMOKE_LADDER.md
+++ b/docs/SMOKE_LADDER.md
@@ -4,9 +4,10 @@ Each rung is a gate: a run may not move up until the rung below passes. The ladd
 because the expensive failures (broken resume, corrupt sharded checkpoints, a mis-matched
 tokenizer) are cheap to catch low and ruinous to discover hours into a cluster job.
 
-Conventions: the offline gate is plain `pytest -q` from the repo root (configured by
+Conventions: the offline gate runs `make gate` from the repo root (configured by
 `pytest.ini`, which registers and excludes the `gpu`/`slow`/`download`/`dataset`/`live`
-markers). Cluster steps read the fleet dashboard address from `NV72_FLEET_DASHBOARD_URL`
+markers and sets the macOS OpenMP guard used by Torch tests). Cluster steps read the
+fleet dashboard address from `NV72_FLEET_DASHBOARD_URL`
 (an internal URL kept out of this repo; see the team's ops notes) and are gated by
 `scripts/preflight_nv72.sh`, which pipes `/api/v1/state` through the offline-tested
 checker in `igc/shared/nv72_preflight.py`.
@@ -14,7 +15,7 @@ checker in `igc/shared/nv72_preflight.py`.
 ## R0 — offline gate (every change)
 
 ```bash
-pytest -q          # must be green; ruff check on touched files
+make gate PYTHON=python
 ```
 
 ## R1 — CPU mini-train (before any GPU time)


### PR DESCRIPTION
Two drift fixes between the documented offline gate and what actually runs:

- `Makefile` `docker-test` target (builds `docker/Dockerfile.test` and runs the gate in the CPU image) now invokes `python -m pytest -q` instead of bare `pytest -q`, matching the `gate` target's module-form invocation so both paths resolve the same interpreter.
- `docs/SMOKE_LADDER.md` R0 conventions now point at `make gate` (the target CI runs, defined at the top of `Makefile`) instead of plain `pytest -q`, and mention the macOS OpenMP guard the gate sets.

Docs/Makefile only; no runtime code changed.