### PR TITLE
Stabilize packaging compatibility checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           wf='^\.github/workflows/'
           {
             echo "shell=$(match "$wf|^scripts/.*\.(sh|sbatch)$|^tests/bats/|^tests/shell/.*\.sh$|^collector\.sh$")"
-            echo "python=$(match "$wf|^igc/|^tests/|^configs/|^scripts/.*\.py$|^docker/requirements|^pytest\.ini$|^setup\.py$|^igc_main\.py$|^igc_ctl\.py$|^redfish_ctl")"
+            echo "python=$(match "$wf|^\.gitlab-ci\.yml$|^environment.*\.ya?ml$|^igc/|^tests/|^configs/|^scripts/.*\.py$|^docker/requirements|^requirements\.txt$|^pytest\.ini$|^setup\.py$|^igc_main\.py$|^igc_ctl\.py$|^redfish_ctl")"
             echo "perf=$(match "$wf|^igc/|^tests/perf/|^scripts/bench_hot_paths\.py$|^redfish_ctl")"
             echo "docker=$(match "$wf|^docker/|^\.dockerignore$|^requirements|^setup\.py$|^conda-recipe\.yaml$")"
           } >> "$GITHUB_OUTPUT"
@@ -127,6 +127,15 @@ jobs:
         run: |
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install -r docker/requirements-test.txt
+      - name: Verify packaging compatibility
+        run: |
+          python -c 'import setuptools; print(setuptools.__version__, setuptools.__file__)'
+          python -c 'import pkg_resources; print(pkg_resources.__file__)'
+      - name: Import and collection smoke
+        env:
+          TRANSFORMERS_OFFLINE: "1"
+          HF_DATASETS_OFFLINE: "1"
+        run: python -m pytest --collect-only -q
       - name: Agent-leak guard
         shell: bash
         env:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,7 +58,9 @@ workflow:
 .igc-test-before-script: &igc-test-before-script
   - export HOMELAB_IN_CLUSTER=1
   - conda env create --file environment-dev.yaml
-  - conda install --name igc-dev --yes setuptools
+  - conda install --name igc-dev --yes 'setuptools=81.*'
+  - conda run -n igc-dev python -c 'import setuptools; print(setuptools.__version__, setuptools.__file__)'
+  - conda run -n igc-dev python -c 'import pkg_resources; print(pkg_resources.__file__)'
 
 focused-gate:
   stage: cpu-gate

--- a/docker/requirements-test.txt
+++ b/docker/requirements-test.txt
@@ -2,6 +2,7 @@
 # torch is installed separately from the CPU wheel index in the Dockerfile.
 # numpy pinned <2: the legacy env's numpy 2.x breaks accelerate/sklearn/nltk/evaluate.
 numpy<2
+setuptools==81.*
 pyyaml
 tqdm
 transformers

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -19,7 +19,7 @@ channels:
 dependencies:
   - python=3.10
   - pip
-  - setuptools
+  - setuptools=81.*
   - numpy<2
   - pyyaml
   - tqdm

--- a/igc/modules/base/igc_base_module.py
+++ b/igc/modules/base/igc_base_module.py
@@ -16,7 +16,6 @@ from pathlib import Path
 from typing import Optional, Any, Union, Dict, Tuple, Callable, Set
 from urllib.error import URLError
 
-import pkg_resources
 import torch
 from torch.utils.data import random_split, Subset, Dataset
 from transformers import PreTrainedModel, PreTrainedTokenizer, PreTrainedTokenizerBase
@@ -959,39 +958,43 @@ class IgcModule(IgcBaseState):
         :return:  The model specs data and root dir where the modules need to be saved
         """
 
-        dataset_path = pkg_resources.resource_filename(
-            "igc", default_model_file
-        )
+        package_root = Path(__file__).resolve().parents[2]
+        dataset_path = (package_root / default_model_file).resolve()
 
-        if not os.path.isfile(dataset_path):
+        if not dataset_path.is_file():
             raise FileNotFoundError(
-                f"The model specs file '{dataset_path}' does not exist.")
+                f"The model specs file '{dataset_path}' does not exist."
+            )
         try:
-            with open(dataset_path, "r") as file:
+            with dataset_path.open("r", encoding="utf-8") as file:
                 models_data = json.load(file)
 
-        except Exception as e:
+        except (OSError, json.JSONDecodeError) as exc:
             raise ValueError(
-                f"Failed to parse the model specs file '{dataset_path}': {str(e)}")
+                f"Failed to parse model specs file '{dataset_path}': {exc}"
+            ) from exc
 
         required_keys = ["mirrors"]
         for key in required_keys:
             if key not in models_data or not isinstance(models_data[key], dict):
                 raise ValueError(
-                    f"Invalid model specs file. '{key}' key is missing or not a dictionary.")
+                    f"Invalid model specs file: '{key}' is missing "
+                    "or is not a dictionary."
+                )
 
         for mirror_url, mirror_entries in models_data["mirrors"].items():
             if not isinstance(mirror_entries, list):
                 raise ValueError(
-                    f"Invalid model specs file. Mirror entries for '{mirror_url}' is not a list.")
+                    f"Mirror entries for '{mirror_url}' must be a list."
+                )
 
             for entry in mirror_entries:
                 if not isinstance(entry, dict):
                     raise ValueError(
-                        f"Invalid model specs file. "
-                        f"Mirror entry for '{mirror_url}' is not a dictionary.")
+                        f"Mirror entry for '{mirror_url}' must be a dictionary."
+                    )
 
-        return models_data, os.path.abspath(os.path.dirname(dataset_path))
+        return models_data, str(dataset_path.parent)
 
     @staticmethod
     def _download_module(


### PR DESCRIPTION
## Summary
- remove the obsolete runtime pkg_resources dependency from model-spec loading
- preserve the current source-tree models.json location with pathlib
- pin Setuptools 81 in test environments for deterministic compatibility checks
- run packaging imports and pytest collection before the GitHub Python gate
- ensure environment and Internal GitLab CI changes trigger the GitHub matrix

## Validation
- git diff --check
- authoritative validation remains in repository CI