### PR TITLE
local_gate: scope the default lock dir by user id

### DIFF
--- a/scripts/local_gate.sh
+++ b/scripts/local_gate.sh
@@ -20,7 +20,7 @@
 # Env knobs:
 #   IGC_GATE_PYTHON        python to use (default: python3 on PATH)
 #   IGC_GATE_TIMEOUT_SECS  kill a wedged suite after this many seconds (1800)
-#   IGC_GATE_LOCK_DIR      lock location (default $TMPDIR/igc-local-gate.lock)
+#   IGC_GATE_LOCK_DIR      exact lock location override
 #   IGC_GATE_CMD           full override of the gated command (tests use this)
 #
 # Used by: agent coordination passes as the default local gate entry point
@@ -31,7 +31,8 @@
 # Mus mbayramo@stanford.edu
 set -uo pipefail
 
-LOCK_DIR="${IGC_GATE_LOCK_DIR:-${TMPDIR:-/tmp}/igc-local-gate.lock}"
+LOCK_OWNER="$(id -u 2>/dev/null || printf '%s' "${USER:-unknown}")"
+LOCK_DIR="${IGC_GATE_LOCK_DIR:-${TMPDIR:-/tmp}/igc-local-gate.${LOCK_OWNER}.lock}"
 TIMEOUT_SECS="${IGC_GATE_TIMEOUT_SECS:-1800}"
 PYTHON_BIN="${IGC_GATE_PYTHON:-python3}"
 

--- a/tests/bats/local_gate.bats
+++ b/tests/bats/local_gate.bats
@@ -28,6 +28,21 @@ setup() {
     [ ! -d "$LOCK" ]
 }
 
+@test "default lock path is scoped by user id" {
+    old_default="$BATS_TEST_TMPDIR/igc-local-gate.lock"
+    current_uid="$(id -u)"
+    scoped_default="$BATS_TEST_TMPDIR/igc-local-gate.${current_uid}.lock"
+    mkdir -p "$old_default"
+    echo 99999999 > "$old_default/pid"
+
+    run env TMPDIR="$BATS_TEST_TMPDIR" IGC_GATE_CMD="echo scoped-ok" bash "$SCRIPT"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *scoped-ok* ]]
+    [ -d "$old_default" ]
+    [ ! -d "$scoped_default" ]
+}
+
 @test "steals a stale lock left by a dead process" {
     mkdir -p "$LOCK"
     echo 99999999 > "$LOCK/pid"   # certainly-dead pid


### PR DESCRIPTION
The default lock `$TMPDIR/igc-local-gate.lock` is not user-scoped, so unrelated users on a shared host could block or stale-steal each other's local gate. Default now includes the uid (`igc-local-gate.<uid>.lock`), falling back to $USER then `unknown`. Adds a bats regression asserting the scoped default path is used and the legacy unscoped path is left untouched.

Offline shell + bats change; no training/GPU path touched.