### PR TITLE
Add Phase 1-3 contract and artifact gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,8 +140,20 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
+          # testpaths=tests + norecursedirs (pytest.ini) means tests/gates/* — including
+          # the offline inference-envelope layer — is discovered here automatically; the
+          # @pytest.mark.gpu envelope stage stays excluded by pytest.ini addopts.
           KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1 \
             python -m pytest -q --cov=igc --cov-report=term --cov-report=xml --cov-report=json
+      - name: Contract-authority gate
+        shell: bash
+        run: |
+          set -o pipefail
+          # Composes the single-source + schema-snapshot gates with the offline
+          # contract/output/envelope tests and writes a sanitized JSON report.
+          # Exits non-zero if any check FAILED (schema-snapshot bootstrap is not a failure).
+          KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1 \
+            python scripts/gates/contract_authority.py
       - name: Metrics snapshot
         shell: bash
         run: |
@@ -155,6 +167,8 @@ jobs:
             coverage.xml
             coverage.json
             metrics.json
+            reports/gate-report-contract-authority.json
+            reports/gate-report-phase123-conformance.json
           retention-days: 90
 
   perf:

--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,5 @@ slurm-*.out
 coverage.json
 coverage.xml
 metrics.json
+reports/gate-report*.json
+.phase123-conformance-tmp/

--- a/configs/artifacts/model_cache.yaml
+++ b/configs/artifacts/model_cache.yaml
@@ -1,0 +1,30 @@
+version: 1
+name: igc-model-artifact-cache
+default_root: /Volumes/k8s-sata-stripe/igc
+
+models:
+  - role: model_x
+    phase: phase1
+    run_id: phase1-finetune-qwen2_5-7b-rslora-slot2-689b4c7
+    lfs_ref: origin/data/model-x-phase1-adapter-20260715T1024Z
+    base_model:
+      id: Qwen/Qwen2.5-7B-Instruct
+      cache_subdir: models--Qwen--Qwen2.5-7B-Instruct
+    files:
+      - kind: weight
+        source_path: models/model_x/phase1-finetune-qwen2_5-7b-rslora-slot2-689b4c7/adapter_model.safetensors
+        dest: artifacts/adapter_model.safetensors
+        lfs: true
+        sha256: 98243e5a7d5311bfac4856fa56684eea38327b5e3d4ab806d6b53f07a764d5e4
+        size_bytes: 323014168
+      - kind: report
+        source_path: models/model_x/phase1-finetune-qwen2_5-7b-rslora-slot2-689b4c7/report.json
+        dest: reports/report.json
+        sha256: e8f52ee23075ef848f36ff0b9ed7439d7efec23057e10bbedc667af9e2a95779
+      - kind: parameters
+        source_path: models/model_x/phase1-finetune-qwen2_5-7b-rslora-slot2-689b4c7/parameters.json
+        dest: reports/parameters.json
+        sha256: 7325ccc7729869c920d304f5e5dd82dcd16fb051b2130d548a88f4d77aa54113
+      - kind: checksum
+        source_path: models/model_x/phase1-finetune-qwen2_5-7b-rslora-slot2-689b4c7/SHA256SUMS.txt
+        dest: reports/SHA256SUMS.txt

--- a/configs/contracts/rest_goal.yaml
+++ b/configs/contracts/rest_goal.yaml
@@ -1,0 +1,41 @@
+version: 1
+name: rest-goal-contract-authority
+
+canonical_module: igc/ds/rest_goal_contract.py
+
+scan_paths:
+  - igc
+  - scripts
+  - tests
+  - configs
+  - docs
+
+file_suffixes:
+  - .py
+  - .yaml
+  - .yml
+  - .md
+
+allow_paths:
+  - configs/contracts/rest_goal.yaml
+  - docs/gates.md
+  - scripts/gates/contract_single_source.py
+  - tests/gates/test_contract_single_source.py
+
+required_symbols:
+  - RedfishContext
+  - TargetCall
+  - build_d1_rest_api_list_row
+  - build_ordered_call_row
+  - render_rest_api_list_example
+  - render_ordered_call_example
+  - parse_rest_api_list_y_pred
+  - parse_ordered_calls_y_pred
+  - evaluate_ordered_calls_y_pred
+  - inference_target_calls_json
+
+forbidden_regex:
+  - "\\bmock_inference_contract\\b"
+  - "\\bphase23_mock\\b"
+  - "[\"']phase2_goal_extract[\"']"
+  - "[\"']phase3_argument_extract[\"']"

--- a/docs/gates.md
+++ b/docs/gates.md
@@ -1,0 +1,109 @@
+# Contract-authority gate (Phase 2/3 REST-goal)
+
+The **contract-authority gate** protects the single canonical Phase 2/3 REST-goal
+contract — the module `igc/ds/rest_goal_contract.py`, which owns the row shape,
+the prompt/target renderers, and the parse/eval used to score model output.
+
+It exists because a green *per-module* test suite is not enough: a past change
+shipped a parallel contract module with a forked metric namespace, and its own
+isolated tests were green, so the fork slipped through. The gates below are
+**repo-level** — they scan the whole live package and freeze the approved JSON
+shape — so that class of drift fails loudly.
+
+The runner is `scripts/gates/contract_authority.py`. It composes the checks and
+writes a sanitized JSON report to `reports/gate-report-contract-authority.json`.
+
+## Checks
+
+| Check | Source | What it proves | Failure behavior |
+| --- | --- | --- | --- |
+| `repo.contract-single-source` | `scripts/gates/contract_single_source.py` + `configs/contracts/rest_goal.yaml` | One canonical contract module; no forked namespace tokens and no canonical symbol defined in a second module (no parallel island). | **fail** (blocks) on any forked token or parallel definition. |
+| `repo.schema-snapshot` | `scripts/gates/schema_snapshot.py` + `schemas/snapshots/rest_goal_contract.shape.json` | The approved Phase 2/3 row *shape* (field names, nesting, value types — never values) has not drifted. | **fail** on drift; **bootstrap** (not a failure) until the snapshot is first committed with `--update`. |
+| `offline.contract-tests` | `tests/ds/test_rest_goal_contract.py` | The canonical row builders, renderers, parsers, and evaluators behave as specified. | **fail** on any red test. |
+| `offline.gate-tests` | `tests/gates/` | The gate self-tests plus the **inference-envelope** deterministic exact-match layer (`tests/gates/test_inference_envelope.py`). | **fail** on any red test. |
+| `offline.phase123-conformance` | `scripts/gates/phase123_conformance.py` | A tiny deterministic row walks from Phase 1 render/token tensors through D1 judging, Phase 2 parse/set metrics, and Phase 3 `target_calls`. | **fail** on any key/shape/envelope drift. |
+
+All five checks run **offline** — no GPU, no network, no HuggingFace download, no
+live Redfish host. Real-model behavior is checked only by the envelope test's
+`@pytest.mark.gpu` stage, which the offline pytest run excludes.
+
+## Artifact Cache Gates
+
+The model-artifact cache tooling keeps run outputs under one operator-selected
+root, with a default of `/Volumes/k8s-sata-stripe/igc` from
+`configs/artifacts/model_cache.yaml`. The structure is:
+
+```text
+<root>/
+  base_models/<hf-cache-subdir>/                  # original base model, once
+  phases/<phase>/<role>/runs/<run_id>/
+    artifacts/adapter_model.safetensors
+    reports/{report.json,parameters.json,SHA256SUMS.txt}
+  cache_manifest.json
+```
+
+Use the cache scripts on an approved Kubernetes/remote container, not as laptop
+validation:
+
+```bash
+python scripts/gates/model_artifact_cache.py plan --root /Volumes/k8s-sata-stripe/igc
+python scripts/gates/model_artifact_cache.py init --root /Volumes/k8s-sata-stripe/igc
+python scripts/gates/model_artifact_cache.py materialize \
+  --download-lfs \
+  --base-source-root /models/hf-cache/hub \
+  --root /Volumes/k8s-sata-stripe/igc
+python scripts/gates/model_artifact_cache.py verify --require-base-model --root /Volumes/k8s-sata-stripe/igc
+python scripts/gates/model_artifact_load_gate.py --root /Volumes/k8s-sata-stripe/igc
+```
+
+`model_artifact_load_gate.py` always verifies report JSON and adapter tensor
+keys/shapes. The heavier `--load-cpu` mode loads base + adapter locally from the
+shared cache and refuses laptop execution unless a tiny fixture test explicitly
+uses `--allow-local-fixture`.
+
+## Profiles
+
+- **Offline profile (default, required on every Phase 2/3 PR).** All five checks
+  above. Runs in CI and in an approved remote container. This is the profile that
+  must produce observed output for a PR.
+- **Envelope/GPU profile (opt-in).** The real-model/vLLM
+  stage in `tests/gates/test_inference_envelope.py`
+  (`test_phase2_model_response_envelope_only`) loads an approved Phase 2
+  checkpoint and checks only the response **envelope** — model loadability,
+  request/response keys present, JSON parse succeeds, output shape — never
+  stochastic answer quality. It skips unless a GPU and `IGC_ENVELOPE_MODEL_DIR`
+  are both present. It runs only inside an approved remote container, never on
+  the operator laptop.
+
+## Execution surface
+
+The runner is intended for **CI** (`.github/workflows/ci.yml` gate job) or an
+**approved remote/container validation surface**. It performs no GPU work itself and does
+no laptop detection; the execution surface is enforced by where it is invoked. The
+report is sanitized (check names, statuses, return codes, and a scrubbed
+one-line summary only — no IPs, hostnames, tokens, or file bodies).
+
+## Running it
+
+```bash
+python scripts/gates/contract_authority.py
+# writes reports/gate-report-contract-authority.json and
+# reports/gate-report-phase123-conformance.json; exits non-zero if any check FAILED
+```
+
+The first time, generate and commit the schema snapshot on an approved surface so
+`repo.schema-snapshot` moves from `bootstrap` to `pass`:
+
+```bash
+python scripts/gates/schema_snapshot.py --update
+git add schemas/snapshots/rest_goal_contract.shape.json
+```
+
+## PR rule
+
+A **Phase 2 or Phase 3 PR** — anything touching the contract, dataset builders,
+renderers, parsers, evaluators, or their metric namespaces — **must include the
+observed contract-authority gate output** (the `overall: pass` report, or the
+console summary) in the PR body. If the gate cannot be run on an approved surface,
+the PR is marked **`BLOCKED:`** with the exact reason. A Phase 2/3 PR with no observed gate output and no
+`BLOCKED:` note is not accepted.

--- a/igc/ds/rest_goal_contract.py
+++ b/igc/ds/rest_goal_contract.py
@@ -472,4 +472,17 @@ def inference_ordered_goals_json(row: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def inference_target_calls_json(row: Mapping[str, Any]) -> dict[str, Any]:
+    """Build the current Phase 3 inference handoff using ``target_calls``.
+
+    :param row: row from :func:`build_ordered_call_row`.
+    :return: ``{"text": ..., "target_calls": [...]}``.
+    """
+
+    return {
+        "text": str(row["x"]["text"]),
+        "target_calls": list(row["y_true"]["calls"]),
+    }
+
+
 # Author: Mus mbayramo@stanford.edu

--- a/schemas/snapshots/rest_goal_contract.shape.json
+++ b/schemas/snapshots/rest_goal_contract.shape.json
@@ -1,0 +1,105 @@
+{
+  "phase2_rendered": {
+    "prompt": "str",
+    "target_char_start": "int",
+    "target_json": "str"
+  },
+  "phase2_row": {
+    "dataset": "str",
+    "model_x": "str",
+    "phase": "int",
+    "source_dataset": "str",
+    "task": "str",
+    "validation": {
+      "all_rest_api_present": "bool",
+      "extra_rest_api_present": "bool",
+      "order_preserved": "bool",
+      "review_judged": "bool",
+      "text_source": "str"
+    },
+    "x": {
+      "allowed_methods": {
+        "/redfish/v1/Managers/1/EthernetInterfaces/1": [
+          "str"
+        ],
+        "/redfish/v1/Systems/1": [
+          "str"
+        ]
+      },
+      "json": [
+        {
+          "@odata.id": "str",
+          "PowerState": "str"
+        }
+      ],
+      "text": "str"
+    },
+    "y_true": {
+      "order_evidence": "str",
+      "rest_api_list": [
+        "str"
+      ]
+    }
+  },
+  "phase3_inference": {
+    "target_calls": [
+      {
+        "allowed_methods": [
+          "str"
+        ],
+        "arguments": {
+          "Address": "str"
+        },
+        "method": "str",
+        "rest_api": "str"
+      }
+    ],
+    "text": "str"
+  },
+  "phase3_rendered": {
+    "prompt": "str",
+    "target_char_start": "int",
+    "target_json": "str"
+  },
+  "phase3_row": {
+    "model_x": "str",
+    "phase": "int",
+    "source_dataset": "str",
+    "task": "str",
+    "x": {
+      "allowed_methods": {
+        "/redfish/v1/Managers/1/EthernetInterfaces/1": [
+          "str"
+        ],
+        "/redfish/v1/Systems/1": [
+          "str"
+        ]
+      },
+      "json": [
+        {
+          "@odata.id": "str",
+          "PowerState": "str"
+        }
+      ],
+      "rest_api_list": [
+        "str"
+      ],
+      "text": "str"
+    },
+    "y_true": {
+      "calls": [
+        {
+          "allowed_methods": [
+            "str"
+          ],
+          "arguments": {
+            "Address": "str"
+          },
+          "method": "str",
+          "rest_api": "str"
+        }
+      ]
+    }
+  },
+  "schema": "igc.rest_goal_contract.shape.v1"
+}

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository scripts import namespace for gate self-tests."""

--- a/scripts/gates/__init__.py
+++ b/scripts/gates/__init__.py
@@ -1,0 +1,1 @@
+"""Contract and artifact gate helpers."""

--- a/scripts/gates/contract_authority.py
+++ b/scripts/gates/contract_authority.py
@@ -1,0 +1,242 @@
+"""Gate runner: repo.contract-authority — one command that proves the Phase 2/3 contract.
+
+This runner is the single entry point a Phase 2/3 PR (or CI) invokes to produce the
+observable gate evidence required before that PR can be accepted. It composes the
+existing repo-level gates and the offline contract/output/envelope tests into one
+sanitized JSON report:
+
+* ``repo.contract-single-source`` — one canonical contract module, no forked
+  namespaces, no parallel islands (``scripts/gates/contract_single_source.py``).
+* ``repo.schema-snapshot`` — the approved Phase 2/3 row schema has not drifted
+  (``scripts/gates/schema_snapshot.py``); reports ``bootstrap`` until the snapshot
+  is committed, which is not a failure.
+* ``offline.contract-tests`` — the canonical contract row/parse/eval tests
+  (``tests/ds/test_rest_goal_contract.py``).
+* ``offline.gate-tests`` — the repo-gate + inference-envelope tests
+  (``tests/gates/``), including the deterministic exact-match envelope layer.
+* ``offline.phase123-conformance`` — a deterministic Phase 1 -> D1 -> Phase 2
+  -> Phase 3 key/shape/output walk, with fixture model and judge responses.
+
+It writes ``reports/gate-report-contract-authority.json`` with a pass/fail (or
+``bootstrap``) status per check and an overall verdict. The report is SANITIZED:
+it carries only check names, statuses, return codes, and a scrubbed one-line
+summary — never IPs, hostnames, tokens, file bodies, or environment values. The
+exit code is non-zero if any check FAILED (``bootstrap`` does not fail the run).
+
+Execution surface (requirement 5). This runner is intended for CI
+(``.github/workflows/ci.yml`` gate job) or an approved remote/container
+container — NOT the operator laptop, per the standing test-execution guard. It
+does no host detection and adds no laptop-refusal logic on purpose: the surface
+is enforced by where it is invoked (CI / approved container), and any real-model
+step lives behind the ``@pytest.mark.gpu`` marker that the offline pytest run
+excludes, so this runner performs no GPU work itself.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_REPORT = "reports/gate-report-contract-authority.json"
+DEFAULT_REGISTRY = "configs/contracts/rest_goal.yaml"
+DEFAULT_SNAPSHOT = "schemas/snapshots/rest_goal_contract.shape.json"
+
+# Offline pytest targets composed into the authority gate. Kept relative so the
+# report never leaks an absolute checkout path.
+_CONTRACT_TEST_TARGETS = ("tests/ds/test_rest_goal_contract.py",)
+_GATE_TEST_TARGETS = ("tests/gates",)
+_PHASE123_REPORT = "reports/gate-report-phase123-conformance.json"
+
+# Redact IPv4 addresses so a scrubbed pytest summary can never leak an endpoint.
+_IPV4_RE = re.compile(r"\b\d{1,3}(?:\.\d{1,3}){3}\b")
+
+
+def _load_gate(name: str, relpath: str) -> Any:
+    """Load a sibling gate script (not an installed package) by file path.
+
+    :param name: module name to register the loaded script under.
+    :param relpath: repo-relative path to the gate script.
+    :return: the loaded module object.
+    """
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / relpath)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load gate script: {relpath}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _sanitize(text: str, limit: int = 200) -> str:
+    """Reduce arbitrary tool output to a short, IP-free, single-line summary.
+
+    :param text: raw stdout/stderr from a check.
+    :param limit: maximum characters to retain.
+    :return: a scrubbed one-line summary safe to commit/log.
+    """
+    # Prefer the pytest result line (e.g. "5 passed in 0.12s") when present.
+    summary = ""
+    for line in reversed(text.strip().splitlines()):
+        stripped = line.strip().strip("= ")
+        if stripped:
+            summary = stripped
+            break
+    summary = _IPV4_RE.sub("[redacted-ip]", summary)
+    summary = " ".join(summary.split())
+    return summary[:limit]
+
+
+def _run_single_source(registry: Path) -> dict[str, Any]:
+    """Run ``repo.contract-single-source`` in-process and record its verdict."""
+    css = _load_gate("contract_single_source", "scripts/gates/contract_single_source.py")
+    try:
+        violations = css.check(registry, REPO_ROOT)
+    except (OSError, ValueError, SystemExit) as exc:
+        return {
+            "name": "repo.contract-single-source",
+            "status": "fail",
+            "detail": f"registry error: {_sanitize(str(exc))}",
+        }
+    if violations:
+        return {
+            "name": "repo.contract-single-source",
+            "status": "fail",
+            "detail": f"{len(violations)} violation(s); first: {_sanitize(violations[0])}",
+        }
+    return {"name": "repo.contract-single-source", "status": "pass", "detail": "one canonical contract"}
+
+
+def _run_schema_snapshot(snapshot: Path) -> dict[str, Any]:
+    """Run ``repo.schema-snapshot`` in-process; bootstrap is not a failure."""
+    ss = _load_gate("schema_snapshot", "scripts/gates/schema_snapshot.py")
+    try:
+        code = ss.check(snapshot)
+    except Exception as exc:  # noqa: BLE001 - gate converts any script failure into evidence.
+        return {
+            "name": "repo.schema-snapshot",
+            "status": "fail",
+            "detail": f"snapshot error: {_sanitize(str(exc))}",
+        }
+    if code == ss.EXIT_OK:
+        return {"name": "repo.schema-snapshot", "status": "pass", "detail": "schema matches snapshot"}
+    if code == ss.EXIT_BOOTSTRAP:
+        return {
+            "name": "repo.schema-snapshot",
+            "status": "bootstrap",
+            "detail": "snapshot not committed yet; run --update on an approved surface",
+        }
+    return {"name": "repo.schema-snapshot", "status": "fail", "detail": "schema drifted from snapshot"}
+
+
+def _run_pytest(name: str, targets: tuple[str, ...]) -> dict[str, Any]:
+    """Run an offline pytest subset in a child process and record its verdict.
+
+    :param name: report check name for this pytest subset.
+    :param targets: repo-relative pytest paths (gpu-marked tests stay excluded by
+        ``pytest.ini`` ``addopts``, so no GPU is touched here).
+    :return: check record with pass/fail status, return code, and scrubbed summary.
+    """
+    env = dict(os.environ)
+    env.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+    env.setdefault("OMP_NUM_THREADS", "1")
+    env.setdefault("TRANSFORMERS_OFFLINE", "1")
+    env.setdefault("HF_DATASETS_OFFLINE", "1")
+    completed = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", *targets],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    status = "pass" if completed.returncode == 0 else "fail"
+    summary = _sanitize(completed.stdout or completed.stderr)
+    return {
+        "name": name,
+        "status": status,
+        "returncode": completed.returncode,
+        "detail": summary,
+    }
+
+
+def _run_phase123_conformance() -> dict[str, Any]:
+    """Run the deterministic Phase 1->D1->Phase 2->Phase 3 conformance gate."""
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/gates/phase123_conformance.py",
+            "--report",
+            _PHASE123_REPORT,
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    return {
+        "name": "offline.phase123-conformance",
+        "status": "pass" if completed.returncode == 0 else "fail",
+        "returncode": completed.returncode,
+        "detail": _sanitize(completed.stdout or completed.stderr),
+    }
+
+
+def run(registry: Path, snapshot: Path) -> dict[str, Any]:
+    """Run every contract-authority check and assemble the report structure.
+
+    :param registry: path to the contract registry YAML.
+    :param snapshot: path to the committed schema-shape snapshot.
+    :return: report mapping with per-check records and an overall verdict.
+    """
+    checks = [
+        _run_single_source(registry),
+        _run_schema_snapshot(snapshot),
+        _run_pytest("offline.contract-tests", _CONTRACT_TEST_TARGETS),
+        _run_pytest("offline.gate-tests", _GATE_TEST_TARGETS),
+        _run_phase123_conformance(),
+    ]
+    failed = [c for c in checks if c["status"] == "fail"]
+    return {
+        "gate": "repo.contract-authority",
+        "overall": "fail" if failed else "pass",
+        "failed_count": len(failed),
+        "checks": checks,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the ``repo.contract-authority`` gate runner."""
+    parser = argparse.ArgumentParser(
+        description="Run the Phase 2/3 contract-authority gate and write a sanitized report."
+    )
+    parser.add_argument("--registry", default=DEFAULT_REGISTRY, help="Contract registry YAML (repo-relative).")
+    parser.add_argument("--snapshot", default=DEFAULT_SNAPSHOT, help="Schema-shape snapshot (repo-relative).")
+    parser.add_argument("--report", default=DEFAULT_REPORT, help="Sanitized JSON report output path (repo-relative).")
+    args = parser.parse_args(argv)
+
+    report = run(REPO_ROOT / args.registry, REPO_ROOT / args.snapshot)
+
+    report_path = REPO_ROOT / args.report
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    for check in report["checks"]:
+        print(f"[{check['status'].upper():9}] {check['name']}: {check.get('detail', '')}")
+    print(f"contract-authority: {report['overall'].upper()} (report: {args.report})")
+    return 1 if report["overall"] == "fail" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/scripts/gates/contract_single_source.py
+++ b/scripts/gates/contract_single_source.py
@@ -1,0 +1,178 @@
+"""Gate: only one canonical Phase 2/3 REST-goal contract exists.
+
+The gate reads ``configs/contracts/rest_goal.yaml`` and scans repo source/docs for
+parallel-contract fingerprints. It also verifies that the canonical symbols are
+defined only in ``igc/ds/rest_goal_contract.py``. This catches the class of
+mistake where a stale branch introduces a second contract module with green
+isolated tests.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_REGISTRY = REPO_ROOT / "configs/contracts/rest_goal.yaml"
+
+
+@dataclass(frozen=True)
+class Registry:
+    """Validated contract-authority registry."""
+
+    canonical_module: Path
+    scan_paths: tuple[Path, ...]
+    file_suffixes: tuple[str, ...]
+    allow_paths: frozenset[Path]
+    required_symbols: tuple[str, ...]
+    forbidden_regex: tuple[re.Pattern[str], ...]
+
+
+def _repo_rel(path: Path, root: Path) -> Path:
+    """Return a repo-relative path for diagnostics."""
+
+    return path.resolve().relative_to(root.resolve())
+
+
+def _load_registry(path: Path, root: Path) -> Registry:
+    """Load and validate the YAML registry."""
+
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("registry must be a mapping")
+    if payload.get("version") != 1:
+        raise ValueError("registry.version must be 1")
+
+    canonical = root / _required_str(payload, "canonical_module")
+    if not canonical.is_file():
+        raise ValueError(f"canonical module missing: {_repo_rel(canonical, root)}")
+
+    scan_paths = tuple(root / item for item in _required_str_list(payload, "scan_paths"))
+    suffixes = tuple(_required_str_list(payload, "file_suffixes"))
+    allow_paths = frozenset(Path(item) for item in _required_str_list(payload, "allow_paths"))
+    symbols = tuple(_required_str_list(payload, "required_symbols"))
+    patterns = tuple(re.compile(item) for item in _required_str_list(payload, "forbidden_regex"))
+
+    return Registry(
+        canonical_module=_repo_rel(canonical, root),
+        scan_paths=scan_paths,
+        file_suffixes=suffixes,
+        allow_paths=allow_paths,
+        required_symbols=symbols,
+        forbidden_regex=patterns,
+    )
+
+
+def _required_str(payload: dict[str, Any], key: str) -> str:
+    """Return a required string registry field."""
+
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"registry.{key} must be a non-empty string")
+    return value
+
+
+def _required_str_list(payload: dict[str, Any], key: str) -> list[str]:
+    """Return a required string-list registry field."""
+
+    value = payload.get(key)
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"registry.{key} must be a list[str]")
+    return value
+
+
+def _iter_scan_files(registry: Registry, root: Path) -> Iterable[Path]:
+    """Yield repo files covered by the registry scan."""
+
+    for raw_path in registry.scan_paths:
+        if not raw_path.exists():
+            continue
+        if raw_path.is_file():
+            if raw_path.suffix in registry.file_suffixes:
+                yield raw_path
+            continue
+        for child in sorted(raw_path.rglob("*")):
+            if child.is_file() and child.suffix in registry.file_suffixes:
+                rel = _repo_rel(child, root)
+                if _is_generated_or_private(rel):
+                    continue
+                yield child
+
+
+def _is_generated_or_private(rel: Path) -> bool:
+    """Skip local-only or generated material that must never be public evidence."""
+
+    parts = rel.parts
+    return (
+        ".git" in parts
+        or ".codex" in parts
+        or ".claude" in parts
+        or ".internal" in parts
+        or parts[:2] == ("docs", "internal")
+        or parts[:1] == ("reports",)
+    )
+
+
+def _definition_pattern(symbol: str) -> re.Pattern[str]:
+    """Return a pattern for top-level class/function definitions."""
+
+    return re.compile(rf"^(?:class|def)\s+{re.escape(symbol)}\b", re.MULTILINE)
+
+
+def check(registry_path: Path = DEFAULT_REGISTRY, root: Path = REPO_ROOT) -> list[str]:
+    """Return contract-authority violations; an empty list is a pass."""
+
+    registry = _load_registry(registry_path, root)
+    violations: list[str] = []
+    definitions: dict[str, list[Path]] = {symbol: [] for symbol in registry.required_symbols}
+
+    for path in _iter_scan_files(registry, root):
+        rel = _repo_rel(path, root)
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if rel not in registry.allow_paths:
+            for pattern in registry.forbidden_regex:
+                if pattern.search(text):
+                    violations.append(f"{rel}: forbidden token matched {pattern.pattern}")
+        if path.suffix == ".py":
+            for symbol in registry.required_symbols:
+                if _definition_pattern(symbol).search(text):
+                    definitions[symbol].append(rel)
+
+    for symbol, paths in definitions.items():
+        if paths != [registry.canonical_module]:
+            rendered = ", ".join(str(path) for path in paths) or "none"
+            violations.append(
+                f"{symbol}: expected only {registry.canonical_module}, found {rendered}"
+            )
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--registry", default=str(DEFAULT_REGISTRY))
+    parser.add_argument("--root", default=str(REPO_ROOT))
+    args = parser.parse_args(argv)
+
+    try:
+        violations = check(Path(args.registry), Path(args.root))
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        print(f"CONTRACT_SINGLE_SOURCE_FAIL {exc}", file=sys.stderr)
+        return 1
+    if violations:
+        print("CONTRACT_SINGLE_SOURCE_FAIL", file=sys.stderr)
+        for violation in violations:
+            print(f"- {violation}", file=sys.stderr)
+        return 1
+    print("CONTRACT_SINGLE_SOURCE_PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gates/model_artifact_cache.py
+++ b/scripts/gates/model_artifact_cache.py
@@ -1,0 +1,402 @@
+"""Materialize and verify the shared IGC model-artifact cache.
+
+The cache keeps immutable run artifacts under one root, for example
+``/Volumes/k8s-sata-stripe/igc/phases/phase1/model_x/runs/<run_id>/...``, and
+stores base-model caches once under ``base_models/``. It is designed to run on an
+approved remote/Kubernetes surface. By default it can plan and verify metadata;
+LFS hydration requires ``--download-lfs`` so a worker cannot accidentally pull
+large objects to the wrong machine.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SPEC = REPO_ROOT / "configs/artifacts/model_cache.yaml"
+
+
+class ArtifactGateError(RuntimeError):
+    """A hard gate failure with a user-readable message."""
+
+
+@dataclass(frozen=True)
+class LfsPointer:
+    """Parsed Git LFS pointer metadata."""
+
+    sha256: str
+    size_bytes: int
+
+
+def load_spec(path: Path = DEFAULT_SPEC) -> dict[str, Any]:
+    """Load the artifact-cache spec from YAML."""
+
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ArtifactGateError("artifact cache spec must be a mapping")
+    if payload.get("version") != 1:
+        raise ArtifactGateError("artifact cache spec version must be 1")
+    if not isinstance(payload.get("models"), list) or not payload["models"]:
+        raise ArtifactGateError("artifact cache spec must contain models")
+    return payload
+
+
+def resolve_root(spec: Mapping[str, Any], override: str | None = None) -> Path:
+    """Resolve the cache root from CLI, env, or spec default."""
+
+    raw = override or os.environ.get("IGC_MODEL_CACHE_ROOT") or spec.get("default_root")
+    if not isinstance(raw, str) or not raw:
+        raise ArtifactGateError("set --root or IGC_MODEL_CACHE_ROOT")
+    return Path(raw).expanduser()
+
+
+def run_dir(root: Path, model: Mapping[str, Any]) -> Path:
+    """Return the immutable cache directory for one model run."""
+
+    return (
+        root
+        / "phases"
+        / str(model["phase"])
+        / str(model["role"])
+        / "runs"
+        / str(model["run_id"])
+    )
+
+
+def base_model_dir(root: Path, model: Mapping[str, Any]) -> Path:
+    """Return the shared base-model cache location for one model spec."""
+
+    base = _mapping(model, "base_model")
+    return root / "base_models" / str(base["cache_subdir"])
+
+
+def planned_paths(spec: Mapping[str, Any], root: Path) -> dict[str, Any]:
+    """Return a JSON-serializable layout plan without touching the filesystem."""
+
+    planned: dict[str, Any] = {
+        "root": str(root),
+        "base_models": str(root / "base_models"),
+        "runs": [],
+    }
+    for model in spec["models"]:
+        rd = run_dir(root, model)
+        planned["runs"].append({
+            "role": model["role"],
+            "phase": model["phase"],
+            "run_id": model["run_id"],
+            "run_dir": str(rd),
+            "base_model_dir": str(base_model_dir(root, model)),
+            "files": [
+                {
+                    "kind": file_spec["kind"],
+                    "source_path": file_spec["source_path"],
+                    "dest": str(rd / file_spec["dest"]),
+                    "lfs": bool(file_spec.get("lfs", False)),
+                }
+                for file_spec in model["files"]
+            ],
+        })
+    return planned
+
+
+def init_layout(spec: Mapping[str, Any], root: Path) -> None:
+    """Create the shared cache directory structure."""
+
+    (root / "base_models").mkdir(parents=True, exist_ok=True)
+    (root / "reports").mkdir(parents=True, exist_ok=True)
+    for model in spec["models"]:
+        rd = run_dir(root, model)
+        (rd / "artifacts").mkdir(parents=True, exist_ok=True)
+        (rd / "reports").mkdir(parents=True, exist_ok=True)
+
+
+def materialize(
+        spec: Mapping[str, Any],
+        root: Path,
+        *,
+        download_lfs: bool = False,
+        base_source_root: Path | None = None,
+        copy_base_models: bool = False) -> dict[str, Any]:
+    """Copy small reports and optionally hydrate LFS weights into the cache."""
+
+    init_layout(spec, root)
+    records: list[dict[str, Any]] = []
+    if base_source_root is not None:
+        records.extend(materialize_base_models(
+            spec,
+            root,
+            base_source_root,
+            copy_base_models=copy_base_models,
+        ))
+    for model in spec["models"]:
+        ref = str(model["lfs_ref"])
+        rd = run_dir(root, model)
+        for file_spec in model["files"]:
+            source = str(file_spec["source_path"])
+            dest = rd / str(file_spec["dest"])
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            if file_spec.get("lfs"):
+                pointer = read_lfs_pointer(ref, source)
+                _validate_pointer(file_spec, pointer)
+                if dest.exists() and _sha256_file(dest) == pointer.sha256:
+                    status = "exists"
+                elif download_lfs:
+                    _smudge_lfs_pointer(ref, source, dest)
+                    _verify_file(file_spec, dest, pointer=pointer)
+                    status = "materialized"
+                else:
+                    raise ArtifactGateError(
+                        f"{source} is LFS-backed; rerun with --download-lfs on an approved surface"
+                    )
+            else:
+                payload = _git_show_bytes(ref, source)
+                dest.write_bytes(payload)
+                _verify_file(file_spec, dest)
+                status = "copied"
+            records.append({
+                "role": model["role"],
+                "phase": model["phase"],
+                "run_id": model["run_id"],
+                "kind": file_spec["kind"],
+                "dest": str(dest),
+                "status": status,
+            })
+    manifest = {
+        "schema": "igc.model_artifact_cache.v1",
+        "created_at_utc": datetime.now(timezone.utc).isoformat(),
+        "root": str(root),
+        "records": records,
+    }
+    (root / "cache_manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def materialize_base_models(
+        spec: Mapping[str, Any],
+        root: Path,
+        source_root: Path,
+        *,
+        copy_base_models: bool = False) -> list[dict[str, Any]]:
+    """Link or copy base-model cache directories once into the shared root."""
+
+    records: list[dict[str, Any]] = []
+    for model in spec["models"]:
+        base = _mapping(model, "base_model")
+        cache_subdir = str(base["cache_subdir"])
+        source = source_root / cache_subdir
+        dest = base_model_dir(root, model)
+        if not source.exists():
+            raise ArtifactGateError(f"base model source missing: {source}")
+        if dest.exists():
+            status = "exists"
+        else:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            if copy_base_models:
+                shutil.copytree(source, dest, symlinks=True)
+                status = "copied"
+            else:
+                dest.symlink_to(source, target_is_directory=True)
+                status = "linked"
+        records.append({
+            "role": model["role"],
+            "phase": model["phase"],
+            "run_id": model["run_id"],
+            "kind": "base_model",
+            "source": str(source),
+            "dest": str(dest),
+            "status": status,
+        })
+    return records
+
+
+def verify(spec: Mapping[str, Any], root: Path, *, require_base_model: bool = False) -> dict[str, Any]:
+    """Verify materialized reports, weights, and optional base-model cache paths."""
+
+    checks: list[dict[str, Any]] = []
+    for model in spec["models"]:
+        if require_base_model:
+            base_dir = base_model_dir(root, model)
+            if not base_dir.exists():
+                raise ArtifactGateError(f"base model cache missing: {base_dir}")
+            checks.append({"kind": "base_model", "path": str(base_dir), "status": "present"})
+        rd = run_dir(root, model)
+        for file_spec in model["files"]:
+            dest = rd / str(file_spec["dest"])
+            if not dest.is_file():
+                raise ArtifactGateError(f"cached artifact missing: {dest}")
+            pointer = None
+            if file_spec.get("lfs"):
+                pointer = LfsPointer(
+                    sha256=str(file_spec["sha256"]),
+                    size_bytes=int(file_spec["size_bytes"]),
+                )
+            _verify_file(file_spec, dest, pointer=pointer)
+            checks.append({
+                "kind": file_spec["kind"],
+                "path": str(dest),
+                "status": "verified",
+            })
+    return {
+        "schema": "igc.model_artifact_cache.verify.v1",
+        "root": str(root),
+        "checks": checks,
+    }
+
+
+def read_lfs_pointer(ref: str, path: str) -> LfsPointer:
+    """Read and parse an LFS pointer from ``ref:path`` without hydrating it."""
+
+    pointer = _git_show_bytes(ref, path).decode("utf-8")
+    lines = pointer.splitlines()
+    if not lines or lines[0] != "version https://git-lfs.github.com/spec/v1":
+        raise ArtifactGateError(f"{path} is not a Git LFS pointer at {ref}")
+    oid = next((line for line in lines if line.startswith("oid sha256:")), "")
+    size = next((line for line in lines if line.startswith("size ")), "")
+    if not oid or not size:
+        raise ArtifactGateError(f"{path} has malformed Git LFS pointer metadata")
+    return LfsPointer(sha256=oid.removeprefix("oid sha256:"), size_bytes=int(size.split()[1]))
+
+
+def _validate_pointer(file_spec: Mapping[str, Any], pointer: LfsPointer) -> None:
+    """Validate pointer metadata against the artifact spec."""
+
+    if str(file_spec.get("sha256", "")).lower() != pointer.sha256.lower():
+        raise ArtifactGateError(f"LFS SHA mismatch for {file_spec['source_path']}")
+    if int(file_spec.get("size_bytes", -1)) != pointer.size_bytes:
+        raise ArtifactGateError(f"LFS size mismatch for {file_spec['source_path']}")
+
+
+def _verify_file(
+        file_spec: Mapping[str, Any],
+        path: Path,
+        *,
+        pointer: LfsPointer | None = None) -> None:
+    """Verify cached file size/SHA and report JSON parseability."""
+
+    if pointer is not None:
+        if path.stat().st_size != pointer.size_bytes:
+            raise ArtifactGateError(f"size mismatch for {path}")
+        if _sha256_file(path).lower() != pointer.sha256.lower():
+            raise ArtifactGateError(f"sha256 mismatch for {path}")
+    expected_sha = file_spec.get("sha256")
+    if expected_sha and _sha256_file(path).lower() != str(expected_sha).lower():
+        raise ArtifactGateError(f"sha256 mismatch for {path}")
+    if file_spec["kind"] in {"report", "parameters"}:
+        json.loads(path.read_text(encoding="utf-8"))
+
+
+def _smudge_lfs_pointer(ref: str, source: str, dest: Path) -> None:
+    """Hydrate one LFS pointer into ``dest`` using git-lfs smudge."""
+
+    pointer = _git_show_bytes(ref, source)
+    completed = subprocess.run(
+        ["git", "lfs", "smudge"],
+        cwd=REPO_ROOT,
+        input=pointer,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise ArtifactGateError(
+            f"git lfs smudge failed for {source}: {completed.stderr.decode('utf-8', 'replace')}"
+        )
+    dest.write_bytes(completed.stdout)
+
+
+def _git_show_bytes(ref: str, path: str) -> bytes:
+    """Return ``git show ref:path`` bytes."""
+
+    completed = subprocess.run(
+        ["git", "show", f"{ref}:{path}"],
+        cwd=REPO_ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise ArtifactGateError(
+            f"git show failed for {ref}:{path}: {completed.stderr.decode('utf-8', 'replace')}"
+        )
+    return completed.stdout
+
+
+def _sha256_file(path: Path) -> str:
+    """Return the SHA256 digest of a local file."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _mapping(payload: Mapping[str, Any], key: str) -> Mapping[str, Any]:
+    """Return a required nested mapping."""
+
+    value = payload.get(key)
+    if not isinstance(value, Mapping):
+        raise ArtifactGateError(f"{key} must be a mapping")
+    return value
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("plan", "init", "materialize", "verify"))
+    parser.add_argument("--spec", default=str(DEFAULT_SPEC))
+    parser.add_argument("--root")
+    parser.add_argument("--download-lfs", action="store_true")
+    parser.add_argument("--base-source-root")
+    parser.add_argument("--copy-base-models", action="store_true")
+    parser.add_argument("--require-base-model", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        spec = load_spec(Path(args.spec))
+        root = resolve_root(spec, args.root)
+        if args.command == "plan":
+            result = planned_paths(spec, root)
+        elif args.command == "init":
+            init_layout(spec, root)
+            result = {"status": "initialized", "root": str(root)}
+        elif args.command == "materialize":
+            base_source_root = Path(args.base_source_root) if args.base_source_root else None
+            result = materialize(
+                spec,
+                root,
+                download_lfs=args.download_lfs,
+                base_source_root=base_source_root,
+                copy_base_models=args.copy_base_models,
+            )
+        else:
+            result = verify(spec, root, require_base_model=args.require_base_model)
+    except ArtifactGateError as exc:
+        print(f"BLOCKER: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(f"MODEL_ARTIFACT_CACHE_{args.command.upper()}_OK root={result.get('root', root)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gates/model_artifact_load_gate.py
+++ b/scripts/gates/model_artifact_load_gate.py
@@ -1,0 +1,156 @@
+"""Verify cached model artifacts and optionally load base+adapter on CPU.
+
+The default mode validates reports and adapter tensor shapes without downloading
+or loading a giant base model. ``--load-cpu`` is an opt-in heavyweight gate for
+approved Kubernetes/remote containers; it refuses laptop execution unless the
+caller sets ``--allow-local-fixture`` for tiny unit-test fixtures.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.gates.model_artifact_cache import (  # noqa: E402
+    ArtifactGateError,
+    base_model_dir,
+    load_spec,
+    resolve_root,
+    run_dir,
+    verify,
+)
+
+
+def is_approved_execution_surface() -> bool:
+    """Return whether heavy model loading is allowed on this machine."""
+
+    return bool(os.environ.get("KUBERNETES_SERVICE_HOST") or os.environ.get("IGC_APPROVED_REMOTE"))
+
+
+def inspect_adapter_tensors(adapter_path: Path) -> dict[str, Any]:
+    """Inspect safetensors keys, dtypes, and shapes without moving tensors."""
+
+    try:
+        from safetensors import safe_open
+    except Exception as exc:  # pragma: no cover - dependency is part of remote image
+        raise ArtifactGateError(f"safetensors is required for tensor shape inspection: {exc}") from exc
+    tensors: list[dict[str, Any]] = []
+    with safe_open(adapter_path, framework="pt", device="cpu") as handle:
+        for key in handle.keys():
+            tensor = handle.get_tensor(key)
+            tensors.append({
+                "key": key,
+                "dtype": str(tensor.dtype),
+                "shape": list(tensor.shape),
+            })
+    if not tensors:
+        raise ArtifactGateError(f"adapter has no tensors: {adapter_path}")
+    return {
+        "tensor_count": len(tensors),
+        "first_tensor": tensors[0],
+        "all_shapes_rank_positive": all(len(item["shape"]) > 0 for item in tensors),
+    }
+
+
+def load_cpu_smoke(model: Mapping[str, Any], root: Path) -> dict[str, Any]:
+    """Load base model + adapter on CPU from the shared cache."""
+
+    try:
+        from peft import PeftModel
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+    except Exception as exc:  # pragma: no cover - dependency is remote-image specific
+        raise ArtifactGateError(f"transformers/peft are required for CPU load gate: {exc}") from exc
+
+    base_dir = base_model_dir(root, model)
+    adapter_dir = run_dir(root, model) / "artifacts"
+    tokenizer = AutoTokenizer.from_pretrained(base_dir, local_files_only=True)
+    base = AutoModelForCausalLM.from_pretrained(
+        base_dir,
+        local_files_only=True,
+        device_map=None,
+        torch_dtype="auto",
+    )
+    loaded = PeftModel.from_pretrained(base, adapter_dir, local_files_only=True)
+    return {
+        "base_model_dir": str(base_dir),
+        "adapter_dir": str(adapter_dir),
+        "tokenizer_vocab_size": int(len(tokenizer)),
+        "parameter_count": int(sum(param.numel() for param in loaded.parameters())),
+    }
+
+
+def run_gate(
+        spec_path: Path,
+        root_override: str | None,
+        *,
+        load_cpu: bool = False,
+        allow_local_fixture: bool = False) -> dict[str, Any]:
+    """Run report/tensor-shape checks and optional heavyweight CPU load."""
+
+    spec = load_spec(spec_path)
+    root = resolve_root(spec, root_override)
+    verify_report = verify(spec, root, require_base_model=load_cpu)
+    model_reports: list[dict[str, Any]] = []
+    for model in spec["models"]:
+        adapter = run_dir(root, model) / "artifacts" / "adapter_model.safetensors"
+        model_report: dict[str, Any] = {
+            "phase": model["phase"],
+            "role": model["role"],
+            "run_id": model["run_id"],
+            "adapter_tensors": inspect_adapter_tensors(adapter),
+        }
+        if load_cpu:
+            if not allow_local_fixture and not is_approved_execution_surface():
+                raise ArtifactGateError(
+                    "--load-cpu requires Kubernetes/approved remote execution; refusing laptop load"
+                )
+            model_report["cpu_load"] = load_cpu_smoke(model, root)
+        model_reports.append(model_report)
+    return {
+        "schema": "igc.model_artifact_load_gate.v1",
+        "root": str(root),
+        "cache": verify_report,
+        "models": model_reports,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--spec", default=str(Path("configs/artifacts/model_cache.yaml")))
+    parser.add_argument("--root")
+    parser.add_argument("--report")
+    parser.add_argument("--load-cpu", action="store_true")
+    parser.add_argument("--allow-local-fixture", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        report = run_gate(
+            Path(args.spec),
+            args.root,
+            load_cpu=args.load_cpu,
+            allow_local_fixture=args.allow_local_fixture,
+        )
+    except ArtifactGateError as exc:
+        print(f"BLOCKER: {exc}", file=sys.stderr)
+        return 1
+
+    text = json.dumps(report, indent=2, sort_keys=True)
+    if args.report:
+        path = Path(args.report)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text + "\n", encoding="utf-8")
+    print("MODEL_ARTIFACT_LOAD_GATE_PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gates/phase123_conformance.py
+++ b/scripts/gates/phase123_conformance.py
@@ -1,0 +1,220 @@
+"""Deterministic Phase 1 -> D1 -> Phase 2 -> Phase 3 contract conformance gate.
+
+This gate uses tiny fixtures and the real render/parse/eval functions to prove
+that keys, tensor shapes, and JSON envelopes line up end-to-end. It does not
+claim model quality: the model/judge responses are deterministic fixture
+responses that stand in for a perfect model and a lightweight schema judge.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from igc.ds.corpus_dataset import CorpusJSONLDataset, PHASE1_PRETRAIN_OBJECTIVE  # noqa: E402
+from igc.ds.phase1_render import render_phase1_completion, render_phase1_prompt  # noqa: E402
+from igc.ds.rest_goal_contract import (  # noqa: E402
+    RedfishContext,
+    build_d1_rest_api_list_row,
+    build_ordered_call_row,
+    evaluate_ordered_calls_y_pred,
+    evaluate_rest_api_set,
+    inference_target_calls_json,
+    parse_ordered_calls_y_pred,
+    parse_rest_api_list_y_pred,
+    render_ordered_call_example,
+    render_rest_api_list_example,
+)
+
+
+class TinyCharTokenizer:
+    """Offline tokenizer for deterministic tensor-shape checks."""
+
+    pad_token_id = 0
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Force the dataset to use the ``encode`` fallback."""
+
+        raise TypeError("TinyCharTokenizer supports encode() only")
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        """Return one nonzero token id per character."""
+
+        return [(ord(char) % 255) + 1 for char in text]
+
+
+def _write_phase1_corpus(tmp_path: Path, example: dict[str, Any]) -> Path:
+    """Write a one-row Phase 1 corpus fixture."""
+
+    corpus = tmp_path / "phase1_corpus"
+    corpus.mkdir(parents=True, exist_ok=True)
+    (corpus / "examples.jsonl").write_text(json.dumps(example) + "\n", encoding="utf-8")
+    return corpus
+
+
+def _tensor_report(item: dict[str, torch.Tensor]) -> dict[str, Any]:
+    """Return tensor key/shape/dtype metadata for a tokenized row."""
+
+    return {
+        key: {
+            "shape": list(value.shape),
+            "dtype": str(value.dtype),
+            "supervised_tokens": int(value.ne(-100).sum().item()) if key == "labels" else None,
+        }
+        for key, value in item.items()
+    }
+
+
+def lightweight_judge(text: str, target: list[str], response: dict[str, Any]) -> dict[str, Any]:
+    """Deterministic schema judge for D1 conformance tests."""
+
+    parsed = parse_rest_api_list_y_pred(response)
+    return {
+        "accepted": bool(text.strip()) and set(parsed) == set(target),
+        "rest_api_set_match": set(parsed) == set(target),
+        "nonsense": not bool(text.strip()),
+    }
+
+
+def build_report(tmp_path: Path, *, max_len: int = 192) -> dict[str, Any]:
+    """Build the deterministic end-to-end conformance report."""
+
+    initial = {
+        "x": {
+            "rest_api": "/redfish/v1/Systems/1",
+            "allowed_methods": ["GET", "PATCH"],
+            "json": {"@odata.id": "/redfish/v1/Systems/1", "PowerState": "Off"},
+        },
+        "y_true": {
+            "json": {"@odata.id": "/redfish/v1/Systems/1", "PowerState": "Off"},
+        },
+    }
+    prompt, target = render_phase1_prompt(initial)
+    completion = render_phase1_completion(target)
+    dataset = CorpusJSONLDataset(
+        str(_write_phase1_corpus(tmp_path, initial)),
+        max_len=max_len,
+        tokenizer=TinyCharTokenizer(),
+        objective=PHASE1_PRETRAIN_OBJECTIVE,
+    )
+    phase1_item = dataset[0]
+
+    context = RedfishContext(
+        rest_api="/redfish/v1/Systems/1",
+        allowed_methods=("GET", "PATCH"),
+        json={"@odata.id": "/redfish/v1/Systems/1", "PowerState": "Off"},
+    )
+    d1_row = build_d1_rest_api_list_row(
+        text="power on system 1",
+        contexts=(context,),
+        rest_api_list=(context.rest_api,),
+    )
+    phase2_rendered = render_rest_api_list_example(d1_row)
+    phase2_response = json.loads(phase2_rendered.target_json)
+    phase2_parsed = parse_rest_api_list_y_pred(phase2_response)
+    phase2_metrics = evaluate_rest_api_set(phase2_parsed, d1_row["y_true"])
+    judge = lightweight_judge(
+        d1_row["x"]["text"],
+        list(d1_row["y_true"]["rest_api_list"]),
+        phase2_response,
+    )
+
+    phase3_row = build_ordered_call_row(
+        text=d1_row["x"]["text"],
+        contexts=(context,),
+        rest_api_list=phase2_parsed,
+        method_by_api={context.rest_api: "PATCH"},
+        arguments_by_api={context.rest_api: {"PowerState": "On"}},
+    )
+    phase3_rendered = render_ordered_call_example(phase3_row)
+    phase3_parsed = parse_ordered_calls_y_pred(phase3_rendered.target_json)
+    phase3_eval = evaluate_ordered_calls_y_pred(phase3_row, phase3_rendered.target_json)
+    handoff = inference_target_calls_json(phase3_row)
+
+    return {
+        "schema": "igc.phase123_conformance.v1",
+        "phase1": {
+            "input_keys": sorted(initial["x"].keys()),
+            "target_keys": sorted(initial["y_true"].keys()),
+            "prompt_len": len(prompt),
+            "completion_len": len(completion),
+            "tensor_keys": sorted(phase1_item.keys()),
+            "tensors": _tensor_report(phase1_item),
+        },
+        "d1": {
+            "row_keys": sorted(d1_row.keys()),
+            "x_keys": sorted(d1_row["x"].keys()),
+            "y_true_keys": sorted(d1_row["y_true"].keys()),
+            "judge": judge,
+        },
+        "phase2": {
+            "prompt_len": len(phase2_rendered.prompt),
+            "parsed_rest_api_list": phase2_parsed,
+            "set_match": phase2_metrics.set_match,
+            "empty_set_match_example": evaluate_rest_api_set([], []).empty_set_match,
+        },
+        "phase3": {
+            "prompt_len": len(phase3_rendered.prompt),
+            "parsed_call_count": len(phase3_parsed),
+            "call_ordered_exact_match": phase3_eval["call_ordered_exact_match"],
+            "target_calls_keys": sorted(handoff.keys()),
+            "target_call_fields": sorted(handoff["target_calls"][0].keys()),
+        },
+    }
+
+
+def assert_report(report: dict[str, Any]) -> None:
+    """Raise ``AssertionError`` when the deterministic contract is broken."""
+
+    assert report["phase1"]["tensor_keys"] == ["attention_mask", "input_ids", "labels"]
+    assert report["phase1"]["tensors"]["input_ids"]["shape"] == [192]
+    assert report["phase1"]["tensors"]["labels"]["supervised_tokens"] > 0
+    assert report["d1"]["x_keys"] == ["allowed_methods", "json", "text"]
+    assert report["d1"]["y_true_keys"] == ["order_evidence", "rest_api_list"]
+    assert report["d1"]["judge"]["accepted"] is True
+    assert report["phase2"]["set_match"] is True
+    assert report["phase2"]["empty_set_match_example"] is True
+    assert report["phase3"]["call_ordered_exact_match"] is True
+    assert report["phase3"]["target_calls_keys"] == ["target_calls", "text"]
+    assert report["phase3"]["target_call_fields"] == [
+        "allowed_methods",
+        "arguments",
+        "method",
+        "rest_api",
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--work-dir", default="")
+    parser.add_argument("--report", default="reports/gate-report-phase123-conformance.json")
+    args = parser.parse_args(argv)
+
+    tmp_path = Path(args.work_dir) if args.work_dir else Path(".phase123-conformance-tmp")
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    report = build_report(tmp_path)
+    try:
+        assert_report(report)
+    except AssertionError as exc:
+        print(f"PHASE123_CONFORMANCE_FAIL {exc}")
+        return 1
+
+    report_path = Path(args.report)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"PHASE123_CONFORMANCE_PASS report={report_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gates/schema_snapshot.py
+++ b/scripts/gates/schema_snapshot.py
@@ -1,0 +1,148 @@
+"""Gate: freeze the approved Phase 2/3 REST-goal JSON shape.
+
+The snapshot stores field names and value types only. Values are fixture data and
+are intentionally erased so the gate catches schema drift without committing
+private captures or brittle examples.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from igc.ds.rest_goal_contract import (  # noqa: E402
+    RedfishContext,
+    build_d1_rest_api_list_row,
+    build_ordered_call_row,
+    inference_target_calls_json,
+    render_ordered_call_example,
+    render_rest_api_list_example,
+)
+
+DEFAULT_SNAPSHOT = REPO_ROOT / "schemas/snapshots/rest_goal_contract.shape.json"
+EXIT_OK = 0
+EXIT_FAIL = 1
+EXIT_BOOTSTRAP = 2
+
+
+def _shape(value: Any) -> Any:
+    """Return a stable shape-only representation for JSON-like values."""
+
+    if isinstance(value, Mapping):
+        return {key: _shape(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        return [_merge_shapes(_shape(item) for item in value)] if value else []
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        return "int"
+    if isinstance(value, float):
+        return "float"
+    if value is None:
+        return "null"
+    return type(value).__name__
+
+
+def _merge_shapes(shapes: Any) -> Any:
+    """Merge list item shapes into one representative shape."""
+
+    shapes = list(shapes)
+    if not shapes:
+        return {}
+    if all(isinstance(shape, dict) for shape in shapes):
+        merged: dict[str, Any] = {}
+        for shape in shapes:
+            for key, value in shape.items():
+                if key in merged:
+                    merged[key] = _merge_shapes([merged[key], value])
+                else:
+                    merged[key] = value
+        return merged
+    if all(isinstance(shape, list) for shape in shapes):
+        inner = [item for shape in shapes for item in shape]
+        return [_merge_shapes(inner)] if inner else []
+    first = shapes[0]
+    return first if all(shape == first for shape in shapes) else sorted(
+        {str(shape) for shape in shapes}
+    )
+
+
+def build_snapshot() -> dict[str, Any]:
+    """Build the canonical Phase 2/3 schema snapshot."""
+
+    read_ctx = RedfishContext(
+        rest_api="/redfish/v1/Systems/1",
+        allowed_methods=("GET", "HEAD"),
+        json={"@odata.id": "/redfish/v1/Systems/1", "PowerState": "On"},
+    )
+    write_ctx = RedfishContext(
+        rest_api="/redfish/v1/Managers/1/EthernetInterfaces/1",
+        allowed_methods=("GET", "PATCH"),
+        json={"@odata.id": "/redfish/v1/Managers/1/EthernetInterfaces/1"},
+    )
+    phase2 = build_d1_rest_api_list_row(
+        text="read system then set manager address",
+        contexts=(read_ctx, write_ctx),
+        rest_api_list=(read_ctx.rest_api, write_ctx.rest_api),
+    )
+    phase3 = build_ordered_call_row(
+        text="read system then set manager address",
+        contexts=(read_ctx, write_ctx),
+        rest_api_list=(read_ctx.rest_api, write_ctx.rest_api),
+        method_by_api={write_ctx.rest_api: "PATCH"},
+        arguments_by_api={write_ctx.rest_api: {"Address": "192.168.1.1"}},
+    )
+    return {
+        "schema": "igc.rest_goal_contract.shape.v1",
+        "phase2_row": _shape(phase2),
+        "phase2_rendered": _shape(render_rest_api_list_example(phase2).__dict__),
+        "phase3_row": _shape(phase3),
+        "phase3_rendered": _shape(render_ordered_call_example(phase3).__dict__),
+        "phase3_inference": _shape(inference_target_calls_json(phase3)),
+    }
+
+
+def check(snapshot: Path = DEFAULT_SNAPSHOT) -> int:
+    """Compare the current contract shape with the committed snapshot."""
+
+    current = build_snapshot()
+    if not snapshot.exists():
+        return EXIT_BOOTSTRAP
+    expected = json.loads(snapshot.read_text(encoding="utf-8"))
+    return EXIT_OK if current == expected else EXIT_FAIL
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--snapshot", default=str(DEFAULT_SNAPSHOT))
+    parser.add_argument("--update", action="store_true")
+    args = parser.parse_args(argv)
+
+    snapshot = Path(args.snapshot)
+    current = build_snapshot()
+    if args.update:
+        snapshot.parent.mkdir(parents=True, exist_ok=True)
+        snapshot.write_text(json.dumps(current, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(f"SCHEMA_SNAPSHOT_UPDATED {snapshot}")
+        return EXIT_OK
+
+    result = check(snapshot)
+    if result == EXIT_OK:
+        print("SCHEMA_SNAPSHOT_PASS")
+    elif result == EXIT_BOOTSTRAP:
+        print(f"SCHEMA_SNAPSHOT_BOOTSTRAP missing={snapshot}")
+    else:
+        print(f"SCHEMA_SNAPSHOT_FAIL drift={snapshot}")
+    return result
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ds/test_rest_goal_contract.py
+++ b/tests/ds/test_rest_goal_contract.py
@@ -23,6 +23,7 @@ from igc.ds.rest_goal_contract import (
     build_ordered_call_row,
     evaluate_ordered_calls_y_pred,
     inference_ordered_goals_json,
+    inference_target_calls_json,
     parse_ordered_calls_y_pred,
     parse_rest_api_list_y_pred,
     render_ordered_call_example,
@@ -772,6 +773,25 @@ def test_inference_json_uses_ordered_goals_shape() -> None:
     assert inference_ordered_goals_json(row) == {
         "text": "check task queue",
         "ordered_goals": row["y_true"]["calls"],
+    }
+
+
+def test_inference_json_uses_target_calls_shape() -> None:
+    """The current Phase 3 handoff names executable goals target_calls."""
+    context = _context(
+        "/redfish/v1/TaskService/Tasks",
+        ("GET", "HEAD"),
+        {"@odata.id": "/redfish/v1/TaskService/Tasks"},
+    )
+    row = build_ordered_call_row(
+        text="check task queue",
+        contexts=(context,),
+        rest_api_list=("/redfish/v1/TaskService/Tasks",),
+    )
+
+    assert inference_target_calls_json(row) == {
+        "text": "check task queue",
+        "target_calls": row["y_true"]["calls"],
     }
 
 

--- a/tests/gates/test_contract_single_source.py
+++ b/tests/gates/test_contract_single_source.py
@@ -1,0 +1,67 @@
+"""Tests for the repo-level contract single-source gate."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.gates.contract_single_source import check
+
+
+def _write_registry(root: Path) -> Path:
+    """Write a tiny registry for a fixture repository."""
+
+    registry = root / "configs/contracts/rest_goal.yaml"
+    registry.parent.mkdir(parents=True)
+    registry.write_text(
+        "\n".join([
+            "version: 1",
+            "canonical_module: igc/ds/rest_goal_contract.py",
+            "scan_paths: [igc, docs]",
+            "file_suffixes: [.py, .md]",
+            "allow_paths: []",
+            "required_symbols:",
+            "  - build_d1_rest_api_list_row",
+            "forbidden_regex:",
+            r"  - \"\\bmock_inference_contract\\b\"",
+        ]),
+        encoding="utf-8",
+    )
+    return registry
+
+
+def test_contract_single_source_passes_canonical_only(tmp_path: Path) -> None:
+    """A repo with the canonical definition only has no violations."""
+
+    canonical = tmp_path / "igc/ds/rest_goal_contract.py"
+    canonical.parent.mkdir(parents=True)
+    canonical.write_text("def build_d1_rest_api_list_row():\n    pass\n", encoding="utf-8")
+
+    assert check(_write_registry(tmp_path), tmp_path) == []
+
+
+def test_contract_single_source_rejects_parallel_definition(tmp_path: Path) -> None:
+    """The same canonical symbol in another module is a contract island."""
+
+    canonical = tmp_path / "igc/ds/rest_goal_contract.py"
+    other = tmp_path / "igc/ds/other_contract.py"
+    canonical.parent.mkdir(parents=True)
+    canonical.write_text("def build_d1_rest_api_list_row():\n    pass\n", encoding="utf-8")
+    other.write_text("def build_d1_rest_api_list_row():\n    pass\n", encoding="utf-8")
+
+    violations = check(_write_registry(tmp_path), tmp_path)
+
+    assert any("expected only" in violation for violation in violations)
+
+
+def test_contract_single_source_rejects_forbidden_fingerprint(tmp_path: Path) -> None:
+    """Stale contract module names fail even when definitions are absent."""
+
+    canonical = tmp_path / "igc/ds/rest_goal_contract.py"
+    stale_doc = tmp_path / "docs/stale.md"
+    canonical.parent.mkdir(parents=True)
+    stale_doc.parent.mkdir(parents=True)
+    canonical.write_text("def build_d1_rest_api_list_row():\n    pass\n", encoding="utf-8")
+    stale_doc.write_text("use mock_inference_contract here\n", encoding="utf-8")
+
+    violations = check(_write_registry(tmp_path), tmp_path)
+
+    assert any("forbidden token" in violation for violation in violations)

--- a/tests/gates/test_dataset_contract.py
+++ b/tests/gates/test_dataset_contract.py
@@ -1,0 +1,225 @@
+"""Pin the dataset-to-model contract for Phase 1/2/3 across the real builders.
+
+PR #108 slipped a parallel contract past green per-module tests; these tests lock
+the *data shape* the three staged trainers actually consume, using the real
+canonical code paths (no mocks of the builders themselves):
+
+* Phase 1 D0: :class:`igc.ds.corpus_dataset.CorpusJSONLDataset` with the
+  ``phase1_pretrain`` objective — the example keys it reads, the prompt/target
+  boundary (loss masked over prompt + padding), and the fixed-length tokenized
+  tensor keys/shapes.
+* Phase 2 D1: :func:`igc.ds.rest_goal_contract.build_d1_rest_api_list_row` — the
+  ``x``/``y_true`` field names and the empty-set (hard-negative) allowance.
+* Phase 3: :func:`igc.ds.rest_goal_contract.build_ordered_call_row` — the ``x``
+  fields and the per-call ``y_true`` field names.
+
+The tests run offline on CI / an approved remote container: a tiny char-level
+in-test tokenizer stands in for the real HF tokenizer, so nothing is downloaded
+and no GPU is required. Real-model generation/decoding stays out of scope here
+(approved remote acceptance gate), so there is deliberately no live-model stage
+in this file.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, List
+
+import torch
+
+from igc.ds.corpus_dataset import CorpusJSONLDataset, PHASE1_PRETRAIN_OBJECTIVE
+from igc.ds.rest_goal_contract import (
+    RedfishContext,
+    build_d1_rest_api_list_row,
+    build_ordered_call_row,
+)
+
+
+class _TinyCharTokenizer:
+    """Offline char-level stand-in for an HF tokenizer (no download, no GPU).
+
+    ``CorpusJSONLDataset._token_ids`` first tries ``tok(text, ...)`` and falls back
+    to ``tok.encode`` on ``TypeError``; this tokenizer raises ``TypeError`` from
+    ``__call__`` so the ``encode`` path is exercised, and reserves id ``0`` for
+    padding so completion ids never collide with the pad id.
+    """
+
+    pad_token_id = 0  # reserved pad id; encode() never emits 0 so padding is detectable.
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Force ``CorpusJSONLDataset._token_ids`` onto its ``encode`` fallback."""
+        raise TypeError("tiny tokenizer only supports encode()")
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> List[int]:
+        """Return one nonzero id per character (0 stays reserved for padding)."""
+        return [(ord(char) % 255) + 1 for char in text]
+
+
+def _write_corpus(tmp_path, examples: List[dict]) -> str:
+    """Write ``examples.jsonl`` under a corpus dir and return the dir path."""
+    corpus_dir = os.path.join(str(tmp_path), "corpus")
+    os.makedirs(corpus_dir, exist_ok=True)
+    with open(os.path.join(corpus_dir, "examples.jsonl"), "w") as handle:
+        for example in examples:
+            handle.write(json.dumps(example))
+            handle.write("\n")
+    return corpus_dir
+
+
+# --- Phase 1 D0: CorpusJSONLDataset phase1_pretrain render/tokenize -----------------
+
+
+def test_phase1_fields_consume_x_and_y_true_keys() -> None:
+    """Phase 1 D0 reads x.rest_api / x.allowed_methods / x.json and y_true.json."""
+    example = {
+        "x": {
+            "rest_api": "/redfish/v1/Systems/1",
+            "allowed_methods": ["get", "patch"],
+            "json": {"@odata.id": "/redfish/v1/Systems/1", "PowerState": "On"},
+        },
+        "y_true": {
+            "json": {"@odata.id": "/redfish/v1/Systems/1", "PowerState": "Off"},
+        },
+    }
+    rest_api, methods, input_json, target_json = CorpusJSONLDataset._phase1_fields(example)
+    assert rest_api == "/redfish/v1/Systems/1"
+    assert methods == ["GET", "PATCH"]  # allowed_methods normalized to upper-case.
+    assert input_json == example["x"]["json"]
+    assert target_json == example["y_true"]["json"]  # y_true.json is the completion target.
+
+
+def test_phase1_pretrain_item_keys_shapes_and_prompt_masking(tmp_path) -> None:
+    """phase1_pretrain emits fixed-length input_ids/attention_mask/labels with loss masked over prompt+padding."""
+    max_len = 128
+    example = {
+        "x": {
+            "rest_api": "/redfish/v1/Chassis/1",
+            "allowed_methods": ["GET"],
+            "json": {"@odata.id": "/redfish/v1/Chassis/1", "Name": "Chassis"},
+        },
+        "y_true": {
+            "json": {"@odata.id": "/redfish/v1/Chassis/1", "Name": "Chassis"},
+        },
+    }
+    corpus_dir = _write_corpus(tmp_path, [example])
+    dataset = CorpusJSONLDataset(
+        corpus_dir,
+        max_len=max_len,
+        tokenizer=_TinyCharTokenizer(),
+        objective=PHASE1_PRETRAIN_OBJECTIVE,
+    )
+    assert len(dataset) == 1
+    item = dataset[0]
+
+    # Tokenized item tensor keys the trainer's collate stacks.
+    assert set(item.keys()) == {"input_ids", "attention_mask", "labels"}
+    for key in ("input_ids", "attention_mask", "labels"):
+        assert item[key].shape == (max_len,), key  # fixed-length padded tensors.
+        assert item[key].dtype == torch.long, key
+
+    input_ids = item["input_ids"]
+    attention_mask = item["attention_mask"]
+    labels = item["labels"]
+
+    supervised = labels != -100
+    # Some tokens are supervised (the completion) and some are masked (the prompt).
+    assert supervised.any()
+    assert (~supervised).any()
+    assert int(supervised.sum()) < max_len  # prompt + padding are masked, never the whole row.
+    assert labels[0].item() == -100  # the prompt prefix is masked out of the loss.
+
+    # Padding is masked in both attention and loss; supervised tokens are real (attended).
+    pad = attention_mask == 0
+    assert torch.all(labels[pad] == -100)
+    assert torch.all(input_ids[pad] == _TinyCharTokenizer.pad_token_id)
+    assert torch.all(attention_mask[supervised] == 1)
+
+    # Supervised labels carry the completion token ids (unshifted; HF shifts internally).
+    assert torch.all(labels[supervised] == input_ids[supervised])
+
+
+# --- Phase 2 D1: build_d1_rest_api_list_row ----------------------------------------
+
+
+def test_phase2_labelled_row_field_names() -> None:
+    """Phase 2 D1 row carries x.text/x.json/x.allowed_methods and y_true.rest_api_list."""
+    context = RedfishContext(
+        rest_api="/redfish/v1/Systems/1",
+        allowed_methods=["GET", "PATCH"],
+        json={"@odata.id": "/redfish/v1/Systems/1"},
+    )
+    row = build_d1_rest_api_list_row(
+        text="power off system 1",
+        contexts=[context],
+        rest_api_list=["/redfish/v1/Systems/1"],
+    )
+    x = row["x"]
+    assert x["text"] == "power off system 1"
+    assert x["json"] == [{"@odata.id": "/redfish/v1/Systems/1"}]  # list of current resource bodies.
+    assert x["allowed_methods"] == {"/redfish/v1/Systems/1": ["GET", "PATCH"]}  # per-API method map.
+    assert row["y_true"]["rest_api_list"] == ["/redfish/v1/Systems/1"]  # ordered API label.
+
+
+def test_phase2_empty_rest_api_list_is_allowed_hard_negative() -> None:
+    """An empty y_true.rest_api_list ([] == no-action) is a legal hard-negative row."""
+    context = RedfishContext(
+        rest_api="/redfish/v1/Systems/1",
+        allowed_methods=["GET"],
+        json={"@odata.id": "/redfish/v1/Systems/1"},
+    )
+    row = build_d1_rest_api_list_row(
+        text="what is the weather today",
+        contexts=[context],
+        rest_api_list=[],
+    )
+    assert row["y_true"]["rest_api_list"] == []  # empty set is retained, not rejected.
+
+
+# --- Phase 3: build_ordered_call_row -----------------------------------------------
+
+
+def test_phase3_ordered_call_row_field_names() -> None:
+    """Phase 3 row carries x.text/x.rest_api_list/x.json/x.allowed_methods and per-call y_true keys."""
+    read_ctx = RedfishContext(
+        rest_api="/redfish/v1/Systems/1",
+        allowed_methods=["GET"],
+        json={"@odata.id": "/redfish/v1/Systems/1"},
+    )
+    write_ctx = RedfishContext(
+        rest_api="/redfish/v1/Managers/1/EthernetInterfaces/1",
+        allowed_methods=["GET", "PATCH"],
+        json={"@odata.id": "/redfish/v1/Managers/1/EthernetInterfaces/1"},
+    )
+    rest_api_list = [read_ctx.rest_api, write_ctx.rest_api]
+    row = build_ordered_call_row(
+        text="read system 1 then set the manager NIC address",
+        contexts=[read_ctx, write_ctx],
+        rest_api_list=rest_api_list,
+        method_by_api={write_ctx.rest_api: "PATCH"},
+        arguments_by_api={write_ctx.rest_api: {"Address": "192.168.1.1"}},
+    )
+
+    x = row["x"]
+    assert x["text"] == "read system 1 then set the manager NIC address"
+    assert x["rest_api_list"] == rest_api_list  # ordered API input from Phase 2.
+    assert x["json"] == [dict(read_ctx.json), dict(write_ctx.json)]  # current resource bodies.
+    assert x["allowed_methods"] == {
+        read_ctx.rest_api: ["GET"],
+        write_ctx.rest_api: ["GET", "PATCH"],
+    }  # per-API method legality map.
+
+    calls = row["y_true"]["calls"]
+    assert [call["rest_api"] for call in calls] == rest_api_list  # order preserved.
+    for call in calls:
+        assert set(call.keys()) == {"rest_api", "allowed_methods", "method", "arguments"}
+    read_call, write_call = calls
+    assert read_call["method"] == "GET"
+    assert read_call["arguments"] == {}  # read-only calls carry no body args.
+    assert write_call["method"] == "PATCH"
+    assert write_call["arguments"] == {"Address": "192.168.1.1"}  # explicit body binding.
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/gates/test_inference_envelope.py
+++ b/tests/gates/test_inference_envelope.py
@@ -1,0 +1,243 @@
+"""Gate tests: the Phase 2/3 inference envelope stays contract-shaped.
+
+Two layers, matching requirement 4:
+
+* An OFFLINE, deterministic layer. A fixed fixture "model response" (the exact
+  canonical target a perfect model would emit) is fed through the ONE canonical
+  parse/eval path in ``igc/ds/rest_goal_contract.py`` and must EXACT-MATCH the
+  expected ``rest_api_list`` (Phase 2) and ordered ``calls`` (Phase 3). A wrong
+  fixture response is also checked so a green result cannot be a vacuous pass.
+  This layer imports no torch/transformers, needs no GPU, and is collected by the
+  default offline gate (``pytest -q`` over ``tests/``).
+
+* A real-model/vLLM layer, marked ``@pytest.mark.gpu`` and therefore excluded from
+  the offline gate by ``pytest.ini`` ``addopts``. It is additionally guarded so it
+  SKIPS unless a GPU and an approved local checkpoint directory are present. It
+  checks only the ENVELOPE — model loadability, that the request/response keys are
+  present, that the completion JSON-parses, and that the parsed output has the
+  right SHAPE — never stochastic answer quality.
+
+  The ``gpu`` layer is authored as a real, clearly-marked skipped stage, not a
+  fake pass. Run it inside an approved remote container with
+  ``IGC_ENVELOPE_MODEL_DIR`` pointing at a Phase 2/3 checkpoint on the shared
+  model store; never on the operator laptop.
+
+Used by ``scripts/gates/contract_authority.py`` (the contract-authority gate runner
+imports/collects this file) and by ``.github/workflows/ci.yml`` via the default
+offline pytest step.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from igc.ds.rest_goal_contract import (
+    RedfishContext,
+    build_d1_rest_api_list_row,
+    build_ordered_call_row,
+    evaluate_ordered_calls_y_pred,
+    parse_ordered_calls_y_pred,
+    parse_rest_api_list_y_pred,
+    render_ordered_call_example,
+    render_rest_api_list_example,
+)
+
+# Fixed, deterministic fixture shared by the offline envelope checks. Values are
+# arbitrary but stable so the expected parse/eval result is fully determined.
+_FIXTURE_REST_API = "/redfish/v1/Systems/1"  # One concrete legal Redfish target.
+_FIXTURE_TEXT = "power on system 1"          # Operator sentence tied to the target.
+
+
+def _phase2_row() -> dict:
+    """Build the canonical Phase 2 row from the fixed fixture."""
+    contexts = [
+        RedfishContext(
+            rest_api=_FIXTURE_REST_API,
+            allowed_methods=["GET", "PATCH"],
+            json={"@odata.id": _FIXTURE_REST_API, "PowerState": "Off"},
+        )
+    ]
+    return build_d1_rest_api_list_row(
+        text=_FIXTURE_TEXT,
+        contexts=contexts,
+        rest_api_list=[_FIXTURE_REST_API],
+    )
+
+
+def _phase3_row() -> dict:
+    """Build the canonical Phase 3 row from the fixed fixture."""
+    contexts = [
+        RedfishContext(
+            rest_api=_FIXTURE_REST_API,
+            allowed_methods=["GET", "PATCH"],
+            json={"@odata.id": _FIXTURE_REST_API, "PowerState": "Off"},
+        )
+    ]
+    return build_ordered_call_row(
+        text=_FIXTURE_TEXT,
+        contexts=contexts,
+        rest_api_list=[_FIXTURE_REST_API],
+        method_by_api={_FIXTURE_REST_API: "PATCH"},
+        arguments_by_api={_FIXTURE_REST_API: {"PowerState": "On"}},
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Offline deterministic layer (default gate; no torch, no GPU).
+# --------------------------------------------------------------------------- #
+def test_phase2_perfect_response_exact_matches_rest_api_list() -> None:
+    """The canonical target parses back to the expected ordered rest_api_list."""
+    row = _phase2_row()
+    rendered = render_rest_api_list_example(row)
+    # A perfect model emits exactly the canonical target JSON completion.
+    parsed = parse_rest_api_list_y_pred(rendered.target_json)
+    assert parsed == list(row["y_true"]["rest_api_list"])
+
+
+def test_phase2_wrapped_y_pred_envelope_parses_identically() -> None:
+    """The ``{"y_pred": {...}}`` transport envelope parses to the same list."""
+    row = _phase2_row()
+    expected = list(row["y_true"]["rest_api_list"])
+    wrapped = json.dumps({"y_pred": {"rest_api_list": expected}})
+    assert parse_rest_api_list_y_pred(wrapped) == expected
+
+
+def test_phase2_wrong_response_does_not_match() -> None:
+    """A wrong Phase 2 response must NOT exact-match — the check is not vacuous."""
+    row = _phase2_row()
+    wrong = json.dumps({"rest_api_list": ["/redfish/v1/Chassis/9"]})
+    assert parse_rest_api_list_y_pred(wrong) != list(row["y_true"]["rest_api_list"])
+
+
+def test_phase2_malformed_response_raises() -> None:
+    """A non-JSON / mis-shaped Phase 2 response is rejected, never coerced."""
+    with pytest.raises((ValueError, json.JSONDecodeError)):
+        parse_rest_api_list_y_pred("not json at all")
+    with pytest.raises(ValueError):
+        parse_rest_api_list_y_pred(json.dumps({"rest_api_list": "not-a-list"}))
+
+
+def test_phase3_perfect_response_exact_matches_calls() -> None:
+    """The canonical Phase 3 target evaluates to an exact ordered-call match."""
+    row = _phase3_row()
+    rendered = render_ordered_call_example(row)
+    result = evaluate_ordered_calls_y_pred(row, rendered.target_json)
+    assert result["parsed"] is True
+    assert result["parse_error"] == ""
+    assert result["call_ordered_exact_match"] is True
+    assert result["call_ordered_exact_match_rate"] == 1.0
+    assert result["method_exact_match_rate"] == 1.0
+    assert result["arguments_exact_match_rate"] == 1.0
+    # The parsed calls round-trip to the row's y_true calls exactly.
+    assert parse_ordered_calls_y_pred(rendered.target_json) == list(row["y_true"]["calls"])
+
+
+def test_phase3_wrong_method_is_not_exact_match() -> None:
+    """A Phase 3 response with the wrong method must not report an exact match."""
+    row = _phase3_row()
+    # Legal method (GET is in allowed_methods) but not the labelled PATCH call.
+    wrong = json.dumps(
+        {
+            "calls": [
+                {
+                    "rest_api": _FIXTURE_REST_API,
+                    "allowed_methods": ["GET", "PATCH"],
+                    "method": "GET",
+                    "arguments": {},
+                }
+            ]
+        }
+    )
+    result = evaluate_ordered_calls_y_pred(row, wrong)
+    assert result["parsed"] is True
+    assert result["call_ordered_exact_match"] is False
+    assert result["method_exact_match_rate"] == 0.0
+
+
+def test_phase3_invalid_json_reports_parse_failure() -> None:
+    """An unparseable Phase 3 response is a recorded failure, not an exception."""
+    result = evaluate_ordered_calls_y_pred(_phase3_row(), "{ broken json")
+    assert result["parsed"] is False
+    assert result["call_ordered_exact_match"] is False
+    assert result["parse_error"]
+
+
+# --------------------------------------------------------------------------- #
+# Real-model / vLLM envelope layer (opt-in; GPU).
+# --------------------------------------------------------------------------- #
+def _extract_json_object(text: str) -> dict:
+    """Extract the last top-level JSON object from a model completion.
+
+    Envelope helper only: locates a ``{...}`` span and parses it. Used by the
+    GPU stage to prove the completion is JSON-shaped without judging its content.
+
+    :param text: raw decoded model completion.
+    :return: the parsed JSON object.
+    :raises ValueError: if no JSON object can be located/parsed.
+    """
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1 or end < start:
+        raise ValueError("no JSON object found in completion")
+    return json.loads(text[start : end + 1])
+
+
+@pytest.mark.gpu
+def test_phase2_model_response_envelope_only() -> None:
+    """Load a real Phase 2 checkpoint and check ONLY the response envelope.
+
+    This test skips unless a GPU AND an approved checkpoint directory
+    (``IGC_ENVELOPE_MODEL_DIR``) are both present, so it never fabricates a pass.
+    It asserts the model loads, the completion
+    JSON-parses, the ``rest_api_list`` key is present, and the parsed value has the
+    right SHAPE (a list of strings). It never asserts which APIs were produced.
+
+    :raises AssertionError: only on an envelope breach (unparseable output or a
+        missing/mis-typed ``rest_api_list`` key), never on answer quality.
+    """
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("requires an approved CUDA-capable remote container")
+    model_dir = os.environ.get("IGC_ENVELOPE_MODEL_DIR")
+    if not model_dir or not os.path.isdir(model_dir):
+        pytest.skip(
+            "set IGC_ENVELOPE_MODEL_DIR to an approved Phase 2 checkpoint "
+            "on the shared model store"
+        )
+    transformers = pytest.importorskip("transformers")
+
+    tokenizer = transformers.AutoTokenizer.from_pretrained(model_dir)
+    model = transformers.AutoModelForCausalLM.from_pretrained(
+        model_dir,
+        torch_dtype=torch.bfloat16,
+    ).to("cuda")
+    model.eval()
+
+    row = _phase2_row()
+    prompt = render_rest_api_list_example(row).prompt
+    inputs = tokenizer(prompt, return_tensors="pt").to("cuda")
+    with torch.no_grad():
+        generated = model.generate(
+            **inputs,
+            max_new_tokens=128,
+            do_sample=False,  # deterministic decode; envelope, not sampling quality
+        )
+    completion = tokenizer.decode(
+        generated[0][inputs["input_ids"].shape[1] :],
+        skip_special_tokens=True,
+    )
+
+    # Envelope: the completion must be JSON-shaped and carry the contract key.
+    obj = _extract_json_object(completion)
+    assert "rest_api_list" in obj, obj
+    parsed = parse_rest_api_list_y_pred(obj)
+    assert isinstance(parsed, list)
+    assert all(isinstance(item, str) for item in parsed)
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/gates/test_model_artifact_cache.py
+++ b/tests/gates/test_model_artifact_cache.py
@@ -1,0 +1,126 @@
+"""Tests for model artifact cache planning, verification, and tensor inspection."""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+import torch
+
+from scripts.gates.model_artifact_cache import materialize_base_models, planned_paths, verify
+from scripts.gates.model_artifact_load_gate import inspect_adapter_tensors
+
+
+def _sha(path: Path) -> str:
+    """Return the SHA256 digest for a tiny fixture file."""
+
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _spec(root: Path, report: Path, weight: Path) -> dict:
+    """Build a minimal cache spec for temp-file verification."""
+
+    return {
+        "version": 1,
+        "default_root": str(root),
+        "models": [{
+            "role": "model_x",
+            "phase": "phase1",
+            "run_id": "fixture-run",
+            "lfs_ref": "HEAD",
+            "base_model": {
+                "id": "fixture/base",
+                "cache_subdir": "models--fixture--base",
+            },
+            "files": [
+                {
+                    "kind": "report",
+                    "source_path": "unused/report.json",
+                    "dest": "reports/report.json",
+                    "sha256": _sha(report),
+                },
+                {
+                    "kind": "weight",
+                    "source_path": "unused/adapter_model.safetensors",
+                    "dest": "artifacts/adapter_model.safetensors",
+                    "lfs": True,
+                    "sha256": _sha(weight),
+                    "size_bytes": weight.stat().st_size,
+                },
+            ],
+        }],
+    }
+
+
+def test_model_artifact_cache_plans_phase_role_run_layout(tmp_path: Path) -> None:
+    """The plan nests artifacts by phase, role, and run id."""
+
+    report = tmp_path / "report.json"
+    weight = tmp_path / "adapter_model.safetensors"
+    report.write_text('{"ok": true}', encoding="utf-8")
+    weight.write_bytes(b"not-real-safetensors")
+    spec = _spec(tmp_path / "cache", report, weight)
+
+    plan = planned_paths(spec, tmp_path / "cache")
+
+    run = plan["runs"][0]
+    assert run["phase"] == "phase1"
+    assert run["role"] == "model_x"
+    assert run["run_id"] == "fixture-run"
+    assert run["run_dir"].endswith("/phases/phase1/model_x/runs/fixture-run")
+
+
+def test_model_artifact_cache_verify_checks_reports_and_weight_hash(tmp_path: Path) -> None:
+    """Verify accepts a materialized report and adapter with matching SHA/size."""
+
+    cache = tmp_path / "cache"
+    run = cache / "phases/phase1/model_x/runs/fixture-run"
+    report = run / "reports/report.json"
+    weight = run / "artifacts/adapter_model.safetensors"
+    report.parent.mkdir(parents=True)
+    weight.parent.mkdir(parents=True)
+    report.write_text(json.dumps({"schema": "fixture"}), encoding="utf-8")
+    weight.write_bytes(b"fixture-weight")
+
+    spec = _spec(cache, report, weight)
+    result = verify(spec, cache)
+
+    assert result["schema"] == "igc.model_artifact_cache.verify.v1"
+    assert len(result["checks"]) == 2
+
+
+def test_model_artifact_cache_links_base_model_once(tmp_path: Path) -> None:
+    """Base HF cache directories are linked into the shared cache once."""
+
+    source_root = tmp_path / "hf-cache"
+    source_base = source_root / "models--fixture--base"
+    source_base.mkdir(parents=True)
+    (source_base / "config.json").write_text("{}", encoding="utf-8")
+    report = tmp_path / "report.json"
+    weight = tmp_path / "adapter_model.safetensors"
+    report.write_text('{"ok": true}', encoding="utf-8")
+    weight.write_bytes(b"weight")
+    cache = tmp_path / "cache"
+
+    records = materialize_base_models(_spec(cache, report, weight), cache, source_root)
+
+    dest = cache / "base_models/models--fixture--base"
+    assert records[0]["status"] == "linked"
+    assert dest.is_symlink()
+    assert dest.exists()
+
+
+def test_model_artifact_load_gate_inspects_safetensor_shapes(tmp_path: Path) -> None:
+    """Tensor inspection reads key/dtype/shape metadata from a tiny safetensors file."""
+
+    safetensors = pytest.importorskip("safetensors.torch")
+    path = tmp_path / "adapter_model.safetensors"
+    safetensors.save_file({"adapter.weight": torch.zeros(2, 3)}, str(path))
+
+    report = inspect_adapter_tensors(path)
+
+    assert report["tensor_count"] == 1
+    assert report["first_tensor"]["key"] == "adapter.weight"
+    assert report["first_tensor"]["shape"] == [2, 3]
+    assert report["all_shapes_rank_positive"] is True

--- a/tests/gates/test_phase123_conformance.py
+++ b/tests/gates/test_phase123_conformance.py
@@ -1,0 +1,18 @@
+"""Tests for the deterministic Phase 1 -> D1 -> Phase 2 -> Phase 3 gate."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.gates.phase123_conformance import assert_report, build_report
+
+
+def test_phase123_conformance_report_has_expected_keys_and_shapes(tmp_path: Path) -> None:
+    """The conformance gate walks the full deterministic contract ladder."""
+
+    report = build_report(tmp_path)
+    assert_report(report)
+
+    assert report["phase1"]["tensor_keys"] == ["attention_mask", "input_ids", "labels"]
+    assert report["d1"]["judge"]["rest_api_set_match"] is True
+    assert report["phase2"]["parsed_rest_api_list"] == ["/redfish/v1/Systems/1"]
+    assert report["phase3"]["parsed_call_count"] == 1


### PR DESCRIPTION
## Summary
- Adds a repo-level Phase 2/3 contract-authority gate that enforces `igc/ds/rest_goal_contract.py` as the canonical contract and blocks stale/parallel contract fingerprints.
- Adds a schema snapshot and deterministic Phase 1 -> labelled-request dataset -> Phase 2 -> Phase 3 conformance gate for input keys, tensor shapes, parse/eval envelopes, and `target_calls` handoff shape.
- Adds model artifact cache tooling for `/Volumes/k8s-sata-stripe/igc` with LFS pointer/report verification, base-model once-only cache linking, adapter tensor-shape inspection, and opt-in CPU load gate.

## Why
A prior Phase 2/3 branch introduced a parallel mock contract that could pass isolated tests while diverging from the canonical row shape. These gates make that failure mode repo-level and merge-blocking.

## Validation
- Not run: pytest/ruff/Bats/Docker/model-load on laptop are disallowed by project policy.
- Ran static/read-only checks only:
  - `git diff --cached --check`
  - staged private-fingerprint scan for private endpoints/internal workflow names
- Expected authoritative validation: CI/approved remote container runs `python scripts/gates/contract_authority.py`; artifact load gate runs on the approved shared model-cache surface.