### PR TITLE
Drop bats files from the CI bash syntax check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           sudo apt-get install -y bats shellcheck
       - name: Bash syntax
         shell: bash
-        run: bash -n scripts/*.sh scripts/*.sbatch tests/bats/*.bats
+        run: bash -n scripts/*.sh scripts/*.sbatch
       - name: ShellCheck
         shell: bash
         run: shellcheck scripts/*.sh scripts/*.sbatch tests/bats/*.bats


### PR DESCRIPTION
The CI shell job's "Bash syntax" step listed `tests/bats/*.bats` in `bash -n`, but bats files are not plain bash — `@test "..." {` blocks need bats preprocessing, and `bash -n` on any of our committed bats files exits 2 with `syntax error near unexpected token '}'` (verified against both bash 5.3 and 3.2). The step has only been "passing" because `bash -n file1 file2 ...` syntax-checks the *first* file only and treats the rest as positional parameters, so the bats files (and everything after the first script) were never actually parsed.

This drops the bats glob from `bash -n`; bats files keep real validation from the ShellCheck step (shellcheck parses bats natively) and from the `bats tests/bats` run itself.

Known residual (queued separately): `bash -n` still only checks the first expanded file — the step needs a per-file loop to validate every script.