### PR TITLE
Phase 1 selective structural loss with a pinned input-noise gap

### DIFF
--- a/.github/workflows/phase1-invariant.yml
+++ b/.github/workflows/phase1-invariant.yml
@@ -1,0 +1,37 @@
+# Focused hard gate: the Phase 1 input-noise invariant test runs on exactly
+# one Python (3.10, the project's env version) with no path filter and no
+# matrix, so a break in the pinned invariant fails the PR visibly on its own
+# check line instead of hiding inside the full offline-gate matrix.
+name: Phase 1 invariant
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  input-noise-invariant:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: pip
+          cache-dependency-path: docker/requirements-test.txt
+      - name: Install dependencies
+        run: |
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install -r docker/requirements-test.txt
+      - name: Phase 1 input-noise invariant
+        shell: bash
+        run: |
+          set -o pipefail
+          KMP_DUPLICATE_LIB_OK=TRUE OMP_NUM_THREADS=1 TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1 \
+            python -m pytest -q tests/ds/test_phase1_input_noise_gap.py

--- a/configs/contracts/phase1.yaml
+++ b/configs/contracts/phase1.yaml
@@ -49,9 +49,25 @@ metadata:
       - chunk_json_sha256
 
 objective:
-  family: causal_lm_completion
+  family: causal_lm_profile_selected_completion
   prompt_tokens_ignored: true
-  completion_tokens_supervised: true
+  completion_tokens_supervised: training_profile.phase1_structural_loss_profile
+  canonical_target_immutable: true
+  full_completion_profile: none
+  structural_loss_registry: configs/training/phase1_structural_loss.yaml
+  historical_structural_mask_v1:
+    selection: one_available_family_per_row_epoch
+    heldout_selection: fixed_by_row
+    requires_input_target_json_equal_before_masking: true
+    selected_span_hidden_from_input: true
+    families:
+      - odata_id
+      - action_targets
+      - target_keys
+      - json_objects
+      - json_arrays
+      - allowable_values
+      - api_prefixes
   overflow_policy: reject
 
 chunking:

--- a/configs/contracts/phase1.yaml
+++ b/configs/contracts/phase1.yaml
@@ -55,11 +55,13 @@ objective:
   canonical_target_immutable: true
   full_completion_profile: none
   structural_loss_registry: configs/training/phase1_structural_loss.yaml
+  structural_loss_registry_role: authoritative_runtime_selector_definitions
   historical_structural_mask_v1:
-    selection: one_available_family_per_row_epoch
-    heldout_selection: fixed_by_row
+    selection: row_epoch_cycle_with_available_family_fallback
+    evaluation_selection: row_fixed_at_epoch_zero
     requires_input_target_json_equal_before_masking: true
     selected_span_hidden_from_input: true
+    api_prefix_policy: supervise_every_removed_occurrence
     families:
       - odata_id
       - action_targets

--- a/configs/training/phase1_structural_loss.yaml
+++ b/configs/training/phase1_structural_loss.yaml
@@ -1,0 +1,48 @@
+version: 1
+profiles:
+  none:
+    enabled: false
+    mask_token: <|redfish_mask|>
+    selection: row_epoch_cycle
+    families: []
+
+  historical_structural_mask_v1:
+    enabled: true
+    mask_token: <|redfish_mask|>
+    selection: row_epoch_cycle
+    families:
+      - name: odata_id
+        selector: key_value
+        patterns:
+          - "@odata.id"
+        max_spans: 8
+      - name: action_targets
+        selector: key_value
+        patterns:
+          - target
+          - Target
+        max_spans: 8
+      - name: target_keys
+        selector: key
+        patterns:
+          - target
+          - Target
+        max_spans: 8
+      - name: json_objects
+        selector: object
+        patterns: []
+        max_spans: 1
+      - name: json_arrays
+        selector: array
+        patterns: []
+        max_spans: 2
+      - name: allowable_values
+        selector: key_value_suffix
+        patterns:
+          - "@Redfish.AllowableValues"
+        max_spans: 8
+      - name: api_prefixes
+        selector: substring
+        patterns:
+          - /redfish/v1/
+        max_spans: 16

--- a/configs/training/phase1_structural_loss.yaml
+++ b/configs/training/phase1_structural_loss.yaml
@@ -45,4 +45,4 @@ profiles:
         selector: substring
         patterns:
           - /redfish/v1/
-        max_spans: 16
+        max_spans: all

--- a/configs/training/profiles.yaml
+++ b/configs/training/profiles.yaml
@@ -9,6 +9,7 @@ profiles:
     weights_role: model_x
     llm_stage: sft
     corpus_objective: phase1_pretrain
+    phase1_structural_loss_profile: none
     use_peft: false
     adapter: null
     precision: "no"
@@ -47,6 +48,7 @@ profiles:
     weights_role: model_x
     llm_stage: sft
     corpus_objective: phase1_pretrain
+    phase1_structural_loss_profile: none
     use_peft: true
     adapter:
       method: lora
@@ -91,6 +93,7 @@ profiles:
     weights_role: model_x
     llm_stage: sft
     corpus_objective: phase1_pretrain
+    phase1_structural_loss_profile: none
     use_peft: true
     adapter:
       method: lora
@@ -137,6 +140,54 @@ profiles:
     weights_role: model_x
     llm_stage: sft
     corpus_objective: phase1_pretrain
+    phase1_structural_loss_profile: none
+    use_peft: true
+    adapter:
+      method: rslora
+      r: 32
+      alpha: 64
+      dropout: 0.05
+      init: default
+      target_modules: [q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj]
+    precision: bf16
+    torch_dtype: bfloat16
+    batch_size: 8
+    grad_accum: 4
+    lr: 0.0001
+    optimizer: AdamW
+    weight_decay: 0.01
+    max_grad_norm: 1.0
+    gradient_checkpointing: true
+    scheduler: OneCycleLR
+    max_lr: 0.0001
+    warmup_ratio: 0.03
+    div_factor: 25.0
+    final_div_factor: 10000.0
+    cycle_momentum: true
+    anneal_strategy: cos
+    epochs: 3
+    max_steps: null
+    eval_steps: 100
+    save_steps: 100
+    early_stopping_patience: 3
+    early_stopping_min_delta: 0.005
+    sharding: none
+    seq_len: 2048
+    num_workers: 8
+    seed: 42
+
+  phase1_7b_rslora_r32_structural_mask:
+    model: Qwen/Qwen2.5-7B-Instruct
+    foundation_model_sha: ${IGC_FOUNDATION_MODEL_SHA}
+    tokenizer_sha: ${IGC_TOKENIZER_SHA}
+    task: redfish_json_reconstruction
+    parent_adapter: ""
+    parent_artifact_sha: ""
+    phase: phase1_finetune
+    weights_role: model_x
+    llm_stage: sft
+    corpus_objective: phase1_pretrain
+    phase1_structural_loss_profile: historical_structural_mask_v1
     use_peft: true
     adapter:
       method: rslora
@@ -181,6 +232,7 @@ profiles:
     weights_role: model_x
     llm_stage: sft
     corpus_objective: phase1_pretrain
+    phase1_structural_loss_profile: none
     use_peft: true
     adapter:
       method: lora
@@ -225,6 +277,7 @@ profiles:
     weights_role: model_x
     llm_stage: sft
     corpus_objective: phase1_pretrain
+    phase1_structural_loss_profile: none
     use_peft: false
     adapter: null
     precision: bf16
@@ -263,6 +316,7 @@ profiles:
     weights_role: model_x
     llm_stage: sft
     corpus_objective: phase1_pretrain
+    phase1_structural_loss_profile: none
     use_peft: false
     adapter: null
     precision: bf16
@@ -303,6 +357,7 @@ profiles:
     weights_role: goal_extractor
     llm_stage: sft
     corpus_objective: labelled_requests
+    phase1_structural_loss_profile: none
     use_peft: true
     adapter:
       method: rslora
@@ -349,6 +404,7 @@ profiles:
     weights_role: argument_extractor
     llm_stage: sft
     corpus_objective: labelled_calls
+    phase1_structural_loss_profile: none
     use_peft: true
     adapter:
       method: rslora

--- a/docs/external/phases/phase-1.md
+++ b/docs/external/phases/phase-1.md
@@ -1,6 +1,8 @@
 # Phase 1: Redfish JSON Pretraining
 
-Phase 1 trains `model_x` on Redfish JSON reconstruction. This is the RedfishBackbone
+Phase 1 trains `model_x` on Redfish JSON structure. The stored D0 target remains the complete
+canonical Redfish document, but the serious baseline uses selective structural loss instead of
+rewarding a copy of every target token. This is the RedfishBackbone
 pretraining/fine-tuning step; StateEncoder, goal extraction, argument extraction, rewards, and RL
 policy training are separate consumers with separate weights. This phase only teaches the chosen LLM
 the shape of Redfish resources, URI grammar, method context, and JSON completion.
@@ -10,7 +12,8 @@ Names are fixed as follows:
 - `model_x`: the chosen base LLM after this Redfish JSON pretraining step.
 - `weights_role`: `model_x`; this run writes a separate Phase 1 checkpoint.
 - `profile`: a `phase1_*` training profile from `igc/modules/train/profiles.py`.
-- `corpus_objective`: `phase1_pretrain`, the Redfish JSON reconstruction objective.
+- `corpus_objective`: `phase1_pretrain`, the D0 Redfish JSON objective.
+- `phase1_structural_loss_profile`: the YAML-owned rule selecting which target spans receive loss.
 - `x`: the input context shown to the model.
 - `y_true`: the exact target JSON the model should emit.
 - `y_pred`: the model output during inference or evaluation.
@@ -23,8 +26,9 @@ and JSON bodies. It does not have human operator text such as "mount an ISO and 
 Phase 1 therefore does not train goal extraction. It trains a Redfish-aware `model_x` so the next
 phase can use that checkpoint to draft plausible human text from machine-side API evidence.
 
-The current serious Phase 1 profile family is the Qwen2.5 7B rsLoRA path:
-`phase1_7b_rslora_r32` in the executable profile registry, with run names that may use
+The current serious Phase 1 profile family is the Qwen2.5 7B rsLoRA path. The historical
+structural-mask baseline is `phase1_7b_rslora_r32_structural_mask` in the executable profile
+registry; `phase1_7b_rslora_r32` remains the directly comparable full-completion arm. Run names may use
 `phase1-finetune-qwen2_5-7b-rslora`. GPT-2 remains a path smoke only.
 
 ## Concrete Bindings
@@ -35,9 +39,11 @@ The current serious Phase 1 profile family is the Qwen2.5 7B rsLoRA path:
 | Corpus materializer | `igc.ds.source_registry.materialize_phase1_registry_corpus` |
 | Dataset | `igc.ds.corpus_dataset.CorpusJSONLDataset` |
 | Renderer | `igc.ds.phase1_render.render_phase1_prompt` |
+| Structural loss | `igc.ds.phase1_structural_loss.build_phase1_structural_loss_view` |
+| Structural-loss spec | `configs/training/phase1_structural_loss.yaml` |
 | Shared token dataset | `igc.ds.sft_dataset.tokenize_prompt_completion` |
 | Trainer | `igc.modules.train.sft.SFTTrainer` |
-| Model/profile | `phase1_7b_rslora_r32` in `configs/training/profiles.yaml` |
+| Model/profile | `phase1_7b_rslora_r32_structural_mask` in `configs/training/profiles.yaml` |
 | Task/prompt spec | `redfish_json_reconstruction` in `configs/training/sft_tasks.yaml` |
 | Machine contract | `configs/contracts/phase1.yaml` |
 | Output checkpoint | `model_x` |
@@ -51,13 +57,24 @@ Every selected corpus must include a non-empty `rest_api_map.v1.json` or `rest_a
 both `url_file_mapping` and `allowed_methods_mapping`; the canonical materializer fails closed when
 that method evidence is missing.
 
-Training is normal causal-LM next-token learning. The rendered prompt contains `x`; labels are
-`-100` over the prompt tokens and actual token IDs over the `y_true` completion tokens. In other
-words, this phase trains:
+Training is causal-LM next-token learning over a profile-selected target view. The rendered prompt
+contains `x`; prompt and padding labels are always `-100`. With
+`historical_structural_mask_v1`, one available family is selected per row and epoch, that evidence
+is hidden from the prompt, and only overlapping completion tokens receive labels. The locked
+families are `@odata.id`, action targets, target keys, JSON objects, JSON arrays, Redfish allowable
+values, and `/redfish/v1/` API prefixes. Held-out family selection is fixed by row. D0 and
+`y_true.json` never change; enabled structural loss fails closed unless the materialized row has
+`x.json == y_true.json` before masking.
+
+The conditional objective is therefore:
 
 ```text
-P(y_true.json | x.rest_api, x.allowed_methods, x.json)
+P(selected structural span of y_true.json | masked x.rest_api,
+  x.allowed_methods, masked x.json)
 ```
+
+The `none` structural-loss profile preserves full-completion labeling for controlled comparison;
+it is not the historical structural-mask baseline.
 
 Checkpoint rule: Phase 1 writes `model_x` only. Phase 2 initializes `goal_extractor` from the
 promoted `model_x`; Phase 3 then initializes `argument_extractor` from the promoted Phase 2
@@ -142,12 +159,14 @@ GET, HEAD
 ```
 
 `x` is everything before `### Complete Redfish JSON`. `y_true` is the JSON after
-`### Complete Redfish JSON`. The shifted labels should mask the `x` tokens and compute
-cross-entropy only on the `y_true` JSON completion. A valid row has `phase == 1`, `dataset == D0`, task
+`### Complete Redfish JSON`. For the structural-mask profile, the selected evidence in `x` is
+replaced by `<|redfish_mask|>` (or a selected target key is removed), while the completion remains
+canonical. Shifted labels compute cross-entropy only on the selected completion span. A valid row
+has `phase == 1`, `dataset == D0`, task
 `redfish_json_reconstruction`, a non-empty string `x.rest_api`, unique uppercase
 `x.allowed_methods`, object-valued `x.json` and `y_true.json`, no committed `y_pred`, and no missing
-target. Prompt plus completion overflow fails closed; full-document labels are never silently
-truncated.
+target. Prompt plus completion overflow fails closed; target bytes and selected spans are never
+silently truncated.
 
 ## Phase 1 W&B Metrics
 
@@ -246,8 +265,11 @@ For Phase 1, evaluation should check:
 
 - `y_pred` parses as JSON.
 - `y_pred.json["@odata.id"]` equals `x.rest_api`.
-- `y_pred.json` exactly matches `y_true.json` for exact reconstruction runs.
-- Loss is computed only on `y_true` tokens, not on prompt/context tokens.
+- `y_pred.json` exactly matches `y_true.json` for full-document diagnostic runs.
+- Loss is computed only on profile-selected `y_true` tokens, never prompt, padding, or unselected
+  completion tokens.
+- Each historical structural family receives deterministic train coverage and a fixed held-out
+  view; the run report records the profile name and exact structural-loss spec SHA.
 
 Author:
 Mus mbayramo@stanford.edu

--- a/docs/external/phases/phase-1.md
+++ b/docs/external/phases/phase-1.md
@@ -62,7 +62,10 @@ contains `x`; prompt and padding labels are always `-100`. With
 `historical_structural_mask_v1`, one available family is selected per row and epoch, that evidence
 is hidden from the prompt, and only overlapping completion tokens receive labels. The locked
 families are `@odata.id`, action targets, target keys, JSON objects, JSON arrays, Redfish allowable
-values, and `/redfish/v1/` API prefixes. Held-out family selection is fixed by row. D0 and
+values, and `/redfish/v1/` API prefixes. The starting family index is `(row_index + epoch) % 7`;
+when that family is absent, selection advances to the next available family. Evaluation fixes the
+epoch at zero, so each held-out row has one stable view. Every API-prefix occurrence removed from
+the input is supervised in the completion. D0 and
 `y_true.json` never change; enabled structural loss fails closed unless the materialized row has
 `x.json == y_true.json` before masking.
 
@@ -269,7 +272,8 @@ For Phase 1, evaluation should check:
 - Loss is computed only on profile-selected `y_true` tokens, never prompt, padding, or unselected
   completion tokens.
 - Each historical structural family receives deterministic train coverage and a fixed held-out
-  view; the run report records the profile name and exact structural-loss spec SHA.
+  view in contract tests; the run report records the profile name and exact structural-loss spec
+  SHA.
 
 Author:
 Mus mbayramo@stanford.edu

--- a/igc/ds/corpus_dataset.py
+++ b/igc/ds/corpus_dataset.py
@@ -23,6 +23,11 @@ from typing import Any, Dict, List, Mapping, Optional
 import torch
 from torch.utils.data import Dataset
 
+from igc.ds.phase1_structural_loss import (
+    Phase1StructuralLossResult,
+    build_phase1_structural_loss_view,
+    load_phase1_structural_loss_profile,
+)
 from igc.ds.phase1_render import render_phase1_completion, render_phase1_prompt
 from igc.ds.sft_dataset import token_ids, tokenize_prompt_completion
 from igc.ds.sources.corpus_io import iter_examples, read_manifest
@@ -51,15 +56,32 @@ class CorpusJSONLDataset(Dataset):
                  default_tokenize: Optional[str] = "gpt2",
                  max_len: Optional[int] = 1024,
                  tokenizer: Optional[Any] = None,
-                 objective: str = LEGACY_OBJECTIVE):
+                 objective: str = LEGACY_OBJECTIVE,
+                 phase1_structural_loss_profile: str = "none",
+                 phase1_structural_loss_mode: str = "train",
+                 phase1_structural_loss_seed: int = 42):
         self._corpus_dir = os.path.abspath(os.path.expanduser(corpus_dir))
         self._default_tokenize = default_tokenize
         self._max_len = max_len
         self._tokenizer = tokenizer
         self.objective = objective
+        self._epoch = 0
+        self._phase1_structural_loss_seed = int(phase1_structural_loss_seed)
+        self._phase1_structural_loss_mode = phase1_structural_loss_mode
+        self._phase1_structural_loss = load_phase1_structural_loss_profile(
+            phase1_structural_loss_profile
+        )
         if objective not in CORPUS_OBJECTIVES:
             raise ValueError(
                 f"unknown corpus objective {objective!r}; choose from {CORPUS_OBJECTIVES}")
+        if phase1_structural_loss_mode not in {"train", "evaluation"}:
+            raise ValueError(
+                "phase1_structural_loss_mode must be 'train' or 'evaluation'"
+            )
+        if self._phase1_structural_loss.enabled and objective != PHASE1_PRETRAIN_OBJECTIVE:
+            raise ValueError(
+                "Phase 1 structural loss requires objective='phase1_pretrain'"
+            )
         self.metric_namespace = PHASE1_FINETUNE if objective == PHASE1_PRETRAIN_OBJECTIVE else ""
 
         examples_path = os.path.join(self._corpus_dir, "examples.jsonl")
@@ -75,11 +97,24 @@ class CorpusJSONLDataset(Dataset):
         )
         self._eval_data_sha256 = ""
 
+        examples = list(iter_examples(examples_path))
+        self._dynamic_phase1_structural_loss = (
+            objective == PHASE1_PRETRAIN_OBJECTIVE
+            and self._phase1_structural_loss.enabled
+            and phase1_structural_loss_mode == "train"
+        )
+        self._examples: List[Mapping[str, Any]] = (
+            examples if self._dynamic_phase1_structural_loss else []
+        )
         self._data: List[Dict[str, torch.Tensor]] = []
         tok = self.tokenizer
-        for example in iter_examples(examples_path):
+        if self._dynamic_phase1_structural_loss:
+            return
+        for row_index, example in enumerate(examples):
             if objective == PHASE1_PRETRAIN_OBJECTIVE:
-                self._data.append(self._phase1_item(tok, example))
+                self._data.append(
+                    self._phase1_item(tok, example, row_index=row_index)
+                )
             else:
                 self._data.append(self._legacy_item(tok, example))
 
@@ -114,19 +149,63 @@ class CorpusJSONLDataset(Dataset):
             "attention_mask": out["attention_mask"].squeeze(0).long(),
         }
 
-    def _phase1_item(self, tok: Any, example: Mapping[str, Any]) -> Dict[str, torch.Tensor]:
+    def _phase1_item(
+        self,
+        tok: Any,
+        example: Mapping[str, Any],
+        *,
+        row_index: int,
+    ) -> Dict[str, torch.Tensor]:
         """Render Phase 1 as prompt context plus JSON completion labels."""
-        prompt, target_json = render_phase1_prompt(example)
+        view = self._phase1_view(example, row_index=row_index)
+        prompt, target_json = render_phase1_prompt(view.row)
         completion = render_phase1_completion(target_json)
-        return self._tokenize_prompt_completion(tok, prompt, completion)
+        completion_label_spans = (
+            tuple(view.completion_spans) if self._phase1_structural_loss.enabled else None
+        )
+        return self._tokenize_prompt_completion(
+            tok,
+            prompt,
+            completion,
+            completion_label_spans=completion_label_spans,
+        )
+
+    def _phase1_view(
+        self,
+        example: Mapping[str, Any],
+        *,
+        row_index: int,
+    ) -> Phase1StructuralLossResult:
+        """Return the current deterministic train or fixed held-out view."""
+
+        return build_phase1_structural_loss_view(
+            example,
+            profile=self._phase1_structural_loss,
+            mode=self._phase1_structural_loss_mode,
+            run_seed=self._phase1_structural_loss_seed,
+            epoch=self._epoch,
+            row_index=row_index,
+        )
 
     def _tokenize_prompt_completion(
-            self, tok: Any, prompt: str, completion: str) -> Dict[str, torch.Tensor]:
+        self,
+        tok: Any,
+        prompt: str,
+        completion: str,
+        *,
+        completion_label_spans: tuple[tuple[int, int], ...] | None = None,
+    ) -> Dict[str, torch.Tensor]:
         """Tokenize prompt/completion and mask loss over prompt + padding."""
         prompt_ids = token_ids(tok, prompt)
         completion_ids = token_ids(tok, completion)
         max_len = int(self._max_len or (prompt_ids.numel() + completion_ids.numel()))
-        return tokenize_prompt_completion(tok, prompt, completion, max_len)
+        return tokenize_prompt_completion(
+            tok,
+            prompt,
+            completion,
+            max_len,
+            completion_label_spans=completion_label_spans,
+        )
 
     @staticmethod
     def _token_ids(tok: Any, text: str) -> torch.Tensor:
@@ -152,6 +231,8 @@ class CorpusJSONLDataset(Dataset):
                 "source_manifest_sha": "",
                 "source_registry_sha": "",
                 "source_artifact_manifest_shas": {},
+                "phase1_structural_loss_profile": self.phase1_structural_loss_profile,
+                "phase1_structural_loss_spec_sha": self.phase1_structural_loss_spec_sha,
             }
         manifest = DataManifest(**self.manifest)
         fields = manifest.to_run_manifest_fields()
@@ -162,8 +243,29 @@ class CorpusJSONLDataset(Dataset):
             "source_manifest_sha": self.manifest_sha256,
             "source_registry_sha": manifest.source_registry_sha,
             "source_artifact_manifest_shas": dict(manifest.source_manifest_shas),
+            "phase1_structural_loss_profile": self.phase1_structural_loss_profile,
+            "phase1_structural_loss_spec_sha": self.phase1_structural_loss_spec_sha,
         })
         return fields
+
+    @property
+    def phase1_structural_loss_profile(self) -> str:
+        """Resolved runtime structural-loss profile name."""
+
+        return self._phase1_structural_loss.name
+
+    @property
+    def phase1_structural_loss_spec_sha(self) -> str:
+        """Exact SHA-256 identity of the structural-loss profile registry."""
+
+        return self._phase1_structural_loss.spec_sha256
+
+    def set_epoch(self, epoch: int) -> None:
+        """Select the reproducible per-epoch train view before iteration starts."""
+
+        if isinstance(epoch, bool) or not isinstance(epoch, int) or epoch < 0:
+            raise ValueError("dataset epoch must be a non-negative integer")
+        self._epoch = epoch
 
     @property
     def data_sha256(self) -> str:
@@ -191,10 +293,20 @@ class CorpusJSONLDataset(Dataset):
 
     def __len__(self) -> int:
         """Number of tokenized examples."""
-        return len(self._data)
+        return (
+            len(self._examples)
+            if self._dynamic_phase1_structural_loss
+            else len(self._data)
+        )
 
     def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
         """The fixed-length ``input_ids``/``attention_mask`` item at ``idx``."""
+        if self._dynamic_phase1_structural_loss:
+            return self._phase1_item(
+                self.tokenizer,
+                self._examples[idx],
+                row_index=idx,
+            )
         return self._data[idx]
 
 

--- a/igc/ds/phase1_render.py
+++ b/igc/ds/phase1_render.py
@@ -1,13 +1,15 @@
 """Canonical Phase 1 prompt and target rendering.
 
-Phase 1 trains on a prompt followed by the whole target Redfish JSON document.
-Producer jobs, offline gates, and the tokenizer bridge should share this module
-so they stay on-distribution when prompt wording evolves.
+Phase 1 renders a prompt followed by the whole target Redfish JSON document.
+The selected training profile decides which completion spans receive loss.
+Producer jobs, gates, and the tokenizer bridge share this module so target
+bytes remain identical.
 """
 from __future__ import annotations
 
 import hashlib
 import json
+from dataclasses import dataclass
 from typing import Any, Mapping, Sequence
 
 from igc.modules.train.sft_tasks import resolve_sft_task
@@ -15,6 +17,17 @@ from igc.modules.train.sft_tasks import resolve_sft_task
 
 PHASE1_DATASET = "D0"
 PHASE1_TASK = "redfish_json_reconstruction"
+
+
+@dataclass(frozen=True)
+class Phase1JSONSpan:
+    """Character span in the canonical Phase 1 JSON rendering."""
+
+    kind: str
+    path: tuple[str | int, ...]
+    key: str | None
+    start: int
+    end: int
 
 
 def build_phase1_row(
@@ -218,22 +231,25 @@ def _validate_phase1_chunk_metadata(value: Any) -> None:
         raise ValueError("Phase 1 non-slice chunks require null range metadata")
 
 
-def render_phase1_prompt(example: Mapping[str, Any]) -> tuple[str, dict[str, Any]]:
+def render_phase1_prompt(
+    example: Mapping[str, Any],
+) -> tuple[str, dict[str, Any]]:
     """Render a Phase 1 prompt and return the target JSON object.
 
     Phase 1 training accepts only explicit D0 rows. Raw source records must be
     converted with :func:`build_phase1_source_row` before persistence.
+
     """
 
     rest_api, allowed_methods, input_json, target_json = _phase1_fields(example)
     allowed = ", ".join(allowed_methods) if allowed_methods else "UNKNOWN"
     task = resolve_sft_task(PHASE1_TASK)
-    prompt = task.render_prompt({
+    values = {
         "rest_api": rest_api,
         "allowed_methods": allowed,
         "json_context": phase1_json_dumps(input_json),
-    })
-    return prompt, target_json
+    }
+    return task.render_prompt(values), target_json
 
 
 def render_phase1_completion(target_json: Mapping[str, Any]) -> str:
@@ -243,9 +259,78 @@ def render_phase1_completion(target_json: Mapping[str, Any]) -> str:
 
 
 def phase1_json_dumps(value: Any) -> str:
-    """Stable pretty JSON rendering for Phase 1 documents."""
+    """Render canonical pretty JSON while sharing the structural span index."""
 
-    return json.dumps(value or {}, indent=2, sort_keys=True)
+    return phase1_json_with_spans(value)[0]
+
+
+def phase1_json_with_spans(value: Any) -> tuple[str, tuple[Phase1JSONSpan, ...]]:
+    """Render canonical pretty JSON and index keys, values, objects, and arrays."""
+
+    pieces: list[str] = []
+    spans: list[Phase1JSONSpan] = []
+    length = 0
+
+    def append(text: str) -> None:
+        nonlocal length
+        pieces.append(text)
+        length += len(text)
+
+    def render(current: Any, level: int, path: tuple[str | int, ...]) -> None:
+        start = length
+        if isinstance(current, Mapping):
+            append("{")
+            if current:
+                append("\n")
+                items = sorted(current.items(), key=lambda item: str(item[0]))
+                for index, (raw_key, child) in enumerate(items):
+                    key = str(raw_key)
+                    append("  " * (level + 1))
+                    key_start = length
+                    append(json.dumps(key))
+                    key_end = length
+                    append(": ")
+                    value_start = length
+                    render(child, level + 1, path + (key,))
+                    value_end = length
+                    spans.append(
+                        Phase1JSONSpan("key", path + (key,), key, key_start, key_end)
+                    )
+                    spans.append(
+                        Phase1JSONSpan(
+                            "key_value",
+                            path + (key,),
+                            key,
+                            key_start,
+                            value_end,
+                        )
+                    )
+                    if index + 1 < len(items):
+                        append(",")
+                    append("\n")
+                append("  " * level)
+            append("}")
+            spans.append(Phase1JSONSpan("object", path, None, start, length))
+            return
+        if isinstance(current, list):
+            append("[")
+            if current:
+                append("\n")
+                for index, child in enumerate(current):
+                    append("  " * (level + 1))
+                    render(child, level + 1, path + (index,))
+                    if index + 1 < len(current):
+                        append(",")
+                    append("\n")
+                append("  " * level)
+            append("]")
+            spans.append(Phase1JSONSpan("array", path, None, start, length))
+            return
+        append(json.dumps(current))
+        spans.append(Phase1JSONSpan("scalar", path, None, start, length))
+
+    render({} if value is None else value, 0, ())
+    return "".join(pieces), tuple(spans)
 
 
 def _phase1_fields(
@@ -269,7 +354,9 @@ __all__ = (
     "PHASE1_TASK",
     "build_phase1_row",
     "build_phase1_source_row",
+    "Phase1JSONSpan",
     "phase1_json_dumps",
+    "phase1_json_with_spans",
     "render_phase1_completion",
     "render_phase1_prompt",
     "validate_phase1_row",

--- a/igc/ds/phase1_render.py
+++ b/igc/ds/phase1_render.py
@@ -290,7 +290,6 @@ def phase1_json_with_spans(value: Any) -> tuple[str, tuple[Phase1JSONSpan, ...]]
                     append(json.dumps(key))
                     key_end = length
                     append(": ")
-                    value_start = length
                     render(child, level + 1, path + (key,))
                     value_end = length
                     spans.append(

--- a/igc/ds/phase1_structural_loss.py
+++ b/igc/ds/phase1_structural_loss.py
@@ -45,7 +45,7 @@ class StructuralLossFamily:
     name: str
     selector: str
     patterns: tuple[str, ...]
-    max_spans: int
+    max_spans: int | None
 
 
 @dataclass(frozen=True)
@@ -187,7 +187,11 @@ def build_phase1_structural_loss_view(
         candidates = list(candidates)
         rng.shuffle(candidates)
         selected_family = family
-        selected_spans = tuple(candidates[:family.max_spans])
+        selected_spans = tuple(
+            candidates
+            if family.max_spans is None
+            else candidates[:family.max_spans]
+        )
         break
     if selected_family is None:
         raise ValueError("Phase 1 row has no span for any structural-loss family")
@@ -235,9 +239,21 @@ def _family_from_raw(
         raise ValueError(f"{field}.patterns must not be empty for {selector}")
     if selector in {"object", "array"} and patterns:
         raise ValueError(f"{field}.patterns must be empty for {selector}")
-    max_spans = raw["max_spans"]
-    if isinstance(max_spans, bool) or not isinstance(max_spans, int) or max_spans < 1:
-        raise ValueError(f"{field}.max_spans must be a positive integer")
+    raw_max_spans = raw["max_spans"]
+    if raw_max_spans == "all":
+        if selector != "substring":
+            raise ValueError(f"{field}.max_spans='all' is limited to substring selectors")
+        max_spans = None
+    else:
+        max_spans = raw_max_spans
+        if (
+            isinstance(max_spans, bool)
+            or not isinstance(max_spans, int)
+            or max_spans < 1
+        ):
+            raise ValueError(
+                f"{field}.max_spans must be a positive integer or 'all'"
+            )
     return StructuralLossFamily(name, selector, tuple(patterns), max_spans)
 
 
@@ -296,7 +312,7 @@ def _mask_input_family(
             mask_token,
         )
         _replace_substrings(input_json, family.patterns, mask_token)
-        return [f"mask:{family.name}:substring"]
+        return [f"mask:{family.name}:substring:{len(selected_spans)}"]
 
     for selected in selected_spans:
         if not isinstance(selected, Phase1JSONSpan):

--- a/igc/ds/phase1_structural_loss.py
+++ b/igc/ds/phase1_structural_loss.py
@@ -1,0 +1,399 @@
+"""Historical Phase 1 structural masking, adapted to completion-only SFT."""
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import random
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Mapping, MutableMapping, Sequence
+
+import yaml
+
+from igc.ds.phase1_render import (
+    Phase1JSONSpan,
+    phase1_json_with_spans,
+    validate_phase1_row,
+)
+
+
+STRUCTURAL_LOSS_SPEC_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "configs"
+    / "training"
+    / "phase1_structural_loss.yaml"
+)
+_PROFILE_FIELDS = {"enabled", "mask_token", "selection", "families"}
+_FAMILY_FIELDS = {"name", "selector", "patterns", "max_spans"}
+_SELECTORS = {
+    "key_value",
+    "key",
+    "object",
+    "array",
+    "key_value_suffix",
+    "substring",
+}
+_SELECTIONS = {"row_epoch_cycle"}
+
+
+@dataclass(frozen=True)
+class StructuralLossFamily:
+    """One historical mask family and its target-span selector."""
+
+    name: str
+    selector: str
+    patterns: tuple[str, ...]
+    max_spans: int
+
+
+@dataclass(frozen=True)
+class Phase1StructuralLossProfile:
+    """Resolved structural-loss curriculum with exact YAML identity."""
+
+    name: str
+    enabled: bool
+    mask_token: str
+    selection: str
+    families: tuple[StructuralLossFamily, ...]
+    spec_sha256: str
+
+
+@dataclass(frozen=True)
+class Phase1StructuralLossResult:
+    """One prompt view and the completion character spans that receive loss."""
+
+    row: dict[str, Any]
+    family: str
+    completion_spans: tuple[tuple[int, int], ...]
+    operations: tuple[str, ...]
+
+
+def load_phase1_structural_loss_profile(
+    name: str,
+    path: str | Path = STRUCTURAL_LOSS_SPEC_PATH,
+) -> Phase1StructuralLossProfile:
+    """Load one strictly validated YAML-owned structural-loss profile."""
+
+    return _load_phase1_structural_loss_profile_cached(
+        name,
+        str(Path(path).expanduser().resolve()),
+    )
+
+
+@lru_cache(maxsize=32)
+def _load_phase1_structural_loss_profile_cached(
+    name: str,
+    path: str,
+) -> Phase1StructuralLossProfile:
+    spec_path = Path(path)
+    raw_bytes = spec_path.read_bytes()
+    try:
+        payload = yaml.safe_load(raw_bytes)
+    except yaml.YAMLError as exc:
+        raise ValueError(
+            f"cannot parse Phase 1 structural-loss spec {spec_path}: {exc}"
+        ) from exc
+    if not isinstance(payload, Mapping) or payload.get("version") != 1:
+        raise ValueError("Phase 1 structural-loss spec version must be 1")
+    profiles = payload.get("profiles")
+    if not isinstance(profiles, Mapping) or name not in profiles:
+        choices = sorted(profiles) if isinstance(profiles, Mapping) else []
+        raise KeyError(
+            f"unknown Phase 1 structural-loss profile {name!r}; choose from {choices}"
+        )
+    raw = profiles[name]
+    if not isinstance(raw, Mapping) or set(raw) != _PROFILE_FIELDS:
+        raise ValueError(
+            f"Phase 1 structural-loss profile {name!r} must contain exactly "
+            f"{sorted(_PROFILE_FIELDS)}"
+        )
+    enabled = _require_bool(raw["enabled"], f"{name}.enabled")
+    mask_token = _require_string(raw["mask_token"], f"{name}.mask_token")
+    selection = _require_string(raw["selection"], f"{name}.selection")
+    if selection not in _SELECTIONS:
+        raise ValueError(f"{name}.selection must be one of {sorted(_SELECTIONS)}")
+    raw_families = raw["families"]
+    if not isinstance(raw_families, list):
+        raise ValueError(f"{name}.families must be a list")
+    families = tuple(
+        _family_from_raw(name, index, family)
+        for index, family in enumerate(raw_families)
+    )
+    if enabled and not families:
+        raise ValueError(f"{name}.families must not be empty when enabled")
+    names = [family.name for family in families]
+    if len(names) != len(set(names)):
+        raise ValueError(f"{name}.families must have unique names")
+    return Phase1StructuralLossProfile(
+        name=name,
+        enabled=enabled,
+        mask_token=mask_token,
+        selection=selection,
+        families=families,
+        spec_sha256="sha256:" + hashlib.sha256(raw_bytes).hexdigest(),
+    )
+
+
+def build_phase1_structural_loss_view(
+    example: Mapping[str, Any],
+    *,
+    profile: Phase1StructuralLossProfile,
+    mode: str,
+    run_seed: int,
+    epoch: int,
+    row_index: int,
+) -> Phase1StructuralLossResult:
+    """Select and hide one available historical structural-loss family."""
+
+    validate_phase1_row(example)
+    if mode not in {"train", "evaluation"}:
+        raise ValueError("Phase 1 structural-loss mode must be train or evaluation")
+    if not profile.enabled:
+        return Phase1StructuralLossResult(
+            row=copy.deepcopy(dict(example)),
+            family="full_completion",
+            completion_spans=(),
+            operations=(),
+        )
+
+    target_json = example["y_true"]["json"]
+    if example["x"]["json"] != target_json:
+        raise ValueError(
+            "Phase 1 structural loss requires x.json == y_true.json before masking"
+        )
+    completion, indexed_spans = phase1_json_with_spans(target_json)
+    effective_epoch = epoch if mode == "train" else 0
+    start_index = (row_index + effective_epoch) % len(profile.families)
+    rng = random.Random(
+        _sample_seed(
+            example,
+            profile=profile,
+            mode=mode,
+            run_seed=run_seed,
+            epoch=effective_epoch,
+            row_index=row_index,
+        )
+    )
+
+    selected_family: StructuralLossFamily | None = None
+    selected_spans: tuple[Phase1JSONSpan | tuple[int, int], ...] = ()
+    for offset in range(len(profile.families)):
+        family = profile.families[(start_index + offset) % len(profile.families)]
+        candidates = _family_spans(family, completion, indexed_spans)
+        if not candidates:
+            continue
+        candidates = list(candidates)
+        rng.shuffle(candidates)
+        selected_family = family
+        selected_spans = tuple(candidates[:family.max_spans])
+        break
+    if selected_family is None:
+        raise ValueError("Phase 1 row has no span for any structural-loss family")
+
+    row = copy.deepcopy(dict(example))
+    operations = _mask_input_family(
+        row,
+        family=selected_family,
+        selected_spans=selected_spans,
+        mask_token=profile.mask_token,
+    )
+    validate_phase1_row(row)
+    char_spans = tuple(
+        (span.start, span.end) if isinstance(span, Phase1JSONSpan) else span
+        for span in selected_spans
+    )
+    if not char_spans or any(start >= end for start, end in char_spans):
+        raise ValueError("Phase 1 structural-loss selection produced an empty span")
+    return Phase1StructuralLossResult(
+        row=row,
+        family=selected_family.name,
+        completion_spans=char_spans,
+        operations=tuple(operations),
+    )
+
+
+def _family_from_raw(
+    profile_name: str,
+    index: int,
+    raw: Any,
+) -> StructuralLossFamily:
+    field = f"{profile_name}.families[{index}]"
+    if not isinstance(raw, Mapping) or set(raw) != _FAMILY_FIELDS:
+        raise ValueError(f"{field} must contain exactly {sorted(_FAMILY_FIELDS)}")
+    name = _require_string(raw["name"], f"{field}.name")
+    selector = _require_string(raw["selector"], f"{field}.selector")
+    if selector not in _SELECTORS:
+        raise ValueError(f"{field}.selector must be one of {sorted(_SELECTORS)}")
+    patterns = raw["patterns"]
+    if not isinstance(patterns, list) or any(
+        not isinstance(pattern, str) or not pattern for pattern in patterns
+    ):
+        raise ValueError(f"{field}.patterns must be list[str]")
+    if selector in {"key_value", "key", "key_value_suffix", "substring"} and not patterns:
+        raise ValueError(f"{field}.patterns must not be empty for {selector}")
+    if selector in {"object", "array"} and patterns:
+        raise ValueError(f"{field}.patterns must be empty for {selector}")
+    max_spans = raw["max_spans"]
+    if isinstance(max_spans, bool) or not isinstance(max_spans, int) or max_spans < 1:
+        raise ValueError(f"{field}.max_spans must be a positive integer")
+    return StructuralLossFamily(name, selector, tuple(patterns), max_spans)
+
+
+def _family_spans(
+    family: StructuralLossFamily,
+    completion: str,
+    spans: Sequence[Phase1JSONSpan],
+) -> list[Phase1JSONSpan | tuple[int, int]]:
+    if family.selector == "key_value":
+        return [
+            span
+            for span in spans
+            if span.kind == "key_value" and span.key in family.patterns
+        ]
+    if family.selector == "key":
+        return [
+            span
+            for span in spans
+            if span.kind == "key" and span.key in family.patterns
+        ]
+    if family.selector == "key_value_suffix":
+        return [
+            span
+            for span in spans
+            if span.kind == "key_value"
+            and span.key is not None
+            and any(span.key.endswith(pattern) for pattern in family.patterns)
+        ]
+    if family.selector in {"object", "array"}:
+        return [span for span in spans if span.kind == family.selector]
+    matches: list[tuple[int, int]] = []
+    for pattern in family.patterns:
+        start = 0
+        while True:
+            index = completion.find(pattern, start)
+            if index < 0:
+                break
+            matches.append((index, index + len(pattern)))
+            start = index + len(pattern)
+    return matches
+
+
+def _mask_input_family(
+    row: dict[str, Any],
+    *,
+    family: StructuralLossFamily,
+    selected_spans: Sequence[Phase1JSONSpan | tuple[int, int]],
+    mask_token: str,
+) -> list[str]:
+    input_json = row["x"]["json"]
+    operations: list[str] = []
+    if family.selector == "substring":
+        row["x"]["rest_api"] = _replace_patterns(
+            row["x"]["rest_api"],
+            family.patterns,
+            mask_token,
+        )
+        _replace_substrings(input_json, family.patterns, mask_token)
+        return [f"mask:{family.name}:substring"]
+
+    for selected in selected_spans:
+        if not isinstance(selected, Phase1JSONSpan):
+            continue
+        path = selected.path
+        if family.selector == "object" and not path:
+            row["x"]["json"] = {mask_token: True}
+            operations.append(f"mask:{family.name}:/")
+            continue
+        parent, key = _resolve_parent(input_json, path)
+        if family.selector == "key":
+            if isinstance(parent, MutableMapping) and key in parent:
+                del parent[key]
+        else:
+            parent[key] = mask_token
+        operations.append(
+            f"mask:{family.name}:/" + "/".join(str(component) for component in path)
+        )
+    return operations
+
+
+def _replace_substrings(value: Any, patterns: Sequence[str], mask_token: str) -> None:
+    if isinstance(value, MutableMapping):
+        for key, child in list(value.items()):
+            if isinstance(child, str):
+                value[key] = _replace_patterns(child, patterns, mask_token)
+            else:
+                _replace_substrings(child, patterns, mask_token)
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            if isinstance(child, str):
+                value[index] = _replace_patterns(child, patterns, mask_token)
+            else:
+                _replace_substrings(child, patterns, mask_token)
+
+
+def _replace_patterns(value: str, patterns: Sequence[str], mask_token: str) -> str:
+    for pattern in patterns:
+        value = value.replace(pattern, mask_token)
+    return value
+
+
+def _resolve_parent(root: Any, path: Sequence[str | int]) -> tuple[Any, str | int]:
+    if not path:
+        raise ValueError("root path has no parent")
+    parent = root
+    for component in path[:-1]:
+        parent = parent[component]
+    return parent, path[-1]
+
+
+def _sample_seed(
+    example: Mapping[str, Any],
+    *,
+    profile: Phase1StructuralLossProfile,
+    mode: str,
+    run_seed: int,
+    epoch: int,
+    row_index: int,
+) -> int:
+    metadata = example.get("metadata")
+    row_id = metadata.get("row_id") if isinstance(metadata, Mapping) else None
+    if not isinstance(row_id, str) or not row_id:
+        row_id = hashlib.sha256(
+            json.dumps(example, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+    material = "\0".join(
+        (
+            profile.spec_sha256,
+            profile.name,
+            mode,
+            str(run_seed),
+            str(epoch),
+            str(row_index),
+            row_id,
+        )
+    )
+    return int.from_bytes(hashlib.sha256(material.encode("utf-8")).digest()[:8], "big")
+
+
+def _require_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field} must be a non-empty string")
+    return value
+
+
+def _require_bool(value: Any, field: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be boolean")
+    return value
+
+
+__all__ = (
+    "STRUCTURAL_LOSS_SPEC_PATH",
+    "Phase1StructuralLossProfile",
+    "Phase1StructuralLossResult",
+    "StructuralLossFamily",
+    "build_phase1_structural_loss_view",
+    "load_phase1_structural_loss_profile",
+)

--- a/igc/ds/sft_dataset.py
+++ b/igc/ds/sft_dataset.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
-from typing import Any, BinaryIO, Mapping, Protocol
+from typing import Any, BinaryIO, Mapping, Protocol, Sequence
 
 import torch
 from torch.utils.data import Dataset
@@ -50,13 +50,17 @@ def tokenize_prompt_completion(
     prompt: str,
     completion: str,
     max_len: int,
+    *,
+    completion_label_spans: Sequence[tuple[int, int]] | None = None,
 ) -> dict[str, torch.Tensor]:
     """Tokenize one SFT example and mask prompt/padding loss positions.
 
     The returned tensors all have shape ``[max_len]``. ``labels`` is aligned
     with ``input_ids`` because Hugging Face causal LMs shift labels internally;
-    prompt and padding positions are ``-100``. Overflow raises instead of
-    silently truncating a full-document target.
+    prompt and padding positions are ``-100``. When
+    ``completion_label_spans`` is supplied, only completion tokens whose
+    character offsets overlap those spans receive labels. Overflow raises
+    instead of silently truncating a full-document target.
     """
     if max_len < 2:
         raise ValueError("SFT examples require max_len >= 2")
@@ -78,7 +82,13 @@ def tokenize_prompt_completion(
     input_ids = torch.cat((prompt_ids, completion_ids)).long()
     attention_mask = torch.ones_like(input_ids, dtype=torch.long)
     labels = torch.full_like(input_ids, -100)
-    labels[prompt_ids.numel():] = completion_ids
+    completion_labels = _completion_labels(
+        tokenizer,
+        completion,
+        completion_ids,
+        completion_label_spans,
+    )
+    labels[prompt_ids.numel():] = completion_labels
 
     if input_ids.numel() < max_len:
         pad_id = int(getattr(tokenizer, "pad_token_id", 0) or 0)
@@ -98,6 +108,82 @@ def tokenize_prompt_completion(
         "attention_mask": attention_mask,
         "labels": labels,
     }
+
+
+def _completion_labels(
+    tokenizer: Any,
+    completion: str,
+    completion_ids: torch.Tensor,
+    spans: Sequence[tuple[int, int]] | None,
+) -> torch.Tensor:
+    """Return full or character-span-selective completion labels."""
+
+    if spans is None:
+        return completion_ids.clone()
+    normalized = tuple(_validate_label_span(span, len(completion)) for span in spans)
+    if not normalized:
+        raise ValueError("completion_label_spans must not be empty")
+    try:
+        encoded = tokenizer(
+            completion,
+            padding=False,
+            truncation=False,
+            return_tensors="pt",
+            add_special_tokens=False,
+            return_offsets_mapping=True,
+        )
+    except (NotImplementedError, TypeError) as exc:
+        raise TypeError(
+            "selective completion labels require a fast tokenizer with "
+            "return_offsets_mapping support"
+        ) from exc
+    offsets = encoded.get("offset_mapping")
+    encoded_ids = encoded.get("input_ids")
+    if offsets is None or encoded_ids is None:
+        raise TypeError(
+            "selective completion labels require input_ids and offset_mapping"
+        )
+    encoded_ids = torch.as_tensor(encoded_ids).squeeze(0).long()
+    offsets = torch.as_tensor(offsets).squeeze(0).long()
+    if encoded_ids.shape != completion_ids.shape or not torch.equal(
+        encoded_ids,
+        completion_ids,
+    ):
+        raise ValueError("offset tokenization does not match completion tokenization")
+    if offsets.ndim != 2 or offsets.shape != (completion_ids.numel(), 2):
+        raise ValueError("completion offset mapping must have shape [tokens, 2]")
+
+    labels = torch.full_like(completion_ids, -100)
+    for token_index, (token_start, token_end) in enumerate(offsets.tolist()):
+        if token_start == token_end:
+            continue
+        if any(token_start < span_end and token_end > span_start
+               for span_start, span_end in normalized):
+            labels[token_index] = completion_ids[token_index]
+    if not torch.any(labels != -100):
+        raise ValueError("completion label spans selected zero tokens")
+    return labels
+
+
+def _validate_label_span(
+    span: tuple[int, int],
+    completion_length: int,
+) -> tuple[int, int]:
+    """Validate one half-open completion character span."""
+
+    if (
+        not isinstance(span, tuple)
+        or len(span) != 2
+        or any(isinstance(value, bool) or not isinstance(value, int) for value in span)
+    ):
+        raise TypeError("completion label spans must be (int, int) tuples")
+    start, end = span
+    if not 0 <= start < end <= completion_length:
+        raise ValueError(
+            "completion label span must be within the completion: "
+            f"span={span} completion_length={completion_length}"
+        )
+    return start, end
 
 
 class PromptCompletionJSONLDataset(Dataset):

--- a/igc/modules/igc_main.py
+++ b/igc/modules/igc_main.py
@@ -97,11 +97,20 @@ class IgcMain:
             )
             if corpus_dir:
                 from igc.ds.corpus_dataset import CorpusJSONLDataset
+                structural_loss_profile = getattr(
+                    self._specs,
+                    "phase1_structural_loss_profile",
+                    "none",
+                )
+                structural_loss_seed = int(getattr(self._specs, "seed", 42))
                 self._dataset = CorpusJSONLDataset(
                     corpus_dir,
                     default_tokenize=self._specs.model_type,
                     max_len=self._specs.seq_len,
                     objective=getattr(self._specs, "corpus_objective", "legacy"),
+                    phase1_structural_loss_profile=structural_loss_profile,
+                    phase1_structural_loss_mode="train",
+                    phase1_structural_loss_seed=structural_loss_seed,
                 )
                 self._eval_dataset = CorpusJSONLDataset(
                     eval_corpus_dir,
@@ -109,6 +118,26 @@ class IgcMain:
                     max_len=self._specs.seq_len,
                     tokenizer=self._dataset.tokenizer,
                     objective=getattr(self._specs, "corpus_objective", "legacy"),
+                    phase1_structural_loss_profile=structural_loss_profile,
+                    phase1_structural_loss_mode="evaluation",
+                    phase1_structural_loss_seed=structural_loss_seed,
+                )
+                train_structural_loss_sha = getattr(
+                    self._dataset,
+                    "phase1_structural_loss_spec_sha",
+                    "",
+                )
+                eval_structural_loss_sha = getattr(
+                    self._eval_dataset,
+                    "phase1_structural_loss_spec_sha",
+                    "",
+                )
+                if train_structural_loss_sha != eval_structural_loss_sha:
+                    raise ValueError(
+                        "Phase 1 train and held-out structural-loss specs must match"
+                    )
+                self._specs.phase1_structural_loss_spec_sha = (
+                    train_structural_loss_sha
                 )
                 self._dataset.set_eval_split_sha256(self._eval_dataset.data_sha256)
             elif task is not None:

--- a/igc/modules/train/emit.py
+++ b/igc/modules/train/emit.py
@@ -34,6 +34,7 @@ _SETTINGS_KEYS = (
     "early_stopping_patience", "early_stopping_min_delta", "masking_type", "num_workers",
     "eval_steps", "save_steps",
     "seed", "profile", "weights_role", "corpus_objective",
+    "phase1_structural_loss_profile", "phase1_structural_loss_spec_sha",
     "phase", "sft_task", "parent_role", "parent_artifact_sha", "output_role",
     "task_spec_sha", "phase_number",
     "foundation_model_sha", "tokenizer_sha", "promotion_source",

--- a/igc/modules/train/launch.py
+++ b/igc/modules/train/launch.py
@@ -41,6 +41,7 @@ def profile_to_argv(profile: TrainingProfile) -> List[str]:
         "--sft_task", profile.task,
         "--train", "llm", "--llm", profile.llm_stage,
         "--corpus_objective", profile.corpus_objective,
+        "--phase1_structural_loss_profile", profile.phase1_structural_loss_profile,
         "--model_type", profile.model,
         "--llm_torch_dtype", profile.torch_dtype,
         "--per_device_train_batch_size", str(profile.batch_size),

--- a/igc/modules/train/profiles.py
+++ b/igc/modules/train/profiles.py
@@ -153,7 +153,11 @@ class TrainingProfile:
         return d
 
 
-_OPTIONAL_PROFILE_FIELDS = {"foundation_model_sha", "tokenizer_sha"}
+_OPTIONAL_PROFILE_FIELDS = {
+    "foundation_model_sha",
+    "tokenizer_sha",
+    "phase1_structural_loss_profile",
+}
 _PROFILE_FIELDS = (
     set(TrainingProfile.__dataclass_fields__)
     - {"name", "adapter"}
@@ -240,7 +244,7 @@ def _profile_from_raw(name: str, raw: dict) -> TrainingProfile:
         raise ValueError(f"profile {name!r} Phase 1 parent_adapter must be empty")
     if task.phase > 1 and not str(raw["parent_adapter"]):
         raise ValueError(f"profile {name!r} requires parent_adapter")
-    structural_loss_profile = str(raw["phase1_structural_loss_profile"])
+    structural_loss_profile = str(raw.get("phase1_structural_loss_profile", "none"))
     from igc.ds.phase1_structural_loss import load_phase1_structural_loss_profile
 
     resolved_structural_loss = load_phase1_structural_loss_profile(

--- a/igc/modules/train/profiles.py
+++ b/igc/modules/train/profiles.py
@@ -86,6 +86,7 @@ class TrainingProfile:
     weights_role: str = "model_x"
     llm_stage: str = "sft"
     corpus_objective: str = "phase1_pretrain"
+    phase1_structural_loss_profile: str = "none"
     use_peft: bool = True
     adapter: Optional[AdapterSpec] = field(default_factory=AdapterSpec)
     precision: str = "bf16"          # accelerate mixed_precision
@@ -126,6 +127,7 @@ class TrainingProfile:
             "tokenizer_sha": self.tokenizer_sha,
             "phase": self.phase, "weights_role": self.weights_role, "llm_stage": self.llm_stage,
             "corpus_objective": self.corpus_objective,
+            "phase1_structural_loss_profile": self.phase1_structural_loss_profile,
             "precision": self.precision, "torch_dtype": self.torch_dtype,
             "batch_size": self.batch_size, "grad_accum": self.grad_accum, "lr": self.lr,
             "optimizer": self.optimizer, "weight_decay": self.weight_decay,
@@ -238,6 +240,16 @@ def _profile_from_raw(name: str, raw: dict) -> TrainingProfile:
         raise ValueError(f"profile {name!r} Phase 1 parent_adapter must be empty")
     if task.phase > 1 and not str(raw["parent_adapter"]):
         raise ValueError(f"profile {name!r} requires parent_adapter")
+    structural_loss_profile = str(raw["phase1_structural_loss_profile"])
+    from igc.ds.phase1_structural_loss import load_phase1_structural_loss_profile
+
+    resolved_structural_loss = load_phase1_structural_loss_profile(
+        structural_loss_profile
+    )
+    if task.phase > 1 and resolved_structural_loss.enabled:
+        raise ValueError(
+            f"profile {name!r} Phase {task.phase} cannot enable Phase 1 structural loss"
+        )
     warmup_ratio = float(raw["warmup_ratio"])
     if not 0.0 < warmup_ratio < 1.0:
         raise ValueError(f"profile {name!r} warmup_ratio must be between 0 and 1")
@@ -264,6 +276,7 @@ def _profile_from_raw(name: str, raw: dict) -> TrainingProfile:
         weights_role=str(raw["weights_role"]),
         llm_stage=str(raw["llm_stage"]),
         corpus_objective=str(raw["corpus_objective"]),
+        phase1_structural_loss_profile=structural_loss_profile,
         use_peft=use_peft,
         adapter=adapter,
         precision=str(raw["precision"]),

--- a/igc/modules/train/sft.py
+++ b/igc/modules/train/sft.py
@@ -209,6 +209,18 @@ def reached_max_steps(global_step: int, max_steps: Optional[int]) -> bool:
     return max_steps is not None and max_steps > 0 and global_step >= max_steps
 
 
+def select_dataset_epoch(dataset: Any, epoch: int) -> None:
+    """Select a reproducible per-epoch dataset view when the dataset supports it.
+
+    Training loaders use non-persistent workers. This hook runs before each loader
+    iteration, so worker processes receive the selected epoch when they are created.
+    """
+
+    set_epoch = getattr(dataset, "set_epoch", None)
+    if callable(set_epoch):
+        set_epoch(epoch)
+
+
 def cadence_due(optimizer_step: int, interval: int) -> bool:
     """Return whether an optimizer-step cadence fires at this update."""
     return optimizer_step > 0 and interval > 0 and optimizer_step % interval == 0
@@ -961,6 +973,7 @@ class SFTTrainer(LlmModule):
             shuffle=self._is_shuffle and sampler is None,
             drop_last=True,  # equal batch count per rank -> no epoch-boundary save-collective deadlock
             pin_memory=self._pin_memory,
+            persistent_workers=False,
             collate_fn=SFTTrainer.custom_collate_fn
         )
 
@@ -1096,6 +1109,7 @@ class SFTTrainer(LlmModule):
         for epoch in range(last_epoch, self.num_epochs):
             if reached_max_steps(global_opt_steps, max_steps):
                 break
+            select_dataset_epoch(train_data, epoch)
             self.model.train()
 
             total_loss = 0.0
@@ -1341,6 +1355,7 @@ class SFTTrainer(LlmModule):
             shuffle=self._is_shuffle and sampler is None,
             drop_last=True,  # equal batch count per rank -> no epoch-boundary save-collective deadlock
             pin_memory=self._pin_memory,
+            persistent_workers=False,
             collate_fn=SFTTrainer.custom_collate_fn
         )
 
@@ -1388,6 +1403,7 @@ class SFTTrainer(LlmModule):
                   f"batch stats freq: {batch_log_frequency}.")
 
         for epoch in range(last_epoch, self.num_epochs):
+            select_dataset_epoch(train_data, epoch)
             self.model.train()
 
             total_loss = 0.0

--- a/igc/modules/train/sft.py
+++ b/igc/modules/train/sft.py
@@ -221,6 +221,20 @@ def select_dataset_epoch(dataset: Any, epoch: int) -> None:
         set_epoch(epoch)
 
 
+def select_training_epoch(dataset: Any, dataloader: Any, epoch: int) -> None:
+    """Advance both a dynamic dataset view and its prepared sampling order."""
+
+    select_dataset_epoch(dataset, epoch)
+    loader_set_epoch = getattr(dataloader, "set_epoch", None)
+    if callable(loader_set_epoch):
+        loader_set_epoch(epoch)
+        return
+    sampler = getattr(dataloader, "sampler", None)
+    sampler_set_epoch = getattr(sampler, "set_epoch", None)
+    if callable(sampler_set_epoch):
+        sampler_set_epoch(epoch)
+
+
 def cadence_due(optimizer_step: int, interval: int) -> bool:
     """Return whether an optimizer-step cadence fires at this update."""
     return optimizer_step > 0 and interval > 0 and optimizer_step % interval == 0
@@ -1109,7 +1123,7 @@ class SFTTrainer(LlmModule):
         for epoch in range(last_epoch, self.num_epochs):
             if reached_max_steps(global_opt_steps, max_steps):
                 break
-            select_dataset_epoch(train_data, epoch)
+            select_training_epoch(train_data, train_dataloader, epoch)
             self.model.train()
 
             total_loss = 0.0
@@ -1403,7 +1417,7 @@ class SFTTrainer(LlmModule):
                   f"batch stats freq: {batch_log_frequency}.")
 
         for epoch in range(last_epoch, self.num_epochs):
-            select_dataset_epoch(train_data, epoch)
+            select_training_epoch(train_data, train_dataloader, epoch)
             self.model.train()
 
             total_loss = 0.0

--- a/igc/shared/shared_arg_parser.py
+++ b/igc/shared/shared_arg_parser.py
@@ -908,6 +908,15 @@ def add_dataset_dataloader(parser):
              "json} and masks labels so loss applies only to the y_true JSON completion.")
 
     group.add_argument(
+        "--phase1_structural_loss_profile",
+        type=str,
+        default="none",
+        help="Named selective-loss profile from "
+             "configs/training/phase1_structural_loss.yaml. Only Phase 1 "
+             "corpus training may enable it.",
+    )
+
+    group.add_argument(
         "--raw_data_dir",
         type=str, default="~/.json_responses",
         help="Raw captured Redfish responses the mock REST env serves; mirrors "

--- a/tests/ds/test_corpus_dataset.py
+++ b/tests/ds/test_corpus_dataset.py
@@ -72,7 +72,10 @@ class _EmptyCompletionTokenizer(_FakeTokenizer):
                  return_offsets_mapping=False):
         if text == '{\n  "empty": true\n}\n':
             empty = torch.empty((1, 0), dtype=torch.long)
-            return {"input_ids": empty, "attention_mask": empty}
+            result = {"input_ids": empty, "attention_mask": empty}
+            if return_offsets_mapping:
+                result["offset_mapping"] = torch.empty((1, 0, 2), dtype=torch.long)
+            return result
         return super().__call__(
             text,
             padding=padding,
@@ -274,6 +277,9 @@ def test_phase1_structural_loss_heldout_view_ignores_epoch_changes(tmp_path: Pat
 
     for key in ("input_ids", "attention_mask", "labels"):
         assert torch.equal(before[key], after[key])
+    active = before["labels"].ne(-100).sum().item()
+    attended = before["attention_mask"].sum().item()
+    assert 0 < active < attended
 
 
 def test_phase1_tiny_sequence_raises_instead_of_truncating_sft(tmp_path: Path):

--- a/tests/ds/test_corpus_dataset.py
+++ b/tests/ds/test_corpus_dataset.py
@@ -41,7 +41,8 @@ class _FakeTokenizer:
     pad_token_id = 0
 
     def __call__(self, text, padding=None, max_length=None, truncation=None,
-                 return_tensors=None, add_special_tokens=None):
+                 return_tensors=None, add_special_tokens=None,
+                 return_offsets_mapping=False):
         ids = [ord(c) % 1000 + 1 for c in text]
         if add_special_tokens:
             ids = [999] + ids + [998]
@@ -52,14 +53,23 @@ class _FakeTokenizer:
             while len(ids) < max_length:
                 ids.append(0)
                 mask.append(0)
-        return {"input_ids": torch.tensor([ids]), "attention_mask": torch.tensor([mask])}
+        result = {
+            "input_ids": torch.tensor([ids]),
+            "attention_mask": torch.tensor([mask]),
+        }
+        if return_offsets_mapping:
+            result["offset_mapping"] = torch.tensor(
+                [[(index, index + 1) for index in range(len(text))]]
+            )
+        return result
 
 
 class _EmptyCompletionTokenizer(_FakeTokenizer):
     """Tokenizer stub that exposes a degenerate zero-token completion."""
 
     def __call__(self, text, padding=None, max_length=None, truncation=None,
-                 return_tensors=None, add_special_tokens=None):
+                 return_tensors=None, add_special_tokens=None,
+                 return_offsets_mapping=False):
         if text == '{\n  "empty": true\n}\n':
             empty = torch.empty((1, 0), dtype=torch.long)
             return {"input_ids": empty, "attention_mask": empty}
@@ -70,6 +80,7 @@ class _EmptyCompletionTokenizer(_FakeTokenizer):
             truncation=truncation,
             return_tensors=return_tensors,
             add_special_tokens=add_special_tokens,
+            return_offsets_mapping=return_offsets_mapping,
         )
 
 
@@ -196,6 +207,73 @@ def test_phase1_items_mask_prompt_and_padding_labels(tmp_path: Path):
     assert torch.equal(item["labels"][active], item["input_ids"][active])
     assert item["labels"][item["attention_mask"].eq(0)].eq(-100).all()
     assert ds.metric_namespace == "phase1_finetune"
+
+
+def test_phase1_structural_loss_changes_train_view_and_active_labels(tmp_path: Path):
+    """Epochs rotate structural masks while preserving canonical target bytes."""
+    tokenizer = _FakeTokenizer()
+    ds = CorpusJSONLDataset(
+        _explicit_phase1_corpus_dir(
+            tmp_path,
+            {
+                "@odata.id": "/redfish/v1/Systems/1",
+                "Id": "1",
+                "Actions": {
+                    "#ComputerSystem.Reset": {
+                        "target": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+                        "ResetType@Redfish.AllowableValues": ["On", "ForceOff"],
+                    }
+                },
+            },
+        ),
+        max_len=2048,
+        tokenizer=tokenizer,
+        objective="phase1_pretrain",
+        phase1_structural_loss_profile="historical_structural_mask_v1",
+        phase1_structural_loss_mode="train",
+        phase1_structural_loss_seed=31,
+    )
+
+    items = []
+    for epoch in range(6):
+        ds.set_epoch(epoch)
+        items.append(ds[0])
+
+    assert len({tuple(item["input_ids"].tolist()) for item in items}) > 1
+    active_labels = [
+        tuple(item["labels"][item["labels"].ne(-100)].tolist())
+        for item in items
+    ]
+    assert len(set(active_labels)) > 1
+    canonical_completion = render_phase1_completion(
+        _first_example(ds._corpus_dir)["y_true"]["json"]
+    )
+    assert all(0 < len(labels) < len(canonical_completion) for labels in active_labels)
+    assert ds.phase1_structural_loss_profile == "historical_structural_mask_v1"
+    assert ds.phase1_structural_loss_spec_sha.startswith("sha256:")
+
+
+def test_phase1_structural_loss_heldout_view_ignores_epoch_changes(tmp_path: Path):
+    """Held-out structural masking is row-fixed for stable promotion evidence."""
+    ds = CorpusJSONLDataset(
+        _explicit_phase1_corpus_dir(
+            tmp_path,
+            {"@odata.id": "/redfish/v1/Systems/1", "Id": "1"},
+        ),
+        max_len=1024,
+        tokenizer=_FakeTokenizer(),
+        objective="phase1_pretrain",
+        phase1_structural_loss_profile="historical_structural_mask_v1",
+        phase1_structural_loss_mode="evaluation",
+        phase1_structural_loss_seed=31,
+    )
+
+    before = ds[0]
+    ds.set_epoch(99)
+    after = ds[0]
+
+    for key in ("input_ids", "attention_mask", "labels"):
+        assert torch.equal(before[key], after[key])
 
 
 def test_phase1_tiny_sequence_raises_instead_of_truncating_sft(tmp_path: Path):

--- a/tests/ds/test_phase1_input_noise_gap.py
+++ b/tests/ds/test_phase1_input_noise_gap.py
@@ -1,0 +1,113 @@
+"""Executable evidence for review issue 1: Phase 1 input noise is absent.
+
+One invariant, one test: rendering always sorts keys canonically (so upstream
+key-order noise never reaches the model), the branch's only shuffle is the
+mask-span candidate shuffle, and ``build_phase1_structural_loss_view`` hard
+requires ``x.json == y_true.json`` so content noise added later is rejected
+by the existing guard. Masking landed; shuffling didn't. When per-epoch input
+noise lands, this demonstration is expected to be replaced by the real noise
+contract tests.
+"""
+
+from __future__ import annotations
+
+import copy
+import inspect
+
+import pytest
+
+import igc.ds.corpus_dataset as corpus_dataset_module
+import igc.ds.phase1_render as phase1_render_module
+import igc.ds.phase1_structural_loss as structural_loss_module
+from igc.ds.phase1_render import build_phase1_row, render_phase1_prompt
+from igc.ds.phase1_structural_loss import (
+    build_phase1_structural_loss_view,
+    load_phase1_structural_loss_profile,
+)
+
+
+def _row() -> dict:
+    """One Phase 1 row with enough sibling keys for order to be observable."""
+    body = {
+        "@odata.id": "/redfish/v1/Systems/1",
+        "Id": "1",
+        "Name": "System One",
+        "PowerState": "On",
+        "SystemType": "Physical",
+        "Actions": {
+            "#ComputerSystem.Reset": {
+                "target": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+                "ResetType@Redfish.AllowableValues": ["On", "ForceOff"],
+            }
+        },
+    }
+    return build_phase1_row(
+        rest_api="/redfish/v1/Systems/1",
+        allowed_methods=["GET", "PATCH"],
+        input_json=body,
+        target_json=body,
+    )
+
+
+def _reversed_key_order(value):
+    """Deep copy with every object's key insertion order reversed."""
+    if isinstance(value, dict):
+        return {
+            key: _reversed_key_order(child)
+            for key, child in reversed(list(value.items()))
+        }
+    if isinstance(value, list):
+        return [_reversed_key_order(child) for child in value]
+    return value
+
+
+def test_phase1_input_noise_is_impossible_without_code_changes() -> None:
+    """Key/order/input noise is absent and cannot be added from data alone.
+
+    Three legs of the same invariant:
+
+    1. canonical rendering — deep-reversing the key insertion order of
+       ``x.json`` produces a byte-identical prompt, so key-order noise is
+       erased before tokenization;
+    2. the only randomness in the view pipeline is the span-candidate
+       shuffle inside the structural-loss module — neither the renderer nor
+       the dataset shuffles anything;
+    3. the ``x.json == y_true.json`` guard rejects content noise (key
+       dropout) outright, so input noise added upstream is refused today.
+    """
+    # Leg 1: rendering canonicalizes any upstream key order.
+    source = _row()
+    reordered = copy.deepcopy(source)
+    reordered["x"]["json"] = _reversed_key_order(reordered["x"]["json"])
+    assert list(reordered["x"]["json"]) != list(source["x"]["json"])
+    assert reordered["x"]["json"] == source["x"]["json"]
+    original_prompt, _ = render_phase1_prompt(source)
+    reordered_prompt, _ = render_phase1_prompt(reordered)
+    assert reordered_prompt == original_prompt
+
+    # Leg 2: the branch's sole shuffle is the mask-span candidate shuffle.
+    structural_source = inspect.getsource(structural_loss_module)
+    assert structural_source.count(".shuffle(") == 1
+    assert "rng.shuffle(candidates)" in structural_source
+    assert ".shuffle(" not in inspect.getsource(corpus_dataset_module)
+    render_source = inspect.getsource(phase1_render_module)
+    assert ".shuffle(" not in render_source
+    assert "sorted(current.items()" in render_source
+
+    # Leg 3: the equality guard rejects content noise added upstream.
+    profile = load_phase1_structural_loss_profile("historical_structural_mask_v1")
+    dropped = _row()
+    dropped["x"]["json"] = {
+        key: value
+        for key, value in dropped["x"]["json"].items()
+        if key != "PowerState"
+    }
+    with pytest.raises(ValueError, match="x.json == y_true.json"):
+        build_phase1_structural_loss_view(
+            dropped,
+            profile=profile,
+            mode="train",
+            run_seed=31,
+            epoch=0,
+            row_index=0,
+        )

--- a/tests/ds/test_phase1_structural_loss.py
+++ b/tests/ds/test_phase1_structural_loss.py
@@ -60,13 +60,21 @@ def test_structural_loss_profile_locks_historical_family_order() -> None:
     assert profile.enabled is True
     assert profile.selection == "row_epoch_cycle"
     assert tuple(family.name for family in profile.families) == EXPECTED_FAMILIES
+    assert profile.families[-1].max_spans is None
     assert profile.spec_sha256.startswith("sha256:")
 
 
-def test_span_renderer_is_byte_identical_to_canonical_json() -> None:
+@pytest.mark.parametrize(
+    "body",
+    [
+        {},
+        {"empty_array": [], "empty_object": {}},
+        {"nested": [{"value": 1}, [True, None, "text"]]},
+        _row()["y_true"]["json"],
+    ],
+)
+def test_span_renderer_is_byte_identical_to_canonical_json(body: dict) -> None:
     """Adding span indexes must not change the existing Phase 1 target bytes."""
-    body = _row()["y_true"]["json"]
-
     rendered, spans = phase1_json_with_spans(body)
 
     assert rendered == json.dumps(body, indent=2, sort_keys=True)
@@ -83,6 +91,7 @@ def test_train_epochs_cover_each_structural_family_without_mutating_target() -> 
     original = copy.deepcopy(source)
     completion = render_phase1_completion(source["y_true"]["json"])
     observed = []
+    snippets_by_family = {}
 
     for epoch in range(len(EXPECTED_FAMILIES)):
         result = build_phase1_structural_loss_view(
@@ -94,6 +103,10 @@ def test_train_epochs_cover_each_structural_family_without_mutating_target() -> 
             row_index=0,
         )
         observed.append(result.family)
+        snippets_by_family[result.family] = tuple(
+            completion[start:end]
+            for start, end in result.completion_spans
+        )
         assert result.row["y_true"] == original["y_true"]
         assert result.row["x"] != original["x"]
         assert result.operations
@@ -104,7 +117,66 @@ def test_train_epochs_cover_each_structural_family_without_mutating_target() -> 
         )
 
     assert tuple(observed) == EXPECTED_FAMILIES
+    assert all("\"@odata.id\"" in text for text in snippets_by_family["odata_id"])
+    assert all("\"target\"" in text for text in snippets_by_family["action_targets"])
+    assert snippets_by_family["target_keys"] == ('"target"',)
+    assert all(
+        text.startswith("{") and text.endswith("}")
+        for text in snippets_by_family["json_objects"]
+    )
+    assert all(
+        text.startswith("[") and text.endswith("]")
+        for text in snippets_by_family["json_arrays"]
+    )
+    assert all(
+        "@Redfish.AllowableValues" in text
+        for text in snippets_by_family["allowable_values"]
+    )
+    assert set(snippets_by_family["api_prefixes"]) == {"/redfish/v1/"}
     assert source == original
+
+
+def test_train_family_start_depends_on_row_and_falls_forward_when_absent() -> None:
+    """Rows start at different families and missing families use the next available one."""
+    profile = load_phase1_structural_loss_profile(
+        "historical_structural_mask_v1"
+    )
+    source = _row()
+
+    first = build_phase1_structural_loss_view(
+        source,
+        profile=profile,
+        mode="train",
+        run_seed=31,
+        epoch=0,
+        row_index=0,
+    )
+    second = build_phase1_structural_loss_view(
+        source,
+        profile=profile,
+        mode="train",
+        run_seed=31,
+        epoch=0,
+        row_index=1,
+    )
+    sparse = build_phase1_row(
+        rest_api="/redfish/v1/Systems/1",
+        allowed_methods=["GET"],
+        input_json={"Id": "1"},
+        target_json={"Id": "1"},
+    )
+    fallback = build_phase1_structural_loss_view(
+        sparse,
+        profile=profile,
+        mode="train",
+        run_seed=31,
+        epoch=0,
+        row_index=1,
+    )
+
+    assert first.family == "odata_id"
+    assert second.family == "action_targets"
+    assert fallback.family == "json_objects"
 
 
 def test_structural_loss_is_reproducible_and_heldout_is_epoch_fixed() -> None:
@@ -146,6 +218,44 @@ def test_structural_loss_is_reproducible_and_heldout_is_epoch_fixed() -> None:
 
     assert train_a == train_b
     assert heldout_a == heldout_b
+    assert heldout_a.family != "full_completion"
+    assert heldout_a.completion_spans
+    assert heldout_a.row["x"] != source["x"]
+
+
+def test_api_prefix_loss_covers_every_prefix_removed_from_input() -> None:
+    """Substring masking and completion supervision have identical cardinality."""
+    body = {
+        f"Uri{index:02d}": f"/redfish/v1/Systems/{index}"
+        for index in range(20)
+    }
+    source = build_phase1_row(
+        rest_api="/redfish/v1/Systems",
+        allowed_methods=["GET"],
+        input_json=body,
+        target_json=body,
+    )
+    profile = load_phase1_structural_loss_profile(
+        "historical_structural_mask_v1"
+    )
+    result = build_phase1_structural_loss_view(
+        source,
+        profile=profile,
+        mode="train",
+        run_seed=31,
+        epoch=6,
+        row_index=0,
+    )
+    completion = render_phase1_completion(source["y_true"]["json"])
+
+    assert result.family == "api_prefixes"
+    assert len(result.completion_spans) == 20
+    assert all(
+        completion[start:end] == "/redfish/v1/"
+        for start, end in result.completion_spans
+    )
+    assert "/redfish/v1/" not in result.row["x"]["rest_api"]
+    assert "/redfish/v1/" not in json.dumps(result.row["x"]["json"])
 
 
 def test_disabled_profile_preserves_full_completion_contract() -> None:

--- a/tests/ds/test_phase1_structural_loss.py
+++ b/tests/ds/test_phase1_structural_loss.py
@@ -1,0 +1,185 @@
+"""Contract tests for the historical Phase 1 selective structural loss."""
+
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from igc.ds.phase1_render import (
+    build_phase1_row,
+    phase1_json_with_spans,
+    render_phase1_completion,
+)
+from igc.ds.phase1_structural_loss import (
+    build_phase1_structural_loss_view,
+    load_phase1_structural_loss_profile,
+)
+
+
+EXPECTED_FAMILIES = (
+    "odata_id",
+    "action_targets",
+    "target_keys",
+    "json_objects",
+    "json_arrays",
+    "allowable_values",
+    "api_prefixes",
+)
+
+
+def _row() -> dict:
+    body = {
+        "@odata.id": "/redfish/v1/Systems/1",
+        "Actions": {
+            "#ComputerSystem.Reset": {
+                "target": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+                "ResetType@Redfish.AllowableValues": [
+                    "On",
+                    "ForceOff",
+                ],
+            }
+        },
+        "Boot": {"BootSourceOverrideTarget": "Pxe"},
+    }
+    return build_phase1_row(
+        rest_api="/redfish/v1/Systems/1",
+        allowed_methods=["GET", "PATCH"],
+        input_json=body,
+        target_json=body,
+    )
+
+
+def test_structural_loss_profile_locks_historical_family_order() -> None:
+    """The first baseline contains exactly the seven proven historical families."""
+    profile = load_phase1_structural_loss_profile(
+        "historical_structural_mask_v1"
+    )
+
+    assert profile.enabled is True
+    assert profile.selection == "row_epoch_cycle"
+    assert tuple(family.name for family in profile.families) == EXPECTED_FAMILIES
+    assert profile.spec_sha256.startswith("sha256:")
+
+
+def test_span_renderer_is_byte_identical_to_canonical_json() -> None:
+    """Adding span indexes must not change the existing Phase 1 target bytes."""
+    body = _row()["y_true"]["json"]
+
+    rendered, spans = phase1_json_with_spans(body)
+
+    assert rendered == json.dumps(body, indent=2, sort_keys=True)
+    assert spans
+    assert all(0 <= span.start < span.end <= len(rendered) for span in spans)
+
+
+def test_train_epochs_cover_each_structural_family_without_mutating_target() -> None:
+    """The curriculum rotates families while D0 and canonical y_true stay immutable."""
+    profile = load_phase1_structural_loss_profile(
+        "historical_structural_mask_v1"
+    )
+    source = _row()
+    original = copy.deepcopy(source)
+    completion = render_phase1_completion(source["y_true"]["json"])
+    observed = []
+
+    for epoch in range(len(EXPECTED_FAMILIES)):
+        result = build_phase1_structural_loss_view(
+            source,
+            profile=profile,
+            mode="train",
+            run_seed=31,
+            epoch=epoch,
+            row_index=0,
+        )
+        observed.append(result.family)
+        assert result.row["y_true"] == original["y_true"]
+        assert result.row["x"] != original["x"]
+        assert result.operations
+        assert result.completion_spans
+        assert all(
+            completion[start:end]
+            for start, end in result.completion_spans
+        )
+
+    assert tuple(observed) == EXPECTED_FAMILIES
+    assert source == original
+
+
+def test_structural_loss_is_reproducible_and_heldout_is_epoch_fixed() -> None:
+    """Train sampling is seeded and evaluation ignores mutable epoch state."""
+    profile = load_phase1_structural_loss_profile(
+        "historical_structural_mask_v1"
+    )
+    source = _row()
+    kwargs = {
+        "profile": profile,
+        "run_seed": 97,
+        "row_index": 3,
+    }
+
+    train_a = build_phase1_structural_loss_view(
+        source,
+        mode="train",
+        epoch=4,
+        **kwargs,
+    )
+    train_b = build_phase1_structural_loss_view(
+        source,
+        mode="train",
+        epoch=4,
+        **kwargs,
+    )
+    heldout_a = build_phase1_structural_loss_view(
+        source,
+        mode="evaluation",
+        epoch=0,
+        **kwargs,
+    )
+    heldout_b = build_phase1_structural_loss_view(
+        source,
+        mode="evaluation",
+        epoch=999,
+        **kwargs,
+    )
+
+    assert train_a == train_b
+    assert heldout_a == heldout_b
+
+
+def test_disabled_profile_preserves_full_completion_contract() -> None:
+    """Existing Phase 1 profiles retain their prior full-completion labels."""
+    source = _row()
+    result = build_phase1_structural_loss_view(
+        source,
+        profile=load_phase1_structural_loss_profile("none"),
+        mode="train",
+        run_seed=1,
+        epoch=4,
+        row_index=2,
+    )
+
+    assert result.row == source
+    assert result.row is not source
+    assert result.family == "full_completion"
+    assert result.completion_spans == ()
+    assert result.operations == ()
+
+
+def test_structural_loss_rejects_non_reconstruction_source_rows() -> None:
+    """Selective masking requires the materialized D0 input/target parity gate."""
+    source = _row()
+    source["x"]["json"] = {"different": True}
+
+    with pytest.raises(ValueError, match="x.json == y_true.json"):
+        build_phase1_structural_loss_view(
+            source,
+            profile=load_phase1_structural_loss_profile(
+                "historical_structural_mask_v1"
+            ),
+            mode="train",
+            run_seed=1,
+            epoch=0,
+            row_index=0,
+        )

--- a/tests/ds/test_sft_dataset.py
+++ b/tests/ds/test_sft_dataset.py
@@ -23,10 +23,17 @@ class _CharTokenizer:
         truncation=None,
         return_tensors=None,
         add_special_tokens=None,
+        return_offsets_mapping=False,
     ):
         _ = (padding, truncation, return_tensors, add_special_tokens)
         ids = [ord(char) % 1000 + 1 for char in text]
-        return {"input_ids": torch.tensor([ids], dtype=torch.long)}
+        result = {"input_ids": torch.tensor([ids], dtype=torch.long)}
+        if return_offsets_mapping:
+            result["offset_mapping"] = torch.tensor(
+                [[(index, index + 1) for index in range(len(text))]],
+                dtype=torch.long,
+            )
+        return result
 
 
 def test_prompt_completion_overflow_raises_instead_of_truncating() -> None:
@@ -54,6 +61,41 @@ def test_prompt_completion_masks_prompt_and_padding_when_it_fits() -> None:
     assert item["labels"][:2].tolist() == [-100, -100]
     assert item["labels"][2:4].tolist() == item["input_ids"][2:4].tolist()
     assert item["labels"][4:].tolist() == [-100, -100]
+
+
+def test_prompt_completion_labels_only_selected_character_spans() -> None:
+    """Selective Phase 1 loss keeps prompt and unselected completion ignored."""
+    item = tokenize_prompt_completion(
+        _CharTokenizer(),
+        prompt="ab",
+        completion="cdef",
+        max_len=8,
+        completion_label_spans=((1, 3),),
+    )
+
+    assert item["labels"].tolist() == [
+        -100,
+        -100,
+        -100,
+        item["input_ids"][3].item(),
+        item["input_ids"][4].item(),
+        -100,
+        -100,
+        -100,
+    ]
+
+
+@pytest.mark.parametrize("span", [(), ((0, 0),), ((0, 5),)])
+def test_prompt_completion_rejects_empty_or_out_of_range_label_spans(span) -> None:
+    """Malformed selective-loss spans fail closed instead of yielding zero loss."""
+    with pytest.raises((TypeError, ValueError)):
+        tokenize_prompt_completion(
+            _CharTokenizer(),
+            prompt="ab",
+            completion="cdef",
+            max_len=8,
+            completion_label_spans=span,
+        )
 
 
 def _write_jsonl(path, rows):

--- a/tests/modules/test_igc_main_corpus_manifest.py
+++ b/tests/modules/test_igc_main_corpus_manifest.py
@@ -39,12 +39,19 @@ class _FakeCorpusDataset:
         max_len=None,
         tokenizer=None,
         objective=None,
+        phase1_structural_loss_profile="none",
+        phase1_structural_loss_mode="train",
+        phase1_structural_loss_seed=42,
     ):
         self.corpus_dir = Path(corpus_dir)
         self.default_tokenize = default_tokenize
         self.max_len = max_len
         self.input_tokenizer = tokenizer
         self.objective = objective
+        self.phase1_structural_loss_profile = phase1_structural_loss_profile
+        self.phase1_structural_loss_mode = phase1_structural_loss_mode
+        self.phase1_structural_loss_seed = phase1_structural_loss_seed
+        self.phase1_structural_loss_spec_sha = "sha256:" + "c" * 64
         self.tokenizer = tokenizer or object()
         suffix = "b" if tokenizer is not None else "a"
         self.data_sha256 = "sha256:" + suffix * 64

--- a/tests/modules/test_igc_main_corpus_path.py
+++ b/tests/modules/test_igc_main_corpus_path.py
@@ -33,12 +33,19 @@ class _FakeCorpusDataset:
         max_len=None,
         tokenizer=None,
         objective="legacy",
+        phase1_structural_loss_profile="none",
+        phase1_structural_loss_mode="train",
+        phase1_structural_loss_seed=42,
     ):
         self.corpus_dir = corpus_dir
         self.default_tokenize = default_tokenize
         self.max_len = max_len
         self.input_tokenizer = tokenizer
         self.objective = objective
+        self.phase1_structural_loss_profile = phase1_structural_loss_profile
+        self.phase1_structural_loss_mode = phase1_structural_loss_mode
+        self.phase1_structural_loss_seed = phase1_structural_loss_seed
+        self.phase1_structural_loss_spec_sha = "sha256:" + "c" * 64
         self.tokenizer = tokenizer or object()
         suffix = "b" if tokenizer is not None else "a"
         self.data_sha256 = "sha256:" + suffix * 64
@@ -98,6 +105,8 @@ def test_run_with_corpus_dir_does_not_build_legacy_masked_dataset(monkeypatch, t
     assert main.eval_dataset.corpus_dir == str(tmp_path / "heldout_corpus")
     assert main.eval_dataset.input_tokenizer is trained["dataset"].tokenizer
     assert main.eval_dataset.objective == "phase1_pretrain"
+    assert trained["dataset"].phase1_structural_loss_mode == "train"
+    assert main.eval_dataset.phase1_structural_loss_mode == "evaluation"
     assert trained["dataset"].eval_split_sha256 == main.eval_dataset.data_sha256
     assert trained["dataset"].eval_data_sha == main.eval_dataset.data_sha256
 

--- a/tests/modules/test_igc_main_sft_paths.py
+++ b/tests/modules/test_igc_main_sft_paths.py
@@ -82,12 +82,19 @@ class _FakeCorpusJSONLDataset:
         max_len,
         tokenizer=None,
         objective="legacy",
+        phase1_structural_loss_profile="none",
+        phase1_structural_loss_mode="train",
+        phase1_structural_loss_seed=42,
     ):
         self.path = Path(corpus_dir)
         self.default_tokenize = default_tokenize
         self.max_len = max_len
         self.input_tokenizer = tokenizer
         self.objective = objective
+        self.phase1_structural_loss_profile = phase1_structural_loss_profile
+        self.phase1_structural_loss_mode = phase1_structural_loss_mode
+        self.phase1_structural_loss_seed = phase1_structural_loss_seed
+        self.phase1_structural_loss_spec_sha = "sha256:" + "c" * 64
         self.tokenizer = tokenizer or object()
         suffix = "d" if tokenizer is None else "e"
         self.data_sha256 = "sha256:" + suffix * 64
@@ -328,8 +335,12 @@ def test_igc_main_phase1_shared_sft_requires_canonical_registry_corpus_dirs(
     assert eval_dataset.path == Path(specs.corpus_eval_dir)
     assert dataset.objective == "phase1_pretrain"
     assert eval_dataset.objective == "phase1_pretrain"
+    assert dataset.phase1_structural_loss_profile == "none"
+    assert dataset.phase1_structural_loss_mode == "train"
+    assert eval_dataset.phase1_structural_loss_mode == "evaluation"
     assert dataset.default_tokenize == "gpt2"
     assert eval_dataset.input_tokenizer is dataset.tokenizer
     assert dataset.eval_split_sha256 == eval_dataset.data_sha256
     assert specs.task_spec_sha.startswith("sha256:")
+    assert specs.phase1_structural_loss_spec_sha == "sha256:" + "c" * 64
     assert specs.phase_number == 1

--- a/tests/modules/train/test_launch.py
+++ b/tests/modules/train/test_launch.py
@@ -54,6 +54,23 @@ def test_7b_rslora_argv_matches_spec(monkeypatch):
     assert _val(argv, "--lora_init") == "default"
 
 
+def test_structural_mask_profile_forwards_named_loss_policy(monkeypatch):
+    """The A/B arm selects structural loss without changing the baseline profile."""
+    monkeypatch.setenv("IGC_FOUNDATION_MODEL_SHA", "sha256:" + "1" * 64)
+    monkeypatch.setenv("IGC_TOKENIZER_SHA", "sha256:" + "2" * 64)
+
+    baseline = profile_to_argv(resolve_profile("phase1_7b_rslora_r32"))
+    structural_mask = profile_to_argv(
+        resolve_profile("phase1_7b_rslora_r32_structural_mask")
+    )
+
+    assert _val(baseline, "--phase1_structural_loss_profile") == "none"
+    assert (
+        _val(structural_mask, "--phase1_structural_loss_profile")
+        == "historical_structural_mask_v1"
+    )
+
+
 def test_profile_to_argv_forwards_every_lora_target_module_after_flag():
     """All adapter target modules must follow one --lora_target_modules flag."""
     target_modules = ("q_proj", "v_proj", "down_proj", "lm_head")

--- a/tests/modules/train/test_profiles.py
+++ b/tests/modules/train/test_profiles.py
@@ -37,6 +37,7 @@ _PROFILE_HYPERPARAMETERS = {
     "cycle_momentum",
     "anneal_strategy",
     "seed",
+    "phase1_structural_loss_profile",
 }
 
 _REGISTERED = [
@@ -44,6 +45,7 @@ _REGISTERED = [
     "phase1_3b_lora",
     "phase1_7b_lora",
     "phase1_7b_rslora_r32",
+    "phase1_7b_rslora_r32_structural_mask",
     "phase1_local",
     "phase1_3b_full",
     "phase1_7b_full_zero3",
@@ -68,6 +70,11 @@ _PROFILE_CASES = [
     ),
     (
         "phase1_7b_rslora_r32", "Qwen/Qwen2.5-7B-Instruct", True, 8, 4,
+        1e-4, "none", 2048, "bf16", None,
+        "phase1_finetune", "model_x", "sft", "phase1_pretrain",
+    ),
+    (
+        "phase1_7b_rslora_r32_structural_mask", "Qwen/Qwen2.5-7B-Instruct", True, 8, 4,
         1e-4, "none", 2048, "bf16", None,
         "phase1_finetune", "model_x", "sft", "phase1_pretrain",
     ),
@@ -151,6 +158,12 @@ def test_profile_matrix_matches_plan_contract(
     assert p.weights_role == weights_role
     assert p.llm_stage == llm_stage
     assert p.corpus_objective == corpus_objective
+    expected_structural_loss = (
+        "historical_structural_mask_v1"
+        if name == "phase1_7b_rslora_r32_structural_mask"
+        else "none"
+    )
+    assert p.phase1_structural_loss_profile == expected_structural_loss
     assert p.early_stopping_patience == 3
     assert p.early_stopping_min_delta == 0.005
 
@@ -202,6 +215,7 @@ def test_resolved_profile_describe_includes_profile_driven_hyperparameters():
         "max_grad_norm": 0.75,
         "max_lr": 0.003,
         "optimizer": "SGD",
+        "phase1_structural_loss_profile": "none",
         "seed": 1234,
         "weight_decay": 0.02,
     }

--- a/tests/modules/train/test_profiles.py
+++ b/tests/modules/train/test_profiles.py
@@ -17,6 +17,7 @@ import yaml
 from igc.modules.train.profiles import (
     AdapterSpec,
     apply_lora_kwargs,
+    load_profiles,
     profile_names,
     resolve_profile,
 )
@@ -185,6 +186,19 @@ def test_profile_yaml_exposes_profile_driven_hyperparameters():
         assert isinstance(profile["cycle_momentum"], bool)
         assert profile["anneal_strategy"] in {"cos", "linear"}
         assert isinstance(profile["seed"], int)
+
+
+def test_older_profile_yaml_defaults_to_full_completion(tmp_path: Path) -> None:
+    """Registries predating structural loss retain the old profile=none behavior."""
+    raw = yaml.safe_load(_PROFILE_YAML.read_text(encoding="utf-8"))
+    profile = raw["profiles"]["phase1_gpt2_smoke"]
+    del profile["phase1_structural_loss_profile"]
+    path = tmp_path / "profiles.yaml"
+    path.write_text(yaml.safe_dump(raw), encoding="utf-8")
+
+    loaded = load_profiles(path)
+
+    assert loaded["phase1_gpt2_smoke"].phase1_structural_loss_profile == "none"
 
 
 def test_resolved_profile_describe_includes_profile_driven_hyperparameters():

--- a/tests/modules/train/test_sft_epoch.py
+++ b/tests/modules/train/test_sft_epoch.py
@@ -1,0 +1,23 @@
+"""Focused tests for epoch-aware dynamic SFT datasets."""
+
+from igc.modules.train.sft import select_dataset_epoch
+
+
+class _EpochDataset:
+    def __init__(self) -> None:
+        self.epochs = []
+
+    def set_epoch(self, epoch: int) -> None:
+        self.epochs.append(epoch)
+
+
+def test_select_dataset_epoch_calls_optional_dataset_hook() -> None:
+    dataset = _EpochDataset()
+
+    select_dataset_epoch(dataset, 4)
+
+    assert dataset.epochs == [4]
+
+
+def test_select_dataset_epoch_accepts_static_dataset() -> None:
+    select_dataset_epoch(object(), 4)

--- a/tests/modules/train/test_sft_epoch.py
+++ b/tests/modules/train/test_sft_epoch.py
@@ -1,9 +1,19 @@
 """Focused tests for epoch-aware dynamic SFT datasets."""
 
-from igc.modules.train.sft import select_dataset_epoch
+from types import SimpleNamespace
+
+from igc.modules.train.sft import select_dataset_epoch, select_training_epoch
 
 
 class _EpochDataset:
+    def __init__(self) -> None:
+        self.epochs = []
+
+    def set_epoch(self, epoch: int) -> None:
+        self.epochs.append(epoch)
+
+
+class _EpochSurface:
     def __init__(self) -> None:
         self.epochs = []
 
@@ -21,3 +31,24 @@ def test_select_dataset_epoch_calls_optional_dataset_hook() -> None:
 
 def test_select_dataset_epoch_accepts_static_dataset() -> None:
     select_dataset_epoch(object(), 4)
+
+
+def test_select_training_epoch_advances_prepared_loader() -> None:
+    dataset = _EpochDataset()
+    dataloader = _EpochSurface()
+
+    select_training_epoch(dataset, dataloader, 5)
+
+    assert dataset.epochs == [5]
+    assert dataloader.epochs == [5]
+
+
+def test_select_training_epoch_advances_plain_loader_sampler() -> None:
+    dataset = _EpochDataset()
+    sampler = _EpochSurface()
+    dataloader = SimpleNamespace(sampler=sampler)
+
+    select_training_epoch(dataset, dataloader, 6)
+
+    assert dataset.epochs == [6]
+    assert sampler.epochs == [6]


### PR DESCRIPTION
## What

- **Structural loss curriculum** (ed676f3): span-indexed canonical JSON rendering (`phase1_json_with_spans`), YAML-owned mask profiles (`configs/training/phase1_structural_loss.yaml`), per-epoch family cycling over @odata.id / action targets / target keys / objects / arrays / allowable values / API prefixes, and selective completion labels — tokens outside the selected spans carry no loss (`-100`).
- **Gates** (21a2845): strict profile validation, train/eval spec-SHA equality, fixed held-out eval views (epoch pinned to 0), run-manifest identity fields.
- **Invariant test** (bfcb952): one test, `tests/ds/test_phase1_input_noise_gap.py`, pinning a known objective gap so it stays visible: rendering sorts keys canonically (upstream reordering yields byte-identical prompts), the branch's only shuffle is the mask-span candidate shuffle, and the `x.json == y_true.json` guard rejects upstream content noise. Masking landed; per-epoch input noise did not — it is intentionally the next change, one step at a time.

## Known follow-ups (reviewed, ordered)

1. Per-epoch input key-order noise (this PR pins the gap; fix comes next).
2. Exclude the root object and cap subtree size in the object/array families (currently a root draw hides the whole input and recreates the memorize-from-URL task).
3. Eval mask seed independence from the run seed (held-out masks currently vary across runs with different seeds).
4. Refuse `profile=none` for `phase1_pretrain` (full-completion copy loss must not stay the silent default).
5. Start key_value loss spans at the value, not the key.

## Validation

Offline CPU test surface via CI (local execution is out of policy for this repo). The new test is pure-Python, offline, deterministic; compile-checked only on the authoring machine.