### PR TITLE
Lint tests/shell scripts in CI ShellCheck step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           done
       - name: ShellCheck
         shell: bash
-        run: shellcheck scripts/*.sh scripts/*.sbatch tests/bats/*.bats
+        run: shellcheck scripts/*.sh scripts/*.sbatch tests/bats/*.bats tests/shell/*.sh
       - name: Bats
         shell: bash
         run: bats tests/bats


### PR DESCRIPTION
Adds `tests/shell/*.sh` to the CI ShellCheck step in `.github/workflows/ci.yml`, completing the tests/shell CI integration started in #135 (the shell job already executes these tests; now it lints them too). The change detector already covers `^tests/shell/.*\.sh$`, so shell-only changes in that directory trigger the job.

Validation (slot/worktree evidence on the board): `shellcheck scripts/*.sh scripts/*.sbatch tests/bats/*.bats tests/shell/*.sh` passed; `bash -n` per-file passed; `git diff --check` clean. Consumes queued CQ-SHELLCHECK-SHELL.