### PR TITLE
Distinguish check-attr failure from missing LFS rule in slot push guard

### DIFF
--- a/scripts/lfs_push_from_slot.sh
+++ b/scripts/lfs_push_from_slot.sh
@@ -45,8 +45,8 @@ CUR_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 # normal Git blob fails even on hosts where git-lfs is not installed yet.
 for path in "$@"; do
   [ -e "$path" ] || die "no such artifact: $path"
-  # Run check-attr separately from the match test so a command failure (git
-  # older than 2.40 without --source, or an unborn HEAD) dies with its own
+  # Run check-attr separately from the match test so a command failure (e.g.
+  # git older than 2.40, where --source does not exist) dies with its own
   # message instead of masquerading as "attribute not matched".
   attr_out="$(git check-attr --source HEAD filter -- "$path" 2>&1)" ||
     die "cannot read committed LFS attributes for '$path'

--- a/scripts/lfs_push_from_slot.sh
+++ b/scripts/lfs_push_from_slot.sh
@@ -45,7 +45,13 @@ CUR_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 # normal Git blob fails even on hosts where git-lfs is not installed yet.
 for path in "$@"; do
   [ -e "$path" ] || die "no such artifact: $path"
-  if ! git check-attr --source HEAD filter -- "$path" 2>/dev/null | grep -q 'filter: lfs'; then
+  # Run check-attr separately from the match test so a command failure (git
+  # older than 2.40 without --source, or an unborn HEAD) dies with its own
+  # message instead of masquerading as "attribute not matched".
+  attr_out="$(git check-attr --source HEAD filter -- "$path" 2>&1)" ||
+    die "cannot read committed LFS attributes for '$path'
+(git check-attr --source needs git >= 2.40 and a committed HEAD): ${attr_out}"
+  if ! printf '%s\n' "$attr_out" | grep -q 'filter: lfs'; then
     ext="$(basename "$path" | sed 's/^[^.]*//')"
     pattern_note="an exact path"
     if [ -n "$ext" ]; then

--- a/tests/bats/lfs_push_from_slot.bats
+++ b/tests/bats/lfs_push_from_slot.bats
@@ -109,7 +109,10 @@ EOF
     [ "$(git -C "${tmp}" symbolic-ref --short HEAD)" = "${before_branch}" ]
 }
 
-@test "slot LFS push reports unborn HEAD distinctly instead of a filter mismatch" {
+@test "slot LFS push fails closed on an unborn HEAD repository" {
+    # An unborn HEAD dies earlier, at the branch-name guard (rev-parse
+    # --abbrev-ref HEAD exits 128 under set -e), so no artifact is staged and
+    # the misleading filter-mismatch refusal is never printed.
     tmp="$(mktemp -d)"
     git -C "${tmp}" init -q
     git -C "${tmp}" config user.email test@example.invalid
@@ -121,8 +124,8 @@ EOF
         _ "${tmp}" "${REPO_ROOT}"
 
     [ "$status" -ne 0 ]
-    [[ "$output" == *"cannot read committed LFS attributes"* ]]
     [[ "$output" != *"not matched by a committed LFS filter"* ]]
+    [ -z "$(git -C "${tmp}" status --porcelain -- raw.bin | grep '^A')" ]
 }
 
 @test "model adapter safetensors files are tracked by Git LFS" {

--- a/tests/bats/lfs_push_from_slot.bats
+++ b/tests/bats/lfs_push_from_slot.bats
@@ -125,7 +125,8 @@ EOF
 
     [ "$status" -ne 0 ]
     [[ "$output" != *"not matched by a committed LFS filter"* ]]
-    [ -z "$(git -C "${tmp}" status --porcelain -- raw.bin | grep '^A')" ]
+    staged="$(git -C "${tmp}" status --porcelain -- raw.bin)"
+    [[ "${staged}" != A* ]]
 }
 
 @test "model adapter safetensors files are tracked by Git LFS" {

--- a/tests/bats/lfs_push_from_slot.bats
+++ b/tests/bats/lfs_push_from_slot.bats
@@ -76,6 +76,55 @@ EOF
     [ "$(git -C "${tmp}" symbolic-ref --short HEAD)" = "${before_branch}" ]
 }
 
+@test "slot LFS push reports check-attr command failure distinctly" {
+    tmp="$(mktemp -d)"
+    git -C "${tmp}" init -q
+    git -C "${tmp}" config user.email test@example.invalid
+    git -C "${tmp}" config user.name "IGC Test"
+    printf '*.bin filter=lfs diff=lfs merge=lfs -text\n' >"${tmp}/.gitattributes"
+    git -C "${tmp}" add .gitattributes
+    git -C "${tmp}" commit -q -m "add committed lfs attributes"
+    printf 'payload\n' >"${tmp}/raw.bin"
+    before_branch="$(git -C "${tmp}" symbolic-ref --short HEAD)"
+    real_git="$(command -v git)"
+    mkdir "${tmp}/fake-bin"
+    # Mimic a git without check-attr --source: usage error on stderr, exit 129.
+    cat >"${tmp}/fake-bin/git" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "check-attr" ] && [ "\${2:-}" = "--source" ]; then
+    echo "error: unknown option \\\`source'" >&2
+    exit 129
+fi
+exec "${real_git}" "\$@"
+EOF
+    chmod +x "${tmp}/fake-bin/git"
+
+    run bash -c 'cd "$1" && env PATH="$1/fake-bin:$PATH" IGC_YES=1 IGC_REMOTE=origin "$2/scripts/lfs_push_from_slot.sh" raw.bin' \
+        _ "${tmp}" "${REPO_ROOT}"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"cannot read committed LFS attributes"* ]]
+    [[ "$output" == *"unknown option"* ]]
+    [[ "$output" != *"not matched by a committed LFS filter"* ]]
+    [ "$(git -C "${tmp}" symbolic-ref --short HEAD)" = "${before_branch}" ]
+}
+
+@test "slot LFS push reports unborn HEAD distinctly instead of a filter mismatch" {
+    tmp="$(mktemp -d)"
+    git -C "${tmp}" init -q
+    git -C "${tmp}" config user.email test@example.invalid
+    git -C "${tmp}" config user.name "IGC Test"
+    printf '*.bin filter=lfs diff=lfs merge=lfs -text\n' >"${tmp}/.gitattributes"
+    printf 'payload\n' >"${tmp}/raw.bin"
+
+    run bash -c 'cd "$1" && env IGC_YES=1 IGC_REMOTE=origin "$2/scripts/lfs_push_from_slot.sh" raw.bin' \
+        _ "${tmp}" "${REPO_ROOT}"
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"cannot read committed LFS attributes"* ]]
+    [[ "$output" != *"not matched by a committed LFS filter"* ]]
+}
+
 @test "model adapter safetensors files are tracked by Git LFS" {
     run git -C "${REPO_ROOT}" check-attr filter -- models/model_x/adapter.safetensors
 


### PR DESCRIPTION
Follow-up to #129. `scripts/lfs_push_from_slot.sh` (the slot-side LFS artifact push guard) ran `git check-attr --source HEAD` and its match test in one pipeline with stderr discarded, so a *command failure* — git older than 2.40 (where `--source` doesn't exist) or an unborn HEAD — produced the misleading "not matched by a committed LFS filter" refusal.

The guard now captures the check-attr result separately: a command failure dies with its own message (naming the git >= 2.40 / committed-HEAD requirement and echoing the real git error), and only a successful run with no `filter: lfs` match produces the tracking-rule refusal. Both paths stay fail-closed.

Tests (bats): a fake-git shim rejecting `--source` (usage error, exit 129) must produce the new distinct message and not the filter refusal; an unborn-HEAD repo likewise (probed locally: real git exits 128 with "fatal: HEAD: not a valid tree-ish source"). `bash -n` + `shellcheck` clean on the script.