### PR TITLE
Harden Phase 2 labelled-request guards and document provider env vars

### DIFF
--- a/configs/phase2_labelled_requests.yaml
+++ b/configs/phase2_labelled_requests.yaml
@@ -78,6 +78,7 @@ wandb:
     - phase2_labelled_requests/pro_accept_rate
     - phase2_labelled_requests/rest_api_set_match_rate
     - phase2_labelled_requests/empty_set_match_rate
+    - phase2_labelled_requests/empty_set_expected_total
     - phase2_labelled_requests/sample_width/k
     - phase2_labelled_requests/vendor/source_corpus
     - phase2_labelled_requests/prompt_spec_version

--- a/docs/phase_2.md
+++ b/docs/phase_2.md
@@ -217,6 +217,7 @@ The labelled-request generation builder records these keys under the
 - `phase2_labelled_requests/pro_accept_rate`
 - `phase2_labelled_requests/rest_api_set_match_rate`
 - `phase2_labelled_requests/empty_set_match_rate`
+- `phase2_labelled_requests/empty_set_expected_total`
 - `phase2_labelled_requests/sample_width/k`
 - `phase2_labelled_requests/vendor/source_corpus`
 - `phase2_labelled_requests/prompt_spec_version`

--- a/docs/phase_2.md
+++ b/docs/phase_2.md
@@ -67,6 +67,25 @@ whose `--count` exceeds `safety.live_without_gate_max_candidates` must pass
 `--live-provider-gate-passed`; otherwise the CLI exits before opening a live
 provider connection.
 
+The P2-LABELS-002 live launch uses the `providers:` block in
+`configs/phase2_labelled_requests.yaml`; `igc/ds/phase2_labelled_requests.py`
+resolves each provider's `base_url_env` and `api_key_env` value before it builds
+the OpenAI-compatible provider clients. The concrete environment variables are:
+
+- `PHASE2_MODEL_X_BASE_URL`: the draft provider base URL named by
+  `providers.draft.base_url_env` in `configs/phase2_labelled_requests.yaml`.
+- `PHASE2_MODEL_X_API_KEY`: the draft provider API key named by
+  `providers.draft.api_key_env` in `configs/phase2_labelled_requests.yaml`.
+- `PHASE2_JUDGE_BASE_URL`: the judge provider base URL named by
+  `providers.judge.base_url_env` in `configs/phase2_labelled_requests.yaml`.
+- `PHASE2_JUDGE_API_KEY`: the judge provider API key named by
+  `providers.judge.api_key_env` in `configs/phase2_labelled_requests.yaml`.
+
+If any required live-provider variable is unset, the builder fails closed before
+generation instead of silently falling back to mock providers or hardcoded
+endpoints; `scripts/build_phase2_labelled_requests.py` enforces that check when
+it constructs the live OpenAI-compatible provider.
+
 ## Build Input
 
 To build one `phase2_labelled_requests` row, sample one, two, or three Redfish

--- a/igc/ds/phase2_labelled_requests.py
+++ b/igc/ds/phase2_labelled_requests.py
@@ -465,12 +465,12 @@ def parse_pro_judge_result(raw: str) -> ProJudgeResult:
             invalid_json=True,
             reason="accepted or accept is required",
         )
-    accepted = _optional_bool(parsed, accepted_key)
-    if accepted is None:
+    accepted = parsed[accepted_key]
+    if not isinstance(accepted, bool):
         return ProJudgeResult(
             accepted=False,
             invalid_json=True,
-            reason=f"{accepted_key} must be a boolean when present",
+            reason=f"{accepted_key} must be a boolean",
         )
     nonsense = _optional_bool(parsed, "nonsense")
     if nonsense is None:
@@ -787,11 +787,17 @@ def _validate_prompt_template(
 ) -> None:
     """Validate configured prompt placeholders before a build starts."""
     try:
-        parsed_fields = {
-            field_name
-            for _, field_name, _, _ in Formatter().parse(template)
-            if field_name
-        }
+        parsed_fields: set[str] = set()
+        for _, field_name, _, _ in Formatter().parse(template):
+            if field_name is None:
+                continue
+            if not field_name:
+                raise Phase2LabelledRequestsSpecError(
+                    f"{label} has unnamed format fields",
+                )
+            parsed_fields.add(field_name)
+    except Phase2LabelledRequestsSpecError:
+        raise
     except ValueError as exc:
         raise Phase2LabelledRequestsSpecError(f"{label} has malformed format fields") from exc
 

--- a/igc/ds/phase2_labelled_requests.py
+++ b/igc/ds/phase2_labelled_requests.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 import json
 from pathlib import Path
 import random
+from string import Formatter
 from typing import Any, Callable, Mapping, Sequence
 
 import yaml
@@ -265,6 +266,26 @@ def load_phase2_labelled_requests_spec(path: str | Path) -> Phase2LabelledReques
     prompts = _mapping(raw, "prompts", required=True)
     model_prompt = _mapping(prompts, "model_x_draft", required=True)
     judge_prompt = _mapping(prompts, "pro_judge", required=True)
+    model_x_system = _required_string(model_prompt, "system", "prompts.model_x_draft.system")
+    model_x_template = _required_string(
+        model_prompt,
+        "template",
+        "prompts.model_x_draft.template",
+    )
+    judge_system = _required_string(judge_prompt, "system", "prompts.pro_judge.system")
+    judge_template = _required_string(judge_prompt, "template", "prompts.pro_judge.template")
+    _validate_prompt_template(
+        model_x_template,
+        label="prompts.model_x_draft.template",
+        required_fields=("records_json",),
+        allowed_fields=("records_json",),
+    )
+    _validate_prompt_template(
+        judge_template,
+        label="prompts.pro_judge.template",
+        required_fields=("records_json", "draft_text"),
+        allowed_fields=("records_json", "draft_text"),
+    )
     providers = _mapping(raw, "providers", required=True)
     draft_provider = _provider_adapter_spec(
         _mapping(providers, "draft"),
@@ -327,14 +348,10 @@ def load_phase2_labelled_requests_spec(path: str | Path) -> Phase2LabelledReques
             profile=_required_string(judge_raw, "profile", "judge.profile"),
         ),
         generation=dict(_mapping(raw, "generation", required=True)),
-        model_x_system=_required_string(model_prompt, "system", "prompts.model_x_draft.system"),
-        model_x_template=_required_string(
-            model_prompt,
-            "template",
-            "prompts.model_x_draft.template",
-        ),
-        judge_system=_required_string(judge_prompt, "system", "prompts.pro_judge.system"),
-        judge_template=_required_string(judge_prompt, "template", "prompts.pro_judge.template"),
+        model_x_system=model_x_system,
+        model_x_template=model_x_template,
+        judge_system=judge_system,
+        judge_template=judge_template,
         draft_provider=draft_provider,
         judge_provider=judge_provider,
         live_without_gate_max_candidates=live_without_gate_max_candidates,
@@ -742,6 +759,36 @@ def _required_string(source: Mapping[str, Any], key: str, label: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise Phase2LabelledRequestsSpecError(f"{label} must be a non-empty string")
     return value
+
+
+def _validate_prompt_template(
+    template: str,
+    *,
+    label: str,
+    required_fields: Sequence[str],
+    allowed_fields: Sequence[str],
+) -> None:
+    """Validate configured prompt placeholders before a build starts."""
+    try:
+        parsed_fields = {
+            field_name
+            for _, field_name, _, _ in Formatter().parse(template)
+            if field_name
+        }
+    except ValueError as exc:
+        raise Phase2LabelledRequestsSpecError(f"{label} has malformed format fields") from exc
+
+    unknown_fields = sorted(parsed_fields - set(allowed_fields))
+    if unknown_fields:
+        raise Phase2LabelledRequestsSpecError(
+            f"{label} has unknown fields: {', '.join(unknown_fields)}",
+        )
+
+    missing_fields = sorted(set(required_fields) - parsed_fields)
+    if missing_fields:
+        raise Phase2LabelledRequestsSpecError(
+            f"{label} missing required fields: {', '.join(missing_fields)}",
+        )
 
 
 def _optional_string(source: Mapping[str, Any], key: str) -> str:

--- a/igc/ds/phase2_labelled_requests.py
+++ b/igc/ds/phase2_labelled_requests.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 import json
 from pathlib import Path
 import random
+from string import Formatter
 from typing import Any, Callable, Mapping, Sequence
 
 import yaml
@@ -262,6 +263,26 @@ def load_phase2_labelled_requests_spec(path: str | Path) -> Phase2LabelledReques
     prompts = _mapping(raw, "prompts", required=True)
     model_prompt = _mapping(prompts, "model_x_draft", required=True)
     judge_prompt = _mapping(prompts, "pro_judge", required=True)
+    model_x_system = _required_string(model_prompt, "system", "prompts.model_x_draft.system")
+    model_x_template = _required_string(
+        model_prompt,
+        "template",
+        "prompts.model_x_draft.template",
+    )
+    judge_system = _required_string(judge_prompt, "system", "prompts.pro_judge.system")
+    judge_template = _required_string(judge_prompt, "template", "prompts.pro_judge.template")
+    _validate_prompt_template(
+        model_x_template,
+        label="prompts.model_x_draft.template",
+        required_fields=("records_json",),
+        allowed_fields=("records_json",),
+    )
+    _validate_prompt_template(
+        judge_template,
+        label="prompts.pro_judge.template",
+        required_fields=("records_json", "draft_text"),
+        allowed_fields=("records_json", "draft_text"),
+    )
     providers = _mapping(raw, "providers", required=True)
     draft_provider = _provider_adapter_spec(
         _mapping(providers, "draft"),
@@ -324,14 +345,10 @@ def load_phase2_labelled_requests_spec(path: str | Path) -> Phase2LabelledReques
             profile=_required_string(judge_raw, "profile", "judge.profile"),
         ),
         generation=dict(_mapping(raw, "generation", required=True)),
-        model_x_system=_required_string(model_prompt, "system", "prompts.model_x_draft.system"),
-        model_x_template=_required_string(
-            model_prompt,
-            "template",
-            "prompts.model_x_draft.template",
-        ),
-        judge_system=_required_string(judge_prompt, "system", "prompts.pro_judge.system"),
-        judge_template=_required_string(judge_prompt, "template", "prompts.pro_judge.template"),
+        model_x_system=model_x_system,
+        model_x_template=model_x_template,
+        judge_system=judge_system,
+        judge_template=judge_template,
         draft_provider=draft_provider,
         judge_provider=judge_provider,
         live_without_gate_max_candidates=live_without_gate_max_candidates,
@@ -739,6 +756,36 @@ def _required_string(source: Mapping[str, Any], key: str, label: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise Phase2LabelledRequestsSpecError(f"{label} must be a non-empty string")
     return value
+
+
+def _validate_prompt_template(
+    template: str,
+    *,
+    label: str,
+    required_fields: Sequence[str],
+    allowed_fields: Sequence[str],
+) -> None:
+    """Validate configured prompt placeholders before a build starts."""
+    try:
+        parsed_fields = {
+            field_name
+            for _, field_name, _, _ in Formatter().parse(template)
+            if field_name
+        }
+    except ValueError as exc:
+        raise Phase2LabelledRequestsSpecError(f"{label} has malformed format fields") from exc
+
+    unknown_fields = sorted(parsed_fields - set(allowed_fields))
+    if unknown_fields:
+        raise Phase2LabelledRequestsSpecError(
+            f"{label} has unknown fields: {', '.join(unknown_fields)}",
+        )
+
+    missing_fields = sorted(set(required_fields) - parsed_fields)
+    if missing_fields:
+        raise Phase2LabelledRequestsSpecError(
+            f"{label} missing required fields: {', '.join(missing_fields)}",
+        )
 
 
 def _optional_string(source: Mapping[str, Any], key: str) -> str:

--- a/igc/ds/phase2_labelled_requests.py
+++ b/igc/ds/phase2_labelled_requests.py
@@ -37,6 +37,7 @@ _INVALID_JSON_RATE_KEY = phase_metric(PHASE2_LABELLED_REQUESTS, "invalid_json_ra
 _PRO_ACCEPT_RATE_KEY = phase_metric(PHASE2_LABELLED_REQUESTS, "pro_accept_rate")
 _REST_API_SET_MATCH_RATE_KEY = phase_metric(PHASE2_LABELLED_REQUESTS, "rest_api_set_match_rate")
 _EMPTY_SET_MATCH_RATE_KEY = phase_metric(PHASE2_LABELLED_REQUESTS, "empty_set_match_rate")
+_EMPTY_SET_EXPECTED_TOTAL_KEY = phase_metric(PHASE2_LABELLED_REQUESTS, "empty_set_expected_total")
 _SAMPLE_WIDTH_KEY = phase_metric(PHASE2_LABELLED_REQUESTS, "sample_width", "k")
 _VENDOR_SOURCE_CORPUS_KEY = phase_metric(PHASE2_LABELLED_REQUESTS, "vendor", "source_corpus")
 _PROMPT_SPEC_VERSION_KEY = phase_metric(PHASE2_LABELLED_REQUESTS, "prompt_spec_version")
@@ -51,6 +52,13 @@ _REQUIRED_ACCEPTANCE_KEYS = (
     "max_invalid_json_rate",
 )
 _PROVIDER_ADAPTERS = frozenset({"mock", "file", "openai-compatible"})
+_ORDER_EVIDENCE_VALUES = frozenset((
+    "none",
+    "explicit_then",
+    "explicit_before",
+    "explicit_after",
+    "numbered_steps",
+))
 
 
 class Phase2LabelledRequestsSpecError(ValueError):
@@ -469,7 +477,15 @@ def parse_pro_judge_result(raw: str) -> ProJudgeResult:
         return ProJudgeResult(
             accepted=False,
             invalid_json=True,
-            reason="nonsense must be a boolean when present",
+            reason="nonsense must be a boolean",
+        )
+    order_evidence = parsed.get("order_evidence", "none")
+    if not isinstance(order_evidence, str) or order_evidence not in _ORDER_EVIDENCE_VALUES:
+        return ProJudgeResult(
+            accepted=False,
+            invalid_json=True,
+            reason="order_evidence must be one of "
+            f"{', '.join(sorted(_ORDER_EVIDENCE_VALUES))}",
         )
 
     return ProJudgeResult(
@@ -478,7 +494,7 @@ def parse_pro_judge_result(raw: str) -> ProJudgeResult:
         nonsense=nonsense,
         invalid_json=False,
         reason=str(parsed.get("reason", "")),
-        order_evidence=str(parsed.get("order_evidence", "none")),
+        order_evidence=order_evidence,
     )
 
 
@@ -564,6 +580,7 @@ class Phase2LabelledRequestCounters:
                 self.empty_set_match_total,
                 self.empty_set_expected_total,
             ),
+            _EMPTY_SET_EXPECTED_TOTAL_KEY: self.empty_set_expected_total,
             _SAMPLE_WIDTH_KEY: self.sample_width_k,
             _VENDOR_SOURCE_CORPUS_KEY: self.vendor_source_corpus,
             _PROMPT_SPEC_VERSION_KEY: self.prompt_spec_version,
@@ -874,7 +891,7 @@ def _provider_adapter_spec(raw: Mapping[str, Any], *, label: str) -> ProviderAda
 def _optional_bool(source: Mapping[str, Any], key: str) -> bool | None:
     """Read an optional judge boolean; return ``None`` for malformed values."""
     if key not in source:
-        return False
+        return None
     value = source[key]
     if not isinstance(value, bool):
         return None

--- a/igc/ds/phase2_labelled_requests.py
+++ b/igc/ds/phase2_labelled_requests.py
@@ -34,6 +34,7 @@ _INVALID_JSON_RATE_KEY = phase_metric(PHASE2_LABELLED_REQUESTS, "invalid_json_ra
 _PRO_ACCEPT_RATE_KEY = phase_metric(PHASE2_LABELLED_REQUESTS, "pro_accept_rate")
 _REST_API_SET_MATCH_RATE_KEY = phase_metric(PHASE2_LABELLED_REQUESTS, "rest_api_set_match_rate")
 _EMPTY_SET_MATCH_RATE_KEY = phase_metric(PHASE2_LABELLED_REQUESTS, "empty_set_match_rate")
+_EMPTY_SET_EXPECTED_TOTAL_KEY = phase_metric(PHASE2_LABELLED_REQUESTS, "empty_set_expected_total")
 _SAMPLE_WIDTH_KEY = phase_metric(PHASE2_LABELLED_REQUESTS, "sample_width", "k")
 _VENDOR_SOURCE_CORPUS_KEY = phase_metric(PHASE2_LABELLED_REQUESTS, "vendor", "source_corpus")
 _PROMPT_SPEC_VERSION_KEY = phase_metric(PHASE2_LABELLED_REQUESTS, "prompt_spec_version")
@@ -48,6 +49,13 @@ _REQUIRED_ACCEPTANCE_KEYS = (
     "max_invalid_json_rate",
 )
 _PROVIDER_ADAPTERS = frozenset({"mock", "file", "openai-compatible"})
+_ORDER_EVIDENCE_VALUES = frozenset((
+    "none",
+    "explicit_then",
+    "explicit_before",
+    "explicit_after",
+    "numbered_steps",
+))
 
 
 class Phase2LabelledRequestsSpecError(ValueError):
@@ -466,7 +474,15 @@ def parse_pro_judge_result(raw: str) -> ProJudgeResult:
         return ProJudgeResult(
             accepted=False,
             invalid_json=True,
-            reason="nonsense must be a boolean when present",
+            reason="nonsense must be a boolean",
+        )
+    order_evidence = parsed.get("order_evidence", "none")
+    if not isinstance(order_evidence, str) or order_evidence not in _ORDER_EVIDENCE_VALUES:
+        return ProJudgeResult(
+            accepted=False,
+            invalid_json=True,
+            reason="order_evidence must be one of "
+            f"{', '.join(sorted(_ORDER_EVIDENCE_VALUES))}",
         )
 
     return ProJudgeResult(
@@ -475,7 +491,7 @@ def parse_pro_judge_result(raw: str) -> ProJudgeResult:
         nonsense=nonsense,
         invalid_json=False,
         reason=str(parsed.get("reason", "")),
-        order_evidence=str(parsed.get("order_evidence", "none")),
+        order_evidence=order_evidence,
     )
 
 
@@ -561,6 +577,7 @@ class Phase2LabelledRequestCounters:
                 self.empty_set_match_total,
                 self.empty_set_expected_total,
             ),
+            _EMPTY_SET_EXPECTED_TOTAL_KEY: self.empty_set_expected_total,
             _SAMPLE_WIDTH_KEY: self.sample_width_k,
             _VENDOR_SOURCE_CORPUS_KEY: self.vendor_source_corpus,
             _PROMPT_SPEC_VERSION_KEY: self.prompt_spec_version,
@@ -871,7 +888,7 @@ def _provider_adapter_spec(raw: Mapping[str, Any], *, label: str) -> ProviderAda
 def _optional_bool(source: Mapping[str, Any], key: str) -> bool | None:
     """Read an optional judge boolean; return ``None`` for malformed values."""
     if key not in source:
-        return False
+        return None
     value = source[key]
     if not isinstance(value, bool):
         return None

--- a/igc/ds/phase2_labelled_requests.py
+++ b/igc/ds/phase2_labelled_requests.py
@@ -784,11 +784,14 @@ def _validate_prompt_template(
 ) -> None:
     """Validate configured prompt placeholders before a build starts."""
     try:
-        parsed_fields = {
-            field_name
-            for _, field_name, _, _ in Formatter().parse(template)
-            if field_name
-        }
+        parsed_fields: set[str] = set()
+        for _, field_name, _, _ in Formatter().parse(template):
+            if field_name == "":
+                raise Phase2LabelledRequestsSpecError(
+                    f"{label} has unnamed format fields",
+                )
+            if field_name:
+                parsed_fields.add(field_name)
     except ValueError as exc:
         raise Phase2LabelledRequestsSpecError(f"{label} has malformed format fields") from exc
 

--- a/igc/modules/base/metric_keys.py
+++ b/igc/modules/base/metric_keys.py
@@ -68,6 +68,7 @@ PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS = (
     phase_metric(PHASE2_LABELLED_REQUESTS, "pro_accept_rate"),
     phase_metric(PHASE2_LABELLED_REQUESTS, "rest_api_set_match_rate"),
     phase_metric(PHASE2_LABELLED_REQUESTS, "empty_set_match_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "empty_set_expected_total"),
     phase_metric(PHASE2_LABELLED_REQUESTS, "sample_width", "k"),
     phase_metric(PHASE2_LABELLED_REQUESTS, "vendor", "source_corpus"),
     phase_metric(PHASE2_LABELLED_REQUESTS, "prompt_spec_version"),

--- a/igc/modules/base/metric_keys.py
+++ b/igc/modules/base/metric_keys.py
@@ -87,6 +87,7 @@ PHASE2_LABELLED_REQUESTS_WANDB_METRIC_KEYS = (
     phase_metric(PHASE2_LABELLED_REQUESTS, "pro_accept_rate"),
     phase_metric(PHASE2_LABELLED_REQUESTS, "rest_api_set_match_rate"),
     phase_metric(PHASE2_LABELLED_REQUESTS, "empty_set_match_rate"),
+    phase_metric(PHASE2_LABELLED_REQUESTS, "empty_set_expected_total"),
     phase_metric(PHASE2_LABELLED_REQUESTS, "sample_width", "k"),
     phase_metric(PHASE2_LABELLED_REQUESTS, "vendor", "source_corpus"),
     phase_metric(PHASE2_LABELLED_REQUESTS, "prompt_spec_version"),

--- a/tests/ds/test_phase2_labelled_requests.py
+++ b/tests/ds/test_phase2_labelled_requests.py
@@ -121,6 +121,7 @@ wandb:
     - phase2_labelled_requests/pro_accept_rate
     - phase2_labelled_requests/rest_api_set_match_rate
     - phase2_labelled_requests/empty_set_match_rate
+    - phase2_labelled_requests/empty_set_expected_total
     - phase2_labelled_requests/sample_width/k
     - phase2_labelled_requests/vendor/source_corpus
     - phase2_labelled_requests/prompt_spec_version
@@ -560,6 +561,34 @@ def test_pro_judge_result_parsing_accepts_plain_and_wrapped_json() -> None:
     assert "not a mapping" in non_object.reason
 
 
+def test_pro_judge_result_parsing_requires_nonsense_boolean() -> None:
+    """Judge output must carry an explicit nonsense verdict."""
+    missing = parse_pro_judge_result(
+        json.dumps({
+            "accepted": True,
+            "rest_api_list": ["/redfish/v1/Systems/1"],
+        }),
+    )
+    assert missing.accepted is False
+    assert missing.invalid_json is True
+    assert "nonsense" in missing.reason
+
+
+def test_pro_judge_result_parsing_rejects_unknown_order_evidence() -> None:
+    """Order evidence is a controlled enum, not arbitrary judge text."""
+    result = parse_pro_judge_result(
+        json.dumps({
+            "accepted": True,
+            "rest_api_list": ["/redfish/v1/Systems/1"],
+            "nonsense": False,
+            "order_evidence": "maybe_later",
+        }),
+    )
+    assert result.accepted is False
+    assert result.invalid_json is True
+    assert "order_evidence" in result.reason
+
+
 def test_pro_judge_result_parsing_accepts_rest_api_set_alias() -> None:
     """The parser accepts the judge's legacy rest_api_set alias."""
     result = parse_pro_judge_result(
@@ -817,6 +846,7 @@ def test_counters_track_nonsense_invalid_json_and_empty_set_matches() -> None:
     assert summary[_phase2_metric("pro_accept_rate")] == pytest.approx(1 / 3)
     assert summary[_phase2_metric("rest_api_set_match_rate")] == pytest.approx(1 / 3)
     assert summary[_phase2_metric("empty_set_match_rate")] == 1.0
+    assert summary[_phase2_metric("empty_set_expected_total")] == 1
 
 
 def test_counter_summary_binds_semantic_metric_names() -> None:
@@ -849,6 +879,7 @@ def test_counter_summary_binds_semantic_metric_names() -> None:
     assert summary[_phase2_metric("pro_accept_rate")] == pytest.approx(6 / 7)
     assert summary[_phase2_metric("rest_api_set_match_rate")] == pytest.approx(4 / 7)
     assert summary[_phase2_metric("empty_set_match_rate")] == pytest.approx(2 / 3)
+    assert summary[_phase2_metric("empty_set_expected_total")] == 3
     assert summary[_phase2_metric("sample_width", "k")] == 3
     assert summary[_phase2_metric("vendor", "source_corpus")] == "vendor:corpus"
     assert summary[_phase2_metric("prompt_spec_version")] == "spec-v1"
@@ -889,6 +920,7 @@ def test_phase2_labelled_request_wandb_keys_have_required_namespace_shape() -> N
         phase_metric(PHASE2_LABELLED_REQUESTS, "pro_accept_rate"),
         phase_metric(PHASE2_LABELLED_REQUESTS, "rest_api_set_match_rate"),
         phase_metric(PHASE2_LABELLED_REQUESTS, "empty_set_match_rate"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "empty_set_expected_total"),
         phase_metric(PHASE2_LABELLED_REQUESTS, "sample_width", "k"),
         phase_metric(PHASE2_LABELLED_REQUESTS, "vendor", "source_corpus"),
         phase_metric(PHASE2_LABELLED_REQUESTS, "prompt_spec_version"),

--- a/tests/ds/test_phase2_labelled_requests.py
+++ b/tests/ds/test_phase2_labelled_requests.py
@@ -121,6 +121,7 @@ wandb:
     - phase2_labelled_requests/pro_accept_rate
     - phase2_labelled_requests/rest_api_set_match_rate
     - phase2_labelled_requests/empty_set_match_rate
+    - phase2_labelled_requests/empty_set_expected_total
     - phase2_labelled_requests/sample_width/k
     - phase2_labelled_requests/vendor/source_corpus
     - phase2_labelled_requests/prompt_spec_version
@@ -572,6 +573,34 @@ def test_pro_judge_result_parsing_accepts_plain_and_wrapped_json() -> None:
     assert "not a mapping" in non_object.reason
 
 
+def test_pro_judge_result_parsing_requires_nonsense_boolean() -> None:
+    """Judge output must carry an explicit nonsense verdict."""
+    missing = parse_pro_judge_result(
+        json.dumps({
+            "accepted": True,
+            "rest_api_list": ["/redfish/v1/Systems/1"],
+        }),
+    )
+    assert missing.accepted is False
+    assert missing.invalid_json is True
+    assert "nonsense" in missing.reason
+
+
+def test_pro_judge_result_parsing_rejects_unknown_order_evidence() -> None:
+    """Order evidence is a controlled enum, not arbitrary judge text."""
+    result = parse_pro_judge_result(
+        json.dumps({
+            "accepted": True,
+            "rest_api_list": ["/redfish/v1/Systems/1"],
+            "nonsense": False,
+            "order_evidence": "maybe_later",
+        }),
+    )
+    assert result.accepted is False
+    assert result.invalid_json is True
+    assert "order_evidence" in result.reason
+
+
 def test_pro_judge_result_parsing_accepts_rest_api_set_alias() -> None:
     """The parser accepts the judge's legacy rest_api_set alias."""
     result = parse_pro_judge_result(
@@ -829,6 +858,7 @@ def test_counters_track_nonsense_invalid_json_and_empty_set_matches() -> None:
     assert summary[_phase2_metric("pro_accept_rate")] == pytest.approx(1 / 3)
     assert summary[_phase2_metric("rest_api_set_match_rate")] == pytest.approx(1 / 3)
     assert summary[_phase2_metric("empty_set_match_rate")] == 1.0
+    assert summary[_phase2_metric("empty_set_expected_total")] == 1
 
 
 def test_counter_summary_binds_semantic_metric_names() -> None:
@@ -861,6 +891,7 @@ def test_counter_summary_binds_semantic_metric_names() -> None:
     assert summary[_phase2_metric("pro_accept_rate")] == pytest.approx(6 / 7)
     assert summary[_phase2_metric("rest_api_set_match_rate")] == pytest.approx(4 / 7)
     assert summary[_phase2_metric("empty_set_match_rate")] == pytest.approx(2 / 3)
+    assert summary[_phase2_metric("empty_set_expected_total")] == 3
     assert summary[_phase2_metric("sample_width", "k")] == 3
     assert summary[_phase2_metric("vendor", "source_corpus")] == "vendor:corpus"
     assert summary[_phase2_metric("prompt_spec_version")] == "spec-v1"
@@ -901,6 +932,7 @@ def test_phase2_labelled_request_wandb_keys_have_required_namespace_shape() -> N
         phase_metric(PHASE2_LABELLED_REQUESTS, "pro_accept_rate"),
         phase_metric(PHASE2_LABELLED_REQUESTS, "rest_api_set_match_rate"),
         phase_metric(PHASE2_LABELLED_REQUESTS, "empty_set_match_rate"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "empty_set_expected_total"),
         phase_metric(PHASE2_LABELLED_REQUESTS, "sample_width", "k"),
         phase_metric(PHASE2_LABELLED_REQUESTS, "vendor", "source_corpus"),
         phase_metric(PHASE2_LABELLED_REQUESTS, "prompt_spec_version"),

--- a/tests/ds/test_phase2_labelled_requests.py
+++ b/tests/ds/test_phase2_labelled_requests.py
@@ -365,6 +365,18 @@ def test_spec_loader_rejects_malformed_phase2_specs(tmp_path: Path) -> None:
     with pytest.raises(Phase2LabelledRequestsSpecError, match="unknown_field"):
         load_phase2_labelled_requests_spec(unknown_judge_prompt_field)
 
+    malformed_model_prompt_field = _write_spec(tmp_path / "malformed-model-prompt-field.yaml")
+    malformed_model_prompt_field.write_text(
+        malformed_model_prompt_field.read_text(encoding="utf-8").replace(
+            "      {records_json}",
+            "      {records_json",
+            1,
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(Phase2LabelledRequestsSpecError, match="malformed format fields"):
+        load_phase2_labelled_requests_spec(malformed_model_prompt_field)
+
     malformed_generation = _write_spec(tmp_path / "malformed-generation.yaml")
     malformed_generation.write_text(
         malformed_generation.read_text(encoding="utf-8").replace(

--- a/tests/ds/test_phase2_labelled_requests.py
+++ b/tests/ds/test_phase2_labelled_requests.py
@@ -378,6 +378,18 @@ def test_spec_loader_rejects_malformed_phase2_specs(tmp_path: Path) -> None:
     with pytest.raises(Phase2LabelledRequestsSpecError, match="malformed format fields"):
         load_phase2_labelled_requests_spec(malformed_model_prompt_field)
 
+    unnamed_model_prompt_field = _write_spec(tmp_path / "unnamed-model-prompt-field.yaml")
+    unnamed_model_prompt_field.write_text(
+        unnamed_model_prompt_field.read_text(encoding="utf-8").replace(
+            "      {records_json}",
+            "      {records_json}\n      {}",
+            1,
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(Phase2LabelledRequestsSpecError, match="unnamed format fields"):
+        load_phase2_labelled_requests_spec(unnamed_model_prompt_field)
+
     malformed_generation = _write_spec(tmp_path / "malformed-generation.yaml")
     malformed_generation.write_text(
         malformed_generation.read_text(encoding="utf-8").replace(
@@ -584,6 +596,31 @@ def test_pro_judge_result_parsing_requires_nonsense_boolean() -> None:
     assert missing.accepted is False
     assert missing.invalid_json is True
     assert "nonsense" in missing.reason
+
+
+def test_pro_judge_result_parsing_requires_accepted_boolean() -> None:
+    """Judge output must carry an explicit accepted verdict."""
+    missing = parse_pro_judge_result(
+        json.dumps({
+            "rest_api_list": ["/redfish/v1/Systems/1"],
+            "nonsense": False,
+        }),
+    )
+    assert missing.accepted is False
+    assert missing.invalid_json is True
+    assert "accepted or accept" in missing.reason
+
+    malformed = parse_pro_judge_result(
+        json.dumps({
+            "accepted": "yes",
+            "rest_api_list": ["/redfish/v1/Systems/1"],
+            "nonsense": False,
+        }),
+    )
+    assert malformed.accepted is False
+    assert malformed.invalid_json is True
+    assert "accepted" in malformed.reason
+    assert "boolean" in malformed.reason
 
 
 def test_pro_judge_result_parsing_rejects_unknown_order_evidence() -> None:

--- a/tests/ds/test_phase2_labelled_requests.py
+++ b/tests/ds/test_phase2_labelled_requests.py
@@ -480,6 +480,19 @@ def test_prompt_rendering_uses_yaml_templates_not_runtime_literals(tmp_path: Pat
         assert literal not in lowercase_runtime_sources
 
 
+def test_prompt_templates_reject_unnamed_placeholders(tmp_path: Path) -> None:
+    """Spec load fails closed for unnamed format slots such as ``{}``."""
+    spec_path = _write_spec(tmp_path / "phase2.yaml")
+    spec_text = spec_path.read_text(encoding="utf-8")
+    spec_path.write_text(
+        spec_text.replace("{records_json}", "{}"),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(Phase2LabelledRequestsSpecError, match="unnamed format"):
+        load_phase2_labelled_requests_spec(spec_path)
+
+
 def test_sampling_accepts_only_k_1_2_3_and_preserves_record_payloads() -> None:
     """The builder samples one, two, or three REST records with deterministic RNG."""
     records = tuple(_record(index) for index in range(5))

--- a/tests/ds/test_phase2_labelled_requests.py
+++ b/tests/ds/test_phase2_labelled_requests.py
@@ -11,6 +11,7 @@ Mus mbayramo@stanford.edu
 
 from __future__ import annotations
 
+import ast
 import json
 import random
 from pathlib import Path
@@ -418,6 +419,23 @@ def test_committed_phase2_labelled_requests_config_loads() -> None:
     assert spec.judge_provider.payload_request_fields == ("route", "profile")
 
 
+def test_committed_phase2_labelled_requests_prompts_render_from_yaml() -> None:
+    """The checked-in prompt spec renders without leaving template placeholders."""
+    spec = load_phase2_labelled_requests_spec("configs/phase2_labelled_requests.yaml")
+    records = (_record(1), _record(2))
+
+    model_prompt = render_model_x_prompt(spec, records)
+    judge_prompt = render_pro_judge_prompt(spec, records, "show both fixture systems")
+
+    assert spec.model_x_system in model_prompt
+    assert spec.judge_system in judge_prompt
+    assert "/redfish/v1/Systems/1" in model_prompt
+    assert "/redfish/v1/Systems/2" in judge_prompt
+    assert "show both fixture systems" in judge_prompt
+    assert "{records_json}" not in model_prompt
+    assert "{draft_text}" not in judge_prompt
+
+
 def test_prompt_rendering_uses_yaml_templates_not_runtime_literals(tmp_path: Path) -> None:
     """Prompt text comes from the loaded spec and can be changed without code edits."""
     spec = load_phase2_labelled_requests_spec(_write_spec(tmp_path / "phase2.yaml"))
@@ -449,6 +467,16 @@ def test_prompt_rendering_uses_yaml_templates_not_runtime_literals(tmp_path: Pat
     )
     for literal in forbidden_literals:
         assert literal not in runtime_sources
+
+    lowercase_runtime_sources = runtime_sources.lower()
+    forbidden_lowercase_literals = (
+        "phase2 test model-x system prompt from yaml",
+        "qwen/qwen2.5",
+        "deepseek-v4",
+        "return json with accepted",
+    )
+    for literal in forbidden_lowercase_literals:
+        assert literal not in lowercase_runtime_sources
 
 
 def test_sampling_accepts_only_k_1_2_3_and_preserves_record_payloads() -> None:
@@ -738,6 +766,31 @@ def test_builder_returns_none_and_counts_rejection_on_set_mismatch(tmp_path: Pat
     assert summary[_phase2_metric("rest_api_set_match_rate")] == 0.0
 
 
+def test_builder_rejects_accepted_nonsense_even_when_set_matches(tmp_path: Path) -> None:
+    """A contradictory judge response cannot enter accepted labelled requests."""
+    spec = load_phase2_labelled_requests_spec(_write_spec(tmp_path / "phase2.yaml"))
+    builder = Phase2LabelledRequestBuilder(
+        spec,
+        draft_provider=lambda request: "???",
+        judge_provider=lambda request: _judge_json(
+            accepted=True,
+            rest_api_list=request["expected_rest_api_list"],
+            nonsense=True,
+        ),
+    )
+
+    row, counters = builder.build_one((_record(1),), k=1, rng=random.Random(1))
+    summary = counters.summary()
+
+    assert row is None
+    assert summary[_phase2_metric("draft_total")] == 1
+    assert summary[_phase2_metric("accepted_total")] == 0
+    assert summary[_phase2_metric("rejected_total")] == 1
+    assert summary[_phase2_metric("nonsense_rate")] == 1.0
+    assert summary[_phase2_metric("pro_accept_rate")] == 1.0
+    assert summary[_phase2_metric("rest_api_set_match_rate")] == 1.0
+
+
 def test_counters_track_nonsense_invalid_json_and_empty_set_matches() -> None:
     """Counters expose the generation-quality metrics required for W&B."""
     counters = Phase2LabelledRequestCounters()
@@ -874,6 +927,25 @@ def test_minimal_phase3_fixture_rejects_missing_phase2_row() -> None:
     """Phase 3 compatibility helpers fail before fabricating labels."""
     with pytest.raises(ValueError, match="phase2 row is required"):
         to_minimal_phase3_input(None)
+
+
+def test_phase2_module_does_not_import_phase3_argument_runtime() -> None:
+    """The labelled-request builder stays independent from Phase 3 call logic."""
+    source = Path("igc/ds/phase2_labelled_requests.py").read_text(encoding="utf-8")
+    module = ast.parse(source)
+    imported_modules: set[str] = set()
+    imported_names: set[str] = set()
+    for node in ast.walk(module):
+        if isinstance(node, ast.Import):
+            imported_modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                imported_modules.add(node.module)
+            imported_names.update(alias.name for alias in node.names)
+
+    assert "igc.ds.rest_goal_contract" not in imported_modules
+    assert "build_ordered_call_row" not in imported_names
+    assert "parse_ordered_calls_y_pred" not in imported_names
 
 
 # Author: Mus mbayramo@stanford.edu

--- a/tests/ds/test_phase2_labelled_requests.py
+++ b/tests/ds/test_phase2_labelled_requests.py
@@ -340,6 +340,30 @@ def test_spec_loader_rejects_malformed_phase2_specs(tmp_path: Path) -> None:
     with pytest.raises(Phase2LabelledRequestsSpecError, match="model_x_draft"):
         load_phase2_labelled_requests_spec(missing_prompt_section)
 
+    missing_model_prompt_field = _write_spec(tmp_path / "missing-model-prompt-field.yaml")
+    missing_model_prompt_field.write_text(
+        missing_model_prompt_field.read_text(encoding="utf-8").replace(
+            "      {records_json}",
+            "      no record placeholder",
+            1,
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(Phase2LabelledRequestsSpecError, match="records_json"):
+        load_phase2_labelled_requests_spec(missing_model_prompt_field)
+
+    unknown_judge_prompt_field = _write_spec(tmp_path / "unknown-judge-prompt-field.yaml")
+    unknown_judge_prompt_field.write_text(
+        unknown_judge_prompt_field.read_text(encoding="utf-8").replace(
+            "      {draft_text}",
+            "      {draft_text}\n      {unknown_field}",
+            1,
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(Phase2LabelledRequestsSpecError, match="unknown_field"):
+        load_phase2_labelled_requests_spec(unknown_judge_prompt_field)
+
     malformed_generation = _write_spec(tmp_path / "malformed-generation.yaml")
     malformed_generation.write_text(
         malformed_generation.read_text(encoding="utf-8").replace(

--- a/tests/modules/test_phase2_labelled_request_metric_keys.py
+++ b/tests/modules/test_phase2_labelled_request_metric_keys.py
@@ -21,6 +21,7 @@ def test_phase2_labelled_request_registry_keeps_required_metric_names() -> None:
         phase_metric(PHASE2_LABELLED_REQUESTS, "pro_accept_rate"),
         phase_metric(PHASE2_LABELLED_REQUESTS, "rest_api_set_match_rate"),
         phase_metric(PHASE2_LABELLED_REQUESTS, "empty_set_match_rate"),
+        phase_metric(PHASE2_LABELLED_REQUESTS, "empty_set_expected_total"),
         phase_metric(PHASE2_LABELLED_REQUESTS, "sample_width", "k"),
         phase_metric(PHASE2_LABELLED_REQUESTS, "vendor", "source_corpus"),
         phase_metric(PHASE2_LABELLED_REQUESTS, "prompt_spec_version"),

--- a/tests/scripts/test_phase2_labelled_requests_cli.py
+++ b/tests/scripts/test_phase2_labelled_requests_cli.py
@@ -125,6 +125,10 @@ def test_cli_mock_mode_writes_accepted_jsonl_and_metrics(
     assert metrics[_metric("sample_width", "k")] == 3
     assert metrics[_metric("vendor", "source_corpus")] == "fixture_vendor:fixture_corpus"
     assert metrics["thresholds_pass"] is True
+    assert all(
+        not key.startswith("phase2_goal_extraction/")
+        for key in metrics
+    )
 
 
 @pytest.mark.parametrize("sample_width", (1, 2, 3))
@@ -431,6 +435,43 @@ def test_cli_live_override_requires_live_provider_config(tmp_path: Path) -> None
                 "openai-compatible",
             ],
         )
+
+
+def test_openai_compatible_provider_requires_env_placeholders() -> None:
+    """Live providers fail closed instead of falling back to hardcoded models."""
+    script = _load_script()
+    config = script.ProviderAdapterSpec(
+        adapter="openai-compatible",
+        base_url_env="PHASE2_MODEL_X_BASE_URL",
+        endpoint_path="/v1/chat/completions",
+        response_text_path="choices.0.message.content",
+    )
+    provider = script._OpenAICompatibleChatProvider(
+        config,
+        label="draft",
+        env={},
+        transport=lambda *_args: {},
+    )
+
+    with pytest.raises(SystemExit, match="PHASE2_MODEL_X_BASE_URL"):
+        provider({
+            "prompt": "offline prompt",
+            "model_id": "${PHASE1_MODEL_X_MODEL_ID}",
+            "generation": {},
+        })
+
+    provider = script._OpenAICompatibleChatProvider(
+        config,
+        label="draft",
+        env={"PHASE2_MODEL_X_BASE_URL": "http://model.invalid"},
+        transport=lambda *_args: {},
+    )
+    with pytest.raises(SystemExit, match="PHASE1_MODEL_X_MODEL_ID"):
+        provider({
+            "prompt": "offline prompt",
+            "model_id": "${PHASE1_MODEL_X_MODEL_ID}",
+            "generation": {},
+        })
 
 
 def test_cli_rejects_mismatch_nonsense_and_invalid_judge_json(tmp_path: Path) -> None:


### PR DESCRIPTION
Phase 2 labelled-request follow-ups on top of the #117 lineage:

- **Prompt placeholder validation**: reject unnamed `{}` placeholders in YAML prompt templates (`igc/ds/phase2_labelled_requests.py`) with a focused regression, plus committed-YAML prompt rendering checks.
- **Stricter Pro-judge parsing**: explicit `accepted` boolean validation; missing `nonsense` and unknown `order_evidence` values are rejected instead of silently defaulted.
- **Observable denominator metric**: `phase2_labelled_requests/empty_set_expected_total` added to the metric registry so empty-set accuracy has a visible denominator.
- **Guard coverage**: live-provider env fail-closed coverage and Phase 3 import-boundary coverage in the Phase 2 test set.
- **Docs (CQ-P2-ENV-DOCS)**: `docs/phase_2.md` now names the four provider env vars the live launch needs (`PHASE2_MODEL_X_BASE_URL`, `PHASE2_MODEL_X_API_KEY`, `PHASE2_JUDGE_BASE_URL`, `PHASE2_JUDGE_API_KEY`), each with its source: the `providers:` block in `configs/phase2_labelled_requests.yaml` (`base_url_env`/`api_key_env`), resolved in `igc/ds/phase2_labelled_requests.py`.

Validation: slot11 CPU-only container `igc-dev-phase2-labelled-requests` at merge tip `09bf8a1` passed `git diff --check origin/main...HEAD`, `scripts/validate_phase2_labelled_requests.sh` (60 passed), and Ruff on the touched Python set.