### PR TITLE
CI: syntax-check every shell script, not just the first

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,11 @@ jobs:
           sudo apt-get install -y bats shellcheck
       - name: Bash syntax
         shell: bash
-        run: bash -n scripts/*.sh scripts/*.sbatch
+        run: |
+          set -euo pipefail
+          for f in scripts/*.sh scripts/*.sbatch; do
+            bash -n "$f"
+          done
       - name: ShellCheck
         shell: bash
         run: shellcheck scripts/*.sh scripts/*.sbatch tests/bats/*.bats


### PR DESCRIPTION
The Bash syntax step ran `bash -n scripts/*.sh scripts/*.sbatch`, which parses only the first expanded path (the rest become positional args to that first script), so most scripts were never syntax-checked. Loop per-file under `set -euo pipefail` so a syntax error in any script fails the step.

Offline/CI-only change (touches .github/workflows/ci.yml). The change validates against the repo's own 20 scripts + 2 .sbatch files via this same CI run.