### PR TITLE
Internal GitLab CI chain: homelab-k8s pipeline and CPU/GPU surface guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,8 @@ jobs:
         with:
           submodules: recursive
           lfs: true
+          # Full history so the agent-leak guard can scan the PR's commit range.
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -126,6 +128,20 @@ jobs:
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install -r docker/requirements-test.txt
           pip install ruff
+      - name: Agent-leak guard
+        shell: bash
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          RANGE=""
+          if [ -n "$BASE_REF" ]; then
+            git fetch -q origin "$BASE_REF"
+            RANGE="origin/${BASE_REF}..HEAD"
+          fi
+          printf '%s\n\n%s\n' "$PR_TITLE" "$PR_BODY" > /tmp/pr_message.txt
+          python scripts/gates/agent_leak_guard.py ${RANGE:+--commit-range "$RANGE"} --message-file /tmp/pr_message.txt
       - name: Run orchestration dry-runs
         shell: bash
         run: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,84 @@
+# Internal GitLab CI for the mirrored igc repo.
+#
+# Surfaces (enforced by scripts/gates/ci_surface_guard.py + configs/ci/pass_matrix.yaml):
+#   cpu — every job below; runs on the in-cluster `homelab-k8s` runner. The
+#         home-lab cluster has NO GPU and cpu jobs must never request one.
+#   gpu — NOTHING here executes on GPUs. GPU passes run on approved GB300 slot
+#         containers outside CI; this pipeline only VALIDATES their recorded
+#         evidence manifests (reports/gpu-evidence/*.json). The `gb300` tag has
+#         no registered runner in home-lab, so a mis-tagged job cannot schedule.
+#
+# This file carries no internal hostnames: the mirror pulls from GitHub, and
+# runners are addressed by tag only.
+
+stages:
+  - cpu-gate
+  - gpu-evidence
+
+default:
+  image: python:3.12-slim
+
+.cpu-base: &cpu-base
+  tags: [homelab-k8s]
+  variables:
+    IGC_SURFACE: cpu
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: '$CI_COMMIT_BRANCH == "main"'
+
+lint:
+  <<: *cpu-base
+  stage: cpu-gate
+  script:
+    - pip install --quiet ruff
+    - ruff check igc tests
+
+offline-gate:
+  <<: *cpu-base
+  stage: cpu-gate
+  variables:
+    IGC_SURFACE: cpu
+    KMP_DUPLICATE_LIB_OK: "TRUE"
+    OMP_NUM_THREADS: "1"
+    TRANSFORMERS_OFFLINE: "1"
+    HF_DATASETS_OFFLINE: "1"
+    PIP_CACHE_DIR: .pip-cache
+  cache:
+    key: pip-$CI_COMMIT_REF_SLUG
+    paths: [.pip-cache]
+  script:
+    - pip install --quiet torch --index-url https://download.pytorch.org/whl/cpu
+    - pip install --quiet -r docker/requirements-test.txt
+    - python -m pytest -q
+
+surface-guard:
+  <<: *cpu-base
+  stage: cpu-gate
+  script:
+    - pip install --quiet pyyaml
+    - python scripts/gates/ci_surface_guard.py
+
+# Validates committed GPU evidence manifests (schema in the pass matrix). This
+# is a CPU job: it reads JSON, it does not touch a GPU. Malformed evidence
+# fails; absent evidence passes (requiredness is enforced at phase acceptance).
+gpu-evidence-validate:
+  <<: *cpu-base
+  stage: gpu-evidence
+  script:
+    - pip install --quiet pyyaml
+    - python scripts/gates/ci_surface_guard.py
+
+# Placeholder marking the GPU execution surface. Never runs in home-lab (the
+# gb300 tag has no runner there) and never in an MR pipeline; if a GB300 runner
+# is ever registered, this stays manual-only per validate->plan->apply->verify.
+gb300-surface:
+  stage: gpu-evidence
+  tags: [gb300]
+  variables:
+    IGC_SURFACE: gpu
+  when: manual
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "main"'
+      when: manual
+  script:
+    - echo "GPU passes run on approved GB300 slot containers; see configs/ci/pass_matrix.yaml"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,6 +58,23 @@ surface-guard:
     - pip install --quiet pyyaml
     - python scripts/gates/ci_surface_guard.py
 
+# Outbound fence: no agent artifacts tracked, no agent attribution or
+# agent-file chatter in commit/MR messages, no internal endpoint literals.
+agent-leak-guard:
+  <<: *cpu-base
+  stage: cpu-gate
+  variables:
+    IGC_SURFACE: cpu
+    GIT_DEPTH: "0"
+  script:
+    - |
+      RANGE=""
+      if [ -n "${CI_MERGE_REQUEST_DIFF_BASE_SHA:-}" ]; then
+        RANGE="${CI_MERGE_REQUEST_DIFF_BASE_SHA}..HEAD"
+      fi
+      printf '%s\n\n%s\n' "${CI_MERGE_REQUEST_TITLE:-}" "${CI_MERGE_REQUEST_DESCRIPTION:-}" > /tmp/mr_message.txt
+      python scripts/gates/agent_leak_guard.py ${RANGE:+--commit-range "$RANGE"} --message-file /tmp/mr_message.txt
+
 # Validates committed GPU evidence manifests (schema in the pass matrix). This
 # is a CPU job: it reads JSON, it does not touch a GPU. Malformed evidence
 # fails; absent evidence passes (requiredness is enforced at phase acceptance).

--- a/configs/ci/pass_matrix.yaml
+++ b/configs/ci/pass_matrix.yaml
@@ -34,6 +34,7 @@ passes:
   perf_budgets:             { surface: cpu, tool: "pytest -m perf (machine-loose tripwires)" }
   no_gpu_homelab_policy:    { surface: cpu, tool: "policy scan: no GPU resource requests in home-lab CI/manifests" }
   gpu_evidence_validation:  { surface: cpu, tool: "validate committed GPU evidence manifests against the schema below" }
+  agent_leak_guard:         { surface: cpu, tool: "scripts/gates/agent_leak_guard.py: no agent artifacts tracked, no agent attribution/chatter in commit+PR/MR messages, no internal endpoint literals" }
 
   # ---- GPU passes: GB300 only; CI sees their EVIDENCE, never runs them. ----
   single_gpu_smoke:         { surface: gpu, evidence: required }

--- a/configs/ci/pass_matrix.yaml
+++ b/configs/ci/pass_matrix.yaml
@@ -1,0 +1,61 @@
+# CI pass matrix — the single source for WHERE every validation pass runs.
+#
+# Used by:
+#   scripts/gates/ci_surface_guard.py  (gate ci.surface-guard — MERGE-BLOCKING)
+#   .gitlab-ci.yml                     (jobs must agree with this matrix)
+#   tests/gates/test_ci_surface_guard.py
+#
+# Surfaces (binding separation — CPU and GPU never mix):
+#   cpu — offline, no GPU/network/downloads. Runs on BOTH shared-code CIs:
+#         GitHub Actions (ubuntu runners) and the internal GitLab CI on the
+#         in-cluster `homelab-k8s` runner. The home-lab cluster has NO GPU;
+#         a cpu pass must never request one.
+#   gpu — needs real GPUs. Runs ONLY on approved GB300 slot containers,
+#         launched outside merge-request pipelines. CI never live-executes a
+#         gpu pass; the pipeline validates RECORDED evidence bundles instead
+#         (schema below). The `gb300` runner tag deliberately has no runner in
+#         home-lab, so a mis-tagged job can never schedule there.
+version: 1
+
+# Runner tags per surface. cpu jobs must carry homelab-k8s (binding); gpu jobs
+# carry gb300 (a tag with NO registered runner in home-lab — scheduling proof).
+runner_tags:
+  cpu: homelab-k8s
+  gpu: gb300
+
+passes:
+  # ---- CPU passes: the offline gate everything merges through. ----
+  lint:                     { surface: cpu, tool: "ruff check igc tests" }
+  offline_pytest:           { surface: cpu, tool: "pytest -q (markers gpu/slow/download excluded)" }
+  shell_suite:              { surface: cpu, tool: "bats + shellcheck over scripts" }
+  orchestration_dry_runs:   { surface: cpu, tool: "render_run/launch_run --dry-run spec renders" }
+  contract_gates:           { surface: cpu, tool: "scripts/gates/* structural + schema gates" }
+  docs_consistency:         { surface: cpu, tool: "scripts/gates/docs_consistency.py" }
+  perf_budgets:             { surface: cpu, tool: "pytest -m perf (machine-loose tripwires)" }
+  no_gpu_homelab_policy:    { surface: cpu, tool: "policy scan: no GPU resource requests in home-lab CI/manifests" }
+  gpu_evidence_validation:  { surface: cpu, tool: "validate committed GPU evidence manifests against the schema below" }
+
+  # ---- GPU passes: GB300 only; CI sees their EVIDENCE, never runs them. ----
+  single_gpu_smoke:         { surface: gpu, evidence: required }
+  ddp_same_node_sanity:     { surface: gpu, evidence: required }
+  fsdp2_same_node_sanity:   { surface: gpu, evidence: required }
+  two_node_sanity:          { surface: gpu, evidence: required }
+  phase1_full_pretrain:     { surface: gpu, evidence: required }
+  phase1_golden_acceptance: { surface: gpu, evidence: required }
+  corpus_full_validation:   { surface: gpu, evidence: required }   # runs in slot containers against /models
+  cuda_profile:             { surface: gpu, evidence: required }
+  latent_invariance_acceptance: { surface: gpu, evidence: required }  # z_rest/z_method model-acceptance
+
+# Evidence manifest schema for gpu passes (one JSON per recorded run under
+# reports/gpu-evidence/). Mirrors the Blackwell acceptance-gate record fields.
+evidence_schema:
+  required_fields:
+    - pass_name        # one of the gpu passes above
+    - commit_sha       # exact commit the run used
+    - command          # exact command/profile/spec
+    - world_size       # rank count
+    - nodes            # slot list, e.g. ["slot2", "slot11"]
+    - precision        # dtype/precision used
+    - wandb_run        # W&B run path or id (or "none" with reason)
+    - artifact_path    # /models/... output location
+    - status           # pass | fail

--- a/scripts/gates/agent_leak_guard.py
+++ b/scripts/gates/agent_leak_guard.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Gate: repo.agent-leak-guard — nothing agent-internal leaks to the outside.
+
+The shared-code repo (GitHub + its internal mirror) must never carry agent
+context: agent/instruction files stay untracked, commit and PR/MR messages
+carry no agent attribution or agent-file chatter, and internal endpoints
+(lab IPs, internal hostnames) never appear in tracked files. The private
+context repo on the internal GitLab is where agent files live — this gate is
+the outbound fence.
+
+Three checks:
+
+1. tracked files — no agent artifact is committed (the binding artifact list);
+2. commit messages (a range) and an optional PR/MR body — no agent
+   attribution trailers, no "Generated with ..." footers, no agent-file
+   mentions, no session chatter. ``claude/*`` / ``codex/*`` BRANCH names are
+   the established public naming convention and are not leaks; patterns below
+   are anchored so branch refs in merge commits pass.
+3. tracked file contents — no internal endpoint literals (lab IP ranges,
+   internal hostnames); env-var indirection is the allowed form.
+
+Used by:
+  tests/gates/test_agent_leak_guard.py  (offline gate; runs in `pytest -q`)
+  .gitlab-ci.yml cpu-gate + the GitHub Actions gate job
+  CLI: python scripts/gates/agent_leak_guard.py [--commit-range A..B]
+       [--message-file FILE]
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Agent artifacts that must never be tracked in the shared-code repo.
+FORBIDDEN_TRACKED = (
+    "CLAUDE.md",
+    "AGENTS.md",
+    "AGENT_BOOTSTRAP.md",
+    "AGENT_HANDOFF.md",
+    "CODEX_HANDOFF.md",
+    "CODEX_TASKS.md",
+    "TEAM_GUIDE.md",
+    "COORDINATION.md",
+    "IMPROVEMENT_PLAN.md",
+    "CLAUDE_REVIEW.md*",
+    "CLAUDE_PLAN.md",
+    "CLAUDE_PATCH.diff",
+    ".claude/*",
+    ".codex/*",
+    ".internal/*",
+    ".agent-review/*",
+)
+
+# Message patterns that ARE leaks. Deliberately anchored/specific so the
+# established public branch naming (claude/<topic>, codex/<topic>) passes.
+MESSAGE_PATTERNS = (
+    (re.compile(r"co-authored-by:.*(claude|anthropic)", re.I), "agent attribution trailer"),
+    (re.compile(r"noreply@anthropic\.com", re.I), "agent attribution email"),
+    (re.compile(r"generated with.*claude", re.I), "agent generation footer"),
+    (re.compile(r"\bclaude code\b", re.I), "agent tool name"),
+    (re.compile(r"\b(claude|codex)\s+(session|worker|agent|pass)\b", re.I), "agent session chatter"),
+    (re.compile(r"\b(CLAUDE|AGENTS|TEAM_GUIDE|COORDINATION|AGENT_HANDOFF|CODEX_TASKS)\.md\b"), "agent file mention"),
+    (re.compile(r"\.internal/"), "internal context path"),
+    (re.compile(r"\bagent handoff\b", re.I), "agent session chatter"),
+)
+
+# Internal endpoint literals that must never appear in tracked content.
+ENDPOINT_PATTERNS = (
+    (re.compile(r"\b172\.25\.230\.\d{1,3}\b"), "lab node IP"),
+    (re.compile(r"\b10\.12\.2\.\d{1,3}\b"), "lab storage IP"),
+    (re.compile(r"\bgitlab\.rnd\.[a-z0-9.-]+\b", re.I), "internal GitLab hostname"),
+    (re.compile(r"\brnd\.embedings\.ai\b", re.I), "internal domain"),
+    (re.compile(r"nv72-brain://", re.I), "internal MCP resource"),
+)
+
+# The gate and its tests carry the detection patterns/fixtures as literals —
+# they are the ONLY files exempt from the endpoint scan.
+_ENDPOINT_SCAN_EXEMPT = {
+    "scripts/gates/agent_leak_guard.py",
+    "tests/gates/test_agent_leak_guard.py",
+}
+
+# Binary-ish assets are skipped by extension instead of content sniffing.
+_SKIP_SUFFIXES = {".png", ".jpg", ".jpeg", ".gif", ".pt", ".bin", ".safetensors", ".npy", ".tar", ".gz"}
+
+
+def _git(args: list[str], cwd: Path) -> str:
+    """Run git and return stdout (empty string on failure)."""
+    try:
+        return subprocess.run(
+            ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+        ).stdout
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def check_tracked_files(repo: Path = REPO_ROOT) -> list[str]:
+    """No agent artifact may be tracked."""
+    violations: list[str] = []
+    for path in _git(["ls-files"], repo).splitlines():
+        name = Path(path).name
+        for pattern in FORBIDDEN_TRACKED:
+            if fnmatch.fnmatch(path, pattern) or fnmatch.fnmatch(name, pattern):
+                violations.append(f"tracked agent artifact: {path}")
+                break
+    return violations
+
+
+def scan_message(message: str, label: str) -> list[str]:
+    """Scan one commit/PR/MR message for agent leaks."""
+    violations: list[str] = []
+    for pattern, why in MESSAGE_PATTERNS:
+        if pattern.search(message):
+            violations.append(f"{label}: {why} ({pattern.pattern})")
+    return violations
+
+
+def check_commit_messages(commit_range: str, repo: Path = REPO_ROOT) -> list[str]:
+    """Scan every commit message (subject+body+trailers) in the range."""
+    violations: list[str] = []
+    raw = _git(["log", "--format=%H%x01%B%x02", commit_range], repo)
+    for entry in raw.split("\x02"):
+        entry = entry.strip()
+        if not entry:
+            continue
+        sha, _, body = entry.partition("\x01")
+        violations += scan_message(body, f"commit {sha[:9]}")
+    return violations
+
+
+def check_endpoint_literals(repo: Path = REPO_ROOT) -> list[str]:
+    """No internal endpoint literal in tracked file contents."""
+    violations: list[str] = []
+    for path in _git(["ls-files"], repo).splitlines():
+        if path in _ENDPOINT_SCAN_EXEMPT:
+            continue
+        file_path = repo / path
+        if file_path.suffix.lower() in _SKIP_SUFFIXES or not file_path.is_file():
+            continue
+        try:
+            text = file_path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for pattern, why in ENDPOINT_PATTERNS:
+            match = pattern.search(text)
+            if match:
+                violations.append(f"{path}: {why} ({match.group(0)})")
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    :return: process exit code (0 = no leaks).
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--commit-range",
+        default="",
+        help="git range to scan (e.g. origin/main..HEAD); omitted/unresolvable -> skipped.",
+    )
+    parser.add_argument(
+        "--message-file",
+        default="",
+        help="Optional file carrying the PR/MR title+body to scan.",
+    )
+    args = parser.parse_args(argv)
+
+    violations = check_tracked_files() + check_endpoint_literals()
+    if args.commit_range:
+        # Skip gracefully when the range is unresolvable (shallow clone).
+        if _git(["rev-list", "-n", "1", args.commit_range], REPO_ROOT):
+            violations += check_commit_messages(args.commit_range)
+        else:
+            print(f"note: commit range {args.commit_range!r} unresolvable — skipped")
+    if args.message_file:
+        text = Path(args.message_file).read_text(encoding="utf-8", errors="ignore")
+        violations += scan_message(text, "PR/MR message")
+
+    for violation in violations:
+        print(f"BLOCKER: {violation}", file=sys.stderr)
+    if not violations:
+        print("OK: no agent leaks in tracked files, messages, or endpoints.")
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/scripts/gates/ci_surface_guard.py
+++ b/scripts/gates/ci_surface_guard.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Gate: ci.surface-guard — CPU and GPU passes never mix surfaces.
+
+The pass matrix (``configs/ci/pass_matrix.yaml``) is the single source for
+where every validation pass runs: cpu passes on the shared-code CIs (GitHub
+Actions + the internal GitLab ``homelab-k8s`` in-cluster runner, which has NO
+GPU), gpu passes only on approved GB300 slot containers with their results
+recorded as evidence manifests. This gate enforces that mechanically:
+
+* every ``.gitlab-ci.yml`` job carries exactly the runner tag its surface
+  demands (cpu -> ``homelab-k8s``; gpu -> ``gb300``, a tag with no home-lab
+  runner so a mis-tagged job cannot schedule);
+* no home-lab (cpu-tagged) job requests a GPU (``nvidia.com/gpu``, ``--gpus``,
+  CUDA device envs) — the ``policy.no-gpu-homelab`` rule;
+* gpu-surface jobs never run in merge-request pipelines (no live GPU work from
+  an MR) — they may only validate committed evidence;
+* committed GPU evidence manifests under ``reports/gpu-evidence/`` conform to
+  the matrix's evidence schema, and their pass names exist in the matrix.
+
+Used by:
+  tests/gates/test_ci_surface_guard.py  (offline gate; runs in `pytest -q`)
+  .gitlab-ci.yml cpu-gate stage
+  CLI: python scripts/gates/ci_surface_guard.py
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MATRIX_PATH = REPO_ROOT / "configs" / "ci" / "pass_matrix.yaml"
+GITLAB_CI_PATH = REPO_ROOT / ".gitlab-ci.yml"
+EVIDENCE_DIR = REPO_ROOT / "reports" / "gpu-evidence"
+
+# Patterns that mean "this job wants a GPU". Any of these in a cpu-tagged job
+# is a policy.no-gpu-homelab violation.
+_GPU_MARKERS = ("nvidia.com/gpu", "--gpus", "CUDA_VISIBLE_DEVICES", "nvidia-smi")
+
+# GitLab CI reserved top-level keys that are not jobs.
+_RESERVED = {
+    "stages", "variables", "default", "include", "workflow", "image",
+    "services", "before_script", "after_script", "cache",
+}
+
+
+def load_matrix(path: Path = MATRIX_PATH) -> dict[str, Any]:
+    """Load the pass matrix."""
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _jobs(ci: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    """Extract job definitions from a parsed .gitlab-ci.yml."""
+    return {
+        name: value
+        for name, value in ci.items()
+        if name not in _RESERVED and not name.startswith(".") and isinstance(value, Mapping)
+    }
+
+
+def check_gitlab_ci(
+    ci: Mapping[str, Any],
+    matrix: Mapping[str, Any],
+) -> list[str]:
+    """Validate the GitLab pipeline against the pass matrix.
+
+    :param ci: parsed .gitlab-ci.yml content.
+    :param matrix: parsed pass matrix.
+    :return: list of human-readable violations; empty means compliant.
+    """
+    violations: list[str] = []
+    tags = matrix["runner_tags"]
+    cpu_tag, gpu_tag = tags["cpu"], tags["gpu"]
+
+    for name, job in _jobs(ci).items():
+        job_tags = list(job.get("tags") or [])
+        surface = str(job.get("variables", {}).get("IGC_SURFACE", ""))
+        if surface not in ("cpu", "gpu"):
+            violations.append(f"job {name}: missing IGC_SURFACE variable (cpu|gpu)")
+            continue
+        expected_tag = cpu_tag if surface == "cpu" else gpu_tag
+        if job_tags != [expected_tag]:
+            violations.append(
+                f"job {name}: surface {surface} must carry exactly tag "
+                f"[{expected_tag}], got {job_tags}"
+            )
+        blob = json.dumps(job)
+        if surface == "cpu":
+            for marker in _GPU_MARKERS:
+                if marker in blob:
+                    violations.append(
+                        f"job {name}: cpu-surface job references GPU marker {marker!r} "
+                        "(policy.no-gpu-homelab)"
+                    )
+        else:
+            # gpu-surface jobs must never run in merge-request pipelines.
+            rules = json.dumps(job.get("rules", []))
+            if "merge_request_event" in rules:
+                violations.append(
+                    f"job {name}: gpu-surface job runs in a merge-request pipeline "
+                    "(no live GPU work from MRs)"
+                )
+            if not job.get("when") == "manual" and not job.get("rules"):
+                violations.append(
+                    f"job {name}: gpu-surface job must be manual or rule-gated"
+                )
+    return violations
+
+
+def check_evidence(matrix: Mapping[str, Any], evidence_dir: Path = EVIDENCE_DIR) -> list[str]:
+    """Validate committed GPU evidence manifests against the matrix schema.
+
+    An empty/missing evidence directory is fine — evidence requiredness is
+    enforced at phase-acceptance time, not per commit; this check only rejects
+    MALFORMED evidence so a bad manifest cannot masquerade as proof.
+    """
+    violations: list[str] = []
+    if not evidence_dir.exists():
+        return violations
+    required = list(matrix["evidence_schema"]["required_fields"])
+    gpu_passes = {
+        name for name, spec in matrix["passes"].items() if spec.get("surface") == "gpu"
+    }
+    for manifest_path in sorted(evidence_dir.glob("*.json")):
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            violations.append(f"{manifest_path.name}: invalid JSON ({exc.msg})")
+            continue
+        for field in required:
+            if field not in manifest:
+                violations.append(f"{manifest_path.name}: missing field {field}")
+        pass_name = manifest.get("pass_name")
+        if pass_name is not None and pass_name not in gpu_passes:
+            violations.append(
+                f"{manifest_path.name}: unknown gpu pass {pass_name!r}"
+            )
+        if manifest.get("status") not in ("pass", "fail", None):
+            violations.append(f"{manifest_path.name}: status must be pass|fail")
+    return violations
+
+
+def check_matrix(matrix: Mapping[str, Any]) -> list[str]:
+    """Sanity-check the matrix itself: two surfaces, binding cpu tag."""
+    violations: list[str] = []
+    if matrix.get("runner_tags", {}).get("cpu") != "homelab-k8s":
+        violations.append("runner_tags.cpu must be 'homelab-k8s' (binding)")
+    for name, spec in matrix.get("passes", {}).items():
+        if spec.get("surface") not in ("cpu", "gpu"):
+            violations.append(f"pass {name}: surface must be cpu|gpu")
+        if spec.get("surface") == "gpu" and spec.get("evidence") != "required":
+            violations.append(f"pass {name}: gpu pass must declare evidence: required")
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    _ = argv
+    matrix = load_matrix()
+    violations = check_matrix(matrix)
+    if GITLAB_CI_PATH.exists():
+        ci = yaml.safe_load(GITLAB_CI_PATH.read_text(encoding="utf-8"))
+        violations += check_gitlab_ci(ci, matrix)
+    violations += check_evidence(matrix)
+    for violation in violations:
+        print(f"BLOCKER: {violation}", file=sys.stderr)
+    if not violations:
+        print("OK: CPU/GPU surface separation holds.")
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/scripts/gb300_distribute_image.sh
+++ b/scripts/gb300_distribute_image.sh
@@ -6,7 +6,7 @@
 #
 # Runs on one node (needs docker + zstd + /models mounted; reaches the others by ssh).
 #   scripts/gb300_distribute_image.sh
-#   DIST_NODES="172.25.230.42 172.25.230.49" scripts/gb300_distribute_image.sh   # subset
+#   DIST_NODES="<node-ip> <node-ip>" scripts/gb300_distribute_image.sh           # subset
 #   FORCE_SAVE=1 scripts/gb300_distribute_image.sh                               # re-save tarball
 #
 # Only the KEYLESS image is distributed here — never the .internal SSH-key image.
@@ -29,9 +29,12 @@ case "$COMPRESS" in
     *) echo "BLOCKER: COMPRESS must be zstd or gzip (got $COMPRESS)" >&2; exit 3 ;;
 esac
 TARBALL="${MODELS_IMAGES}/${IMAGE}-${TAG}.${EXT}"
-# All 18 GB300 nodes: 172.25.230.40 .. .57
+# Node list comes from the environment (or a gitignored nodes file) — the fleet
+# addressing is internal and never hardcoded in the public repo.
+NODES_FILE="${GB300_NODES_FILE:-.internal/gb300_nodes}"
 # shellcheck disable=SC2206  # word-split the space-separated override on purpose
-NODES=(${DIST_NODES:-$(seq -f "172.25.230.%g" 40 57)})
+NODES=(${DIST_NODES:-$(cat "$NODES_FILE" 2>/dev/null || true)})
+[ "${#NODES[@]}" -gt 0 ] || { echo "BLOCKER: set DIST_NODES=\"ip ip ...\" or provide $NODES_FILE (one line, space-separated node IPs)" >&2; exit 3; }
 SSH="ssh -o BatchMode=yes -o ConnectTimeout=8"
 
 log() { echo "=== [$(date -u '+%F %T')] $* ==="; }

--- a/scripts/gb300_sanity_check.sh
+++ b/scripts/gb300_sanity_check.sh
@@ -8,7 +8,7 @@
 # prints PASS/FAIL per config; any failure means "do NOT start full training".
 #
 # Usage (on a node, or from a control host with ssh to the nodes):
-#   SANITY_NODES="172.25.230.42 172.25.230.49" scripts/gb300_sanity_check.sh   # runs 1,4,8
+#   SANITY_NODES="<node-ip> <node-ip>" scripts/gb300_sanity_check.sh           # runs 1,4,8
 #   SANITY_GPUS="1 4" scripts/gb300_sanity_check.sh                            # single-node only
 #   IGC_IMAGE=igc-train:ngc26.03-py3 SANITY_NODES="…" scripts/gb300_sanity_check.sh
 #

--- a/tests/gates/test_agent_leak_guard.py
+++ b/tests/gates/test_agent_leak_guard.py
@@ -1,0 +1,129 @@
+"""Offline tests for the agent-leak guard.
+
+The real repo must be clean (no tracked agent artifacts, no internal endpoint
+literals); fixture repos prove each leak class is detected; the established
+public branch naming (claude/<topic>, codex/<topic>) must NOT be flagged.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+SCRIPT = Path("scripts/gates/agent_leak_guard.py")
+
+
+def _load_gate() -> ModuleType:
+    """Load the gate script module for direct testing."""
+    spec = importlib.util.spec_from_file_location("agent_leak_guard", SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _git(repo: Path, *args: str) -> None:
+    """Run git in the fixture repo."""
+    subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@t", *args],
+        cwd=repo, check=True, capture_output=True,
+    )
+
+
+def _fixture_repo(tmp_path: Path) -> Path:
+    """A tiny git repo with one clean tracked file."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    (repo / "module.py").write_text("VALUE = 1\n", encoding="utf-8")
+    _git(repo, "add", "module.py")
+    _git(repo, "commit", "-q", "-m", "Add module")
+    return repo
+
+
+def test_real_repo_is_clean() -> None:
+    """The shared-code repo tracks no agent artifacts and no endpoint literals."""
+    gate = _load_gate()
+    assert gate.check_tracked_files() == []
+    assert gate.check_endpoint_literals() == []
+
+
+def test_tracked_agent_artifact_fails(tmp_path: Path) -> None:
+    """A committed CLAUDE.md (or .internal file) is a leak."""
+    gate = _load_gate()
+    repo = _fixture_repo(tmp_path)
+    (repo / "CLAUDE.md").write_text("agent instructions", encoding="utf-8")
+    (repo / ".internal").mkdir()
+    (repo / ".internal" / "notes.md").write_text("internal", encoding="utf-8")
+    _git(repo, "add", "-f", "CLAUDE.md", ".internal/notes.md")
+    _git(repo, "commit", "-q", "-m", "oops")
+
+    violations = gate.check_tracked_files(repo)
+    assert any("CLAUDE.md" in v for v in violations)
+    assert any(".internal/notes.md" in v for v in violations)
+
+
+def test_endpoint_literal_fails(tmp_path: Path) -> None:
+    """A lab IP or internal hostname in tracked content is a leak."""
+    gate = _load_gate()
+    repo = _fixture_repo(tmp_path)
+    (repo / "config.py").write_text(
+        'HOST = "172.25.230.42"\nGL = "gitlab.rnd.example"\n', encoding="utf-8"
+    )
+    _git(repo, "add", "config.py")
+    _git(repo, "commit", "-q", "-m", "Add config")
+
+    violations = gate.check_endpoint_literals(repo)
+    assert any("lab node IP" in v for v in violations)
+    assert any("internal GitLab hostname" in v for v in violations)
+
+
+def test_attribution_and_agent_chatter_in_messages_fail(tmp_path: Path) -> None:
+    """Attribution trailers, generation footers, and agent-file mentions are leaks."""
+    gate = _load_gate()
+
+    for message, expected in (
+        ("Fix bug\n\nCo-Authored-By: Claude <x@y>", "attribution trailer"),
+        ("Fix bug\n\nGenerated with Claude Code", "agent"),
+        ("Update per CLAUDE.md instructions", "agent file mention"),
+        ("Sync notes to .internal/board", "internal context path"),
+        ("Handled by the codex worker overnight", "session chatter"),
+    ):
+        violations = gate.scan_message(message, "m")
+        assert violations, message
+        assert any(expected in v for v in violations), (message, violations)
+
+
+def test_branch_naming_convention_is_not_flagged() -> None:
+    """claude/<topic> and codex/<topic> branch refs in merge messages pass."""
+    gate = _load_gate()
+    for message in (
+        "Merge pull request #142 from spyroot/claude/phase23-semantics",
+        "Merge branch 'codex/p0-d1-contract-source-fix' into main",
+        "Reconcile codex/phase2-labelled-requests follow-up",
+    ):
+        assert gate.scan_message(message, "m") == [], message
+
+
+def test_commit_range_scan_detects_leaky_commit(tmp_path: Path) -> None:
+    """A leaky message inside the scanned range is caught."""
+    gate = _load_gate()
+    repo = _fixture_repo(tmp_path)
+    base = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+    (repo / "module.py").write_text("VALUE = 2\n", encoding="utf-8")
+    _git(repo, "commit", "-aq", "-m", "Tune value\n\nCo-Authored-By: Claude <noreply@anthropic.com>")
+
+    violations = gate.check_commit_messages(f"{base}..HEAD", repo)
+    assert any("attribution" in v for v in violations)
+
+
+# Author: Mus mbayramo@stanford.edu

--- a/tests/gates/test_ci_surface_guard.py
+++ b/tests/gates/test_ci_surface_guard.py
@@ -1,0 +1,135 @@
+"""Offline tests for the CPU/GPU surface-separation gate.
+
+The committed pipeline + matrix must pass; representative violations (a cpu
+job requesting a GPU, a gpu job in an MR pipeline, a wrong runner tag, a
+malformed evidence manifest) must fail.
+
+Author:
+Mus mbayramo@stanford.edu
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import yaml
+
+SCRIPT = Path("scripts/gates/ci_surface_guard.py")
+
+
+def _load_gate() -> ModuleType:
+    """Load the gate script module for direct testing."""
+    spec = importlib.util.spec_from_file_location("ci_surface_guard", SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _ci() -> dict:
+    """The committed .gitlab-ci.yml, parsed."""
+    return yaml.safe_load(Path(".gitlab-ci.yml").read_text(encoding="utf-8"))
+
+
+def test_committed_pipeline_and_matrix_pass() -> None:
+    """The committed matrix, pipeline, and (absent) evidence all validate."""
+    gate = _load_gate()
+    matrix = gate.load_matrix()
+
+    assert gate.check_matrix(matrix) == []
+    assert gate.check_gitlab_ci(_ci(), matrix) == []
+    assert gate.check_evidence(matrix) == []
+
+
+def test_cpu_job_requesting_gpu_fails() -> None:
+    """A homelab job referencing a GPU marker violates policy.no-gpu-homelab."""
+    gate = _load_gate()
+    matrix = gate.load_matrix()
+    ci = _ci()
+    ci["lint"]["script"].append("nvidia-smi")
+
+    violations = gate.check_gitlab_ci(ci, matrix)
+    assert any("no-gpu-homelab" in v for v in violations)
+
+
+def test_wrong_runner_tag_fails() -> None:
+    """A cpu-surface job on any tag but homelab-k8s fails."""
+    gate = _load_gate()
+    matrix = gate.load_matrix()
+    ci = _ci()
+    ci["lint"]["tags"] = ["gb300"]
+
+    violations = gate.check_gitlab_ci(ci, matrix)
+    assert any("must carry exactly tag" in v for v in violations)
+
+
+def test_gpu_job_in_merge_request_pipeline_fails() -> None:
+    """A gpu-surface job wired into MR pipelines fails (no live GPU from MRs)."""
+    gate = _load_gate()
+    matrix = gate.load_matrix()
+    ci = _ci()
+    ci["gb300-surface"]["rules"] = [
+        {"if": '$CI_PIPELINE_SOURCE == "merge_request_event"'},
+    ]
+
+    violations = gate.check_gitlab_ci(ci, matrix)
+    assert any("merge-request pipeline" in v for v in violations)
+
+
+def test_job_without_surface_variable_fails() -> None:
+    """Every job must declare its surface explicitly."""
+    gate = _load_gate()
+    matrix = gate.load_matrix()
+    ci = _ci()
+    del ci["lint"]["variables"]
+
+    violations = gate.check_gitlab_ci(ci, matrix)
+    assert any("missing IGC_SURFACE" in v for v in violations)
+
+
+def test_malformed_evidence_manifest_fails(tmp_path: Path) -> None:
+    """A GPU evidence manifest missing schema fields is rejected."""
+    gate = _load_gate()
+    matrix = gate.load_matrix()
+    evidence = tmp_path / "gpu-evidence"
+    evidence.mkdir()
+    (evidence / "run1.json").write_text(
+        json.dumps({"pass_name": "ddp_same_node_sanity", "status": "pass"}),
+        encoding="utf-8",
+    )
+
+    violations = gate.check_evidence(matrix, evidence)
+    assert any("missing field commit_sha" in v for v in violations)
+
+
+def test_unknown_gpu_pass_in_evidence_fails(tmp_path: Path) -> None:
+    """Evidence naming a pass outside the matrix is rejected."""
+    gate = _load_gate()
+    matrix = gate.load_matrix()
+    evidence = tmp_path / "gpu-evidence"
+    evidence.mkdir()
+    manifest = {field: "x" for field in matrix["evidence_schema"]["required_fields"]}
+    manifest["pass_name"] = "made_up_pass"
+    manifest["status"] = "pass"
+    (evidence / "run1.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    violations = gate.check_evidence(matrix, evidence)
+    assert any("unknown gpu pass" in v for v in violations)
+
+
+def test_unfrozen_matrix_cpu_tag_fails(tmp_path: Path) -> None:
+    """Changing the binding homelab-k8s cpu tag fails the matrix sanity check."""
+    gate = _load_gate()
+    matrix = gate.load_matrix()
+    matrix["runner_tags"]["cpu"] = "anywhere"
+
+    violations = gate.check_matrix(matrix)
+    assert any("homelab-k8s" in v for v in violations)
+
+
+# Author: Mus mbayramo@stanford.edu


### PR DESCRIPTION
Wires the shared-code repo for the GitHub → internal-GitLab pull mirror, with a hard CPU/GPU surface separation and an outbound agent-leak fence:

- **`.gitlab-ci.yml`** — cpu-gate (lint, offline pytest gate, surface guard, leak guard) + gpu-evidence validation; every job tagged for the in-cluster `homelab-k8s` runner; no internal hostnames (mirror pulls from GitHub, runners addressed by tag only).
- **`configs/ci/pass_matrix.yaml`** — single source for where every validation pass runs: `cpu` (GitHub Actions + homelab-k8s; the home-lab cluster has NO GPU) vs `gpu` (GB300 slots only, recorded as evidence manifests — CI validates, never live-executes).
- **`ci.surface-guard` gate** — every job declares `IGC_SURFACE` and must carry exactly that surface's runner tag; cpu jobs referencing GPU markers fail (`policy.no-gpu-homelab`); gpu-surface jobs are manual-only and never in MR pipelines; the `gb300` tag has no home-lab runner so a mis-tagged job cannot schedule; committed `reports/gpu-evidence/*.json` manifests must carry the full run identity.
- **`repo.agent-leak-guard` gate** — the outbound fence: no agent instruction files tracked, no assistant attribution or instruction-file chatter in commit/PR/MR messages (branch-name conventions pass), no internal endpoint literals in tracked content. Runs on both CI sides (commit-range + PR/MR body scan).
- **Leak fixes found by the new guard**: the GB300 distribute/sanity scripts hardcoded node addresses (including a whole-fleet range generator) — now env-driven with a gitignored nodes-file fallback.

GitLab-side setup (mirroring, private context repo, token grants) is operator-driven and documented internally; nothing here needs a token or names an internal host.

Independent of the #142→#143→#144 chain (no file overlap).