### PR TITLE
Install setuptools in offline conda environment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,6 +58,7 @@ workflow:
 .igc-test-before-script: &igc-test-before-script
   - export HOMELAB_IN_CLUSTER=1
   - conda env create --file environment-dev.yaml
+  - conda install --name igc-dev --yes setuptools
 
 focused-gate:
   stage: cpu-gate

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -19,6 +19,7 @@ channels:
 dependencies:
   - python=3.10
   - pip
+  - setuptools
   - numpy<2
   - pyyaml
   - tqdm


### PR DESCRIPTION
## Summary
- declare setuptools in the offline test conda environment
- ensure the CI test environment installs setuptools before pytest collection

## Validation
- git diff --check
- authoritative test execution is delegated to the repository CI gate