### PR TITLE
Gate the shell LFS-push regression in CI and mirror the new guard cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           # the workflow itself changing re-runs everything
           wf='^\.github/workflows/'
           {
-            echo "shell=$(match "$wf|^scripts/.*\.(sh|sbatch)$|^tests/bats/|^collector\.sh$")"
+            echo "shell=$(match "$wf|^scripts/.*\.(sh|sbatch)$|^tests/bats/|^tests/shell/.*\.sh$|^collector\.sh$")"
             echo "python=$(match "$wf|^igc/|^tests/|^configs/|^scripts/.*\.py$|^docker/requirements|^pytest\.ini$|^setup\.py$|^igc_main\.py$|^igc_ctl\.py$|^redfish_ctl")"
             echo "perf=$(match "$wf|^igc/|^tests/perf/|^scripts/bench_hot_paths\.py$|^redfish_ctl")"
             echo "docker=$(match "$wf|^docker/|^\.dockerignore$|^requirements|^setup\.py$|^conda-recipe\.yaml$")"
@@ -95,6 +95,14 @@ jobs:
       - name: Bats
         shell: bash
         run: bats tests/bats
+      - name: Shell regression tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          for t in tests/shell/*.sh; do
+            echo "== $t =="
+            bash "$t"
+          done
 
   gate:
     needs: changes

--- a/tests/shell/test_lfs_push_from_slot.sh
+++ b/tests/shell/test_lfs_push_from_slot.sh
@@ -85,4 +85,95 @@ fi
 grep -q "git-lfs not found" "$tracked_out"
 test "$(git -C "$tracked" symbolic-ref --short HEAD)" = "$tracked_branch"
 
+# A committed *.bin filter matches raw.bin, so the path check would pass; but a
+# git whose `check-attr --source` errors (e.g. git < 2.40, no --source option)
+# must die with its own distinct message, not the misleading committed-filter
+# refusal. Mirrors the bats "check-attr command failure" regression so the slot
+# validator covers it without bats installed.
+attrfail="$tmp/attrfail"
+mkdir "$attrfail"
+git -C "$attrfail" init -q
+git -C "$attrfail" config user.email test@example.invalid
+git -C "$attrfail" config user.name "IGC Test"
+printf '*.bin filter=lfs diff=lfs merge=lfs -text\n' >"$attrfail/.gitattributes"
+git -C "$attrfail" add .gitattributes
+git -C "$attrfail" commit -q -m "add committed lfs attributes"
+printf 'payload\n' >"$attrfail/raw.bin"
+attrfail_branch="$(git -C "$attrfail" symbolic-ref --short HEAD)"
+mkdir "$attrfail/fake-bin"
+cat >"$attrfail/fake-bin/git" <<EOF
+#!/usr/bin/env bash
+if [ "\${1:-}" = "check-attr" ] && [ "\${2:-}" = "--source" ]; then
+    echo "error: unknown option --source" >&2
+    exit 129
+fi
+exec "$real_git" "\$@"
+EOF
+chmod +x "$attrfail/fake-bin/git"
+
+attrfail_out="$attrfail/lfs_push.out"
+set +e
+(
+    cd "$attrfail"
+    PATH="$attrfail/fake-bin:$PATH" IGC_YES=1 IGC_REMOTE=origin \
+        "$repo_root/scripts/lfs_push_from_slot.sh" raw.bin
+) >"$attrfail_out" 2>&1
+attrfail_status=$?
+set -e
+
+cat "$attrfail_out"
+
+if [ "$attrfail_status" -eq 0 ]; then
+    echo "expected lfs_push_from_slot.sh to fail when check-attr --source errors" >&2
+    exit 1
+fi
+
+grep -q "cannot read committed LFS attributes" "$attrfail_out"
+grep -q "unknown option --source" "$attrfail_out"
+if grep -q "not matched by a committed LFS filter" "$attrfail_out"; then
+    echo "check-attr command failure must not print the filter-mismatch refusal" >&2
+    exit 1
+fi
+test "$(git -C "$attrfail" symbolic-ref --short HEAD)" = "$attrfail_branch"
+
+# An unborn HEAD (git init, no commit yet) must fail closed before any artifact
+# is staged and must not print the misleading filter-mismatch refusal. Mirrors
+# the bats "fails closed on an unborn HEAD" regression.
+unborn="$tmp/unborn"
+mkdir "$unborn"
+git -C "$unborn" init -q
+git -C "$unborn" config user.email test@example.invalid
+git -C "$unborn" config user.name "IGC Test"
+printf '*.bin filter=lfs diff=lfs merge=lfs -text\n' >"$unborn/.gitattributes"
+printf 'payload\n' >"$unborn/raw.bin"
+
+unborn_out="$unborn/lfs_push.out"
+set +e
+(
+    cd "$unborn"
+    IGC_YES=1 IGC_REMOTE=origin \
+        "$repo_root/scripts/lfs_push_from_slot.sh" raw.bin
+) >"$unborn_out" 2>&1
+unborn_status=$?
+set -e
+
+cat "$unborn_out"
+
+if [ "$unborn_status" -eq 0 ]; then
+    echo "expected lfs_push_from_slot.sh to fail closed on an unborn HEAD" >&2
+    exit 1
+fi
+
+if grep -q "not matched by a committed LFS filter" "$unborn_out"; then
+    echo "unborn HEAD must not print the filter-mismatch refusal" >&2
+    exit 1
+fi
+unborn_staged="$(git -C "$unborn" status --porcelain -- raw.bin)"
+case "$unborn_staged" in
+    A*)
+        echo "unborn HEAD run must not stage the artifact" >&2
+        exit 1
+        ;;
+esac
+
 git diff --check


### PR DESCRIPTION
Two coupled changes:

1. **tests/shell/test_lfs_push_from_slot.sh** — mirror the two bats regressions added for the slot LFS-push guard so the plain-shell validator (run on a slot without bats) also proves them:
   - a git whose `check-attr --source` errors dies with `cannot read committed LFS attributes` instead of the misleading committed-filter-mismatch refusal, and does not stage the artifact;
   - an unborn HEAD fails closed before staging.

2. **.github/workflows/ci.yml** — the shell-level regression under `tests/shell/` was never executed or change-detected by CI (only the slot validator ran it), so edits could regress undetected. Add `tests/shell/*.sh` to the shell change filter and run each script in the shell job after Bats. This makes the shell regressions self-gating — this PR's own CI run executes the new cases.

Offline shell + CI-config only; no Python/GPU/training path touched. The tests run without network or git-lfs.