### PR TITLE
Harden Phase 1 corruption and promotion gates

### DIFF
--- a/configs/inference/phase1_golden_acceptance.yaml
+++ b/configs/inference/phase1_golden_acceptance.yaml
@@ -9,6 +9,7 @@ thresholds:
   max_missing_target_rows: 0
   max_missing_prediction_rows: 0
   min_model_json_parse_rate: 0.995
+  min_model_json_exact_match_rate: 0.8
   min_model_resource_identity_match_rate: 0.995
   min_exact_match_delta_vs_foundation: 0.02
   max_instruction_judge_accept_rate_drop: 0.03

--- a/igc/ds/phase1_render.py
+++ b/igc/ds/phase1_render.py
@@ -7,6 +7,7 @@ bytes remain identical.
 """
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 from dataclasses import dataclass
@@ -46,9 +47,9 @@ def build_phase1_row(
         "x": {
             "rest_api": rest_api,
             "allowed_methods": list(allowed_methods),
-            "json": dict(input_json),
+            "json": copy.deepcopy(dict(input_json)),
         },
-        "y_true": {"json": dict(target_json)},
+        "y_true": {"json": copy.deepcopy(dict(target_json))},
     }
     if metadata is not None:
         row["metadata"] = dict(metadata)

--- a/igc/ds/phase1_structural_loss.py
+++ b/igc/ds/phase1_structural_loss.py
@@ -70,6 +70,15 @@ class Phase1StructuralLossResult:
     operations: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class Phase1Repair:
+    """One exact change required to restore a corrupted Phase 1 input."""
+
+    kind: str
+    path: tuple[str | int, ...]
+    value: Any = None
+
+
 def load_phase1_structural_loss_profile(
     name: str,
     path: str | Path = STRUCTURAL_LOSS_SPEC_PATH,
@@ -218,6 +227,77 @@ def build_phase1_structural_loss_view(
     )
 
 
+def detect_phase1_repairs(
+    observed: Any,
+    expected: Any,
+) -> tuple[Phase1Repair, ...]:
+    """Return the deterministic minimal repair plan from observed to expected."""
+
+    repairs: list[Phase1Repair] = []
+
+    def visit(current: Any, target: Any, path: tuple[str | int, ...]) -> None:
+        if isinstance(current, Mapping) and isinstance(target, Mapping):
+            current_keys = set(current)
+            target_keys = set(target)
+            for key in sorted(current_keys - target_keys, key=str):
+                repairs.append(Phase1Repair("delete", path + (key,)))
+            for key in sorted(target_keys - current_keys, key=str):
+                repairs.append(
+                    Phase1Repair("set", path + (key,), copy.deepcopy(target[key]))
+                )
+            for key in sorted(current_keys & target_keys, key=str):
+                visit(current[key], target[key], path + (key,))
+            return
+        if isinstance(current, list) and isinstance(target, list):
+            if current != target:
+                repairs.append(Phase1Repair("set", path, copy.deepcopy(target)))
+            return
+        if current != target:
+            repairs.append(Phase1Repair("set", path, copy.deepcopy(target)))
+
+    visit(observed, expected, ())
+    return tuple(repairs)
+
+
+def apply_phase1_repairs(
+    observed: Any,
+    repairs: Sequence[Phase1Repair],
+) -> Any:
+    """Apply a repair plan without mutating the observed Phase 1 input."""
+
+    repaired = copy.deepcopy(observed)
+    for repair in repairs:
+        if repair.kind not in {"set", "delete"}:
+            raise ValueError(f"unknown Phase 1 repair kind {repair.kind!r}")
+        if not repair.path:
+            if repair.kind == "delete":
+                raise ValueError("cannot delete the Phase 1 repair root")
+            repaired = copy.deepcopy(repair.value)
+            continue
+        parent, key = _resolve_parent(repaired, repair.path)
+        if repair.kind == "delete":
+            if isinstance(parent, MutableMapping):
+                if key not in parent:
+                    raise ValueError(
+                        f"Phase 1 repair path does not exist: {repair.path!r}"
+                    )
+                del parent[key]
+            elif isinstance(parent, list) and isinstance(key, int):
+                del parent[key]
+            else:
+                raise ValueError(
+                    f"Phase 1 repair path is not deletable: {repair.path!r}"
+                )
+            continue
+        if isinstance(parent, MutableMapping):
+            parent[key] = copy.deepcopy(repair.value)
+        elif isinstance(parent, list) and isinstance(key, int):
+            parent[key] = copy.deepcopy(repair.value)
+        else:
+            raise ValueError(f"Phase 1 repair path is not assignable: {repair.path!r}")
+    return repaired
+
+
 def _family_from_raw(
     profile_name: str,
     index: int,
@@ -282,8 +362,22 @@ def _family_spans(
             and span.key is not None
             and any(span.key.endswith(pattern) for pattern in family.patterns)
         ]
-    if family.selector in {"object", "array"}:
-        return [span for span in spans if span.kind == family.selector]
+    if family.selector == "object":
+        nested_objects = [
+            span for span in spans if span.kind == "object" and span.path
+        ]
+        if nested_objects:
+            return nested_objects
+        # A root object is never a valid mask target: replacing it would
+        # remove the entire observation and turn the task into URL memorization.
+        # Flat resources instead supervise one bounded root field.
+        return [
+            span
+            for span in spans
+            if span.kind == "key_value" and len(span.path) == 1
+        ]
+    if family.selector == "array":
+        return [span for span in spans if span.kind == "array"]
     matches: list[tuple[int, int]] = []
     for pattern in family.patterns:
         start = 0
@@ -409,7 +503,10 @@ __all__ = (
     "STRUCTURAL_LOSS_SPEC_PATH",
     "Phase1StructuralLossProfile",
     "Phase1StructuralLossResult",
+    "Phase1Repair",
     "StructuralLossFamily",
+    "apply_phase1_repairs",
     "build_phase1_structural_loss_view",
+    "detect_phase1_repairs",
     "load_phase1_structural_loss_profile",
 )

--- a/igc/modules/train/phase1_promotion.py
+++ b/igc/modules/train/phase1_promotion.py
@@ -277,6 +277,7 @@ def evaluate_phase1_promotion(
     minimum_generation_budget = full_model.get(generation_budget_key)
     finite_values = (
         full_model.get(parse_key),
+        full_model.get(exact_key),
         full_model.get(identity_key),
         full_delta.get(exact_key),
         golden_model.get(parse_key),
@@ -309,6 +310,12 @@ def evaluate_phase1_promotion(
         "min_model_json_parse_rate",
         full_model.get(parse_key),
         thresholds.get("min_model_json_parse_rate"),
+    )
+    _minimum(
+        checks,
+        "min_model_json_exact_match_rate",
+        full_model.get(exact_key),
+        thresholds.get("min_model_json_exact_match_rate"),
     )
     _minimum(
         checks,
@@ -365,6 +372,12 @@ def evaluate_phase1_promotion(
             f"min_resource_identity_match_rate_{corpus}",
             model_corpus.get("resource_identity_match_rate"),
             thresholds.get("min_model_resource_identity_match_rate"),
+        )
+        _minimum_value(
+            checks,
+            f"min_json_exact_match_rate_{corpus}",
+            model_corpus.get("json_exact_match_rate"),
+            thresholds.get("min_model_json_exact_match_rate"),
         )
         baseline_exact = baseline_corpus.get("json_exact_match_rate")
         model_exact = model_corpus.get("json_exact_match_rate")

--- a/scripts/gates/phase1_contract.py
+++ b/scripts/gates/phase1_contract.py
@@ -59,13 +59,41 @@ def _check_machine_contract(failures: list[str]) -> None:
 
     objective = value.get("objective", {})
     expected_objective = {
-        "family": "causal_lm_completion",
+        "family": "causal_lm_profile_selected_completion",
         "prompt_tokens_ignored": True,
-        "completion_tokens_supervised": True,
+        "completion_tokens_supervised": (
+            "training_profile.phase1_structural_loss_profile"
+        ),
+        "canonical_target_immutable": True,
+        "full_completion_profile": "none",
+        "structural_loss_registry": (
+            "configs/training/phase1_structural_loss.yaml"
+        ),
+        "structural_loss_registry_role": (
+            "authoritative_runtime_selector_definitions"
+        ),
+        "historical_structural_mask_v1": {
+            "selection": "row_epoch_cycle_with_available_family_fallback",
+            "evaluation_selection": "row_fixed_at_epoch_zero",
+            "requires_input_target_json_equal_before_masking": True,
+            "selected_span_hidden_from_input": True,
+            "api_prefix_policy": "supervise_every_removed_occurrence",
+            "families": [
+                "odata_id",
+                "action_targets",
+                "target_keys",
+                "json_objects",
+                "json_arrays",
+                "allowable_values",
+                "api_prefixes",
+            ],
+        },
         "overflow_policy": "reject",
     }
     if objective != expected_objective:
-        failures.append("Phase 1 objective does not match completion-only training")
+        failures.append(
+            "Phase 1 objective does not match profile-selected structural loss"
+        )
 
     materialization = value.get("materialization", {})
     if materialization != {

--- a/tests/ds/test_corpus_dataset.py
+++ b/tests/ds/test_corpus_dataset.py
@@ -542,6 +542,8 @@ def test_shared_sft_dataset_surface(tmp_path: Path):
         "source_manifest_sha": "",
         "source_registry_sha": "",
         "source_artifact_manifest_shas": {},
+        "phase1_structural_loss_profile": ds.phase1_structural_loss_profile,
+        "phase1_structural_loss_spec_sha": ds.phase1_structural_loss_spec_sha,
     }
 
 
@@ -568,6 +570,8 @@ def test_run_manifest_fields_round_trip_exact_file_lineage(tmp_path: Path):
         "source_manifest_sha": train_manifest_sha,
         "source_registry_sha": "",
         "source_artifact_manifest_shas": {},
+        "phase1_structural_loss_profile": ds.phase1_structural_loss_profile,
+        "phase1_structural_loss_spec_sha": ds.phase1_structural_loss_spec_sha,
     }
 
     ds.set_eval_split_sha256(heldout.data_sha256)
@@ -581,6 +585,8 @@ def test_run_manifest_fields_round_trip_exact_file_lineage(tmp_path: Path):
         "source_manifest_sha": train_manifest_sha,
         "source_registry_sha": "",
         "source_artifact_manifest_shas": {},
+        "phase1_structural_loss_profile": ds.phase1_structural_loss_profile,
+        "phase1_structural_loss_spec_sha": ds.phase1_structural_loss_spec_sha,
     }
     assert fields["data_manifest"].startswith("sha256:")
     assert fields["train_data_sha"].startswith("sha256:")

--- a/tests/ds/test_phase1_root_mask_degeneracy.py
+++ b/tests/ds/test_phase1_root_mask_degeneracy.py
@@ -1,18 +1,11 @@
-"""Executable evidence for review break 2: root masking recreates memorization.
+"""Regression coverage for the flat-resource root masking failure.
 
 Grounded on real data: the fixture is an actual GB300 HGX ERoT firmware
 ImageSlot document from the public ``redfish_ctl`` Supermicro corpus, where
 19% of the 1,886 captured resources are flat like it (a private full-crawl
-measured 27.3% of 7,329). The ``json_objects`` family indexes every object
-span including the ROOT; for a flat document the root is the only candidate,
-so the draw is deterministic: the whole input context collapses to a single
-mask token while the loss span covers the entire completion — the model must
-reproduce real firmware states and version numbers from the URL alone, which
-is exactly the memorize-from-URL objective Phase 1 was redesigned to
-eliminate. No existing guard rejects the degenerate view; acceptance is the
-defect this test pins. When root exclusion (or a subtree-size cap) lands,
-this demonstration is expected to be replaced by the real coverage contract
-tests.
+measured 27.3% of 7,329). The ``json_objects`` family must never select the
+root span: flat documents fall back to one bounded root field so the model
+cannot be trained to regenerate an entire firmware document from its URL.
 """
 
 from __future__ import annotations
@@ -53,28 +46,12 @@ def _nested_object_count(value) -> int:
     return count
 
 
-def test_root_mask_degenerates_to_memorization_on_real_corpus_document() -> None:
-    """Root draw is certain for a real flat capture, and no guard rejects it.
-
-    Three legs of the same break:
-
-    1. reachability — ``row_epoch_cycle`` starts at family index
-       ``(row_index + epoch) % 7``, so epoch 3 / row 0 selects
-       ``json_objects``; the real document is flat, so the root span is the
-       only candidate and the draw is certain, no randomness involved;
-    2. degeneracy — the masked input is exactly ``{mask_token: True}`` (all
-       document content gone) while the loss span covers the entire
-       completion, so every token of the real firmware document carries loss
-       and the only remaining signal is the URL in the prompt;
-    3. no guard — ``build_phase1_structural_loss_view`` returns the view and
-       ``validate_phase1_row`` accepts it; nothing in the pipeline refuses
-       the memorization task.
-    """
+def test_root_object_span_is_rejected_for_flat_real_corpus_document() -> None:
+    """A real flat capture receives one bounded field mask, never a root mask."""
     document = json.loads(FIXTURE.read_text())
 
-    # Fixture preconditions: a real, flat Redfish resource. If the fixture
-    # is ever swapped for a nested document this test must scream, because
-    # leg 1 would no longer be deterministic.
+    # If the fixture becomes nested, this no longer exercises the flat-row
+    # fallback and must fail instead of silently weakening the regression.
     assert document["@odata.id"].startswith("/redfish/v1/")
     assert _nested_object_count(document) == 0
     assert "FirmwareComparisonNumber" in document
@@ -96,26 +73,29 @@ def test_root_mask_degenerates_to_memorization_on_real_corpus_document() -> None
         row_index=0,
     )
 
-    # Leg 1: the deterministic root draw happened on the real document.
     assert view.family == "json_objects"
-    assert view.operations == ("mask:json_objects:/",)
+    assert len(view.operations) == 1
+    assert view.operations != ("mask:json_objects:/",)
 
-    # Leg 2: input context is a bare mask token; loss covers the whole doc.
-    # The completion is the rendered document plus a trailing newline; the
-    # root span covers every byte of the document itself.
-    assert view.row["x"]["json"] == {profile.mask_token: True}
+    # The root survives and exactly one field is hidden. The supervised span
+    # is therefore smaller than the whole canonical document.
+    assert view.row["x"]["json"] != {profile.mask_token: True}
+    assert len(view.row["x"]["json"]) == len(document)
+    assert list(view.row["x"]["json"].values()).count(profile.mask_token) == 1
     completion = render_phase1_completion(source["y_true"]["json"])
     rendered = phase1_json_dumps(source["y_true"]["json"])
     assert completion == rendered + "\n"
-    assert view.completion_spans == ((0, len(rendered)),)
+    assert all(
+        0 <= start < end <= len(rendered) and end - start < len(rendered)
+        for start, end in view.completion_spans
+    )
 
     prompt, target_json = render_phase1_prompt(view.row)
     assert profile.mask_token in prompt
-    assert document["@odata.id"] in prompt      # the URL survives...
-    assert "FirmwareComparisonNumber" not in prompt  # ...the document does not
-    assert str(document["FirmwareComparisonNumber"]) not in prompt
-    assert "FirmwareComparisonNumber" in completion  # yet all of it carries loss
+    assert document["@odata.id"] in prompt
+    assert phase1_json_dumps(document) not in prompt
+    assert "FirmwareComparisonNumber" in completion
     assert target_json == source["y_true"]["json"]
 
-    # Leg 3: every existing guard accepts the degenerate view.
+    # The bounded view remains a valid Phase 1 row.
     validate_phase1_row(view.row)

--- a/tests/ds/test_phase1_structural_loss.py
+++ b/tests/ds/test_phase1_structural_loss.py
@@ -9,11 +9,15 @@ import pytest
 
 from igc.ds.phase1_render import (
     build_phase1_row,
+    phase1_json_dumps,
     phase1_json_with_spans,
     render_phase1_completion,
+    render_phase1_prompt,
 )
 from igc.ds.phase1_structural_loss import (
+    apply_phase1_repairs,
     build_phase1_structural_loss_view,
+    detect_phase1_repairs,
     load_phase1_structural_loss_profile,
 )
 
@@ -293,3 +297,167 @@ def test_structural_loss_rejects_non_reconstruction_source_rows() -> None:
             epoch=0,
             row_index=0,
         )
+
+
+def test_phase1_target_is_not_present_in_input() -> None:
+    """Every enabled family removes target bytes before the prompt is rendered."""
+    source = _row()
+    profile = load_phase1_structural_loss_profile("historical_structural_mask_v1")
+    target = phase1_json_dumps(source["y_true"]["json"])
+
+    for epoch in range(len(EXPECTED_FAMILIES)):
+        view = build_phase1_structural_loss_view(
+            source,
+            profile=profile,
+            mode="train",
+            run_seed=31,
+            epoch=epoch,
+            row_index=0,
+        )
+        prompt, prompt_target = render_phase1_prompt(view.row)
+
+        assert prompt_target == source["y_true"]["json"]
+        assert view.row["x"] != source["x"]
+        assert target not in prompt
+
+
+def test_phase1_copy_baseline_cannot_pass() -> None:
+    """Copying the corrupted JSON context cannot equal the canonical completion."""
+    source = _row()
+    profile = load_phase1_structural_loss_profile("historical_structural_mask_v1")
+    expected = render_phase1_completion(source["y_true"]["json"])
+
+    for epoch in range(len(EXPECTED_FAMILIES)):
+        view = build_phase1_structural_loss_view(
+            source,
+            profile=profile,
+            mode="train",
+            run_seed=31,
+            epoch=epoch,
+            row_index=0,
+        )
+        copied = render_phase1_completion(view.row["x"]["json"])
+
+        assert copied != expected
+        assert any(
+            copied[start:end] != expected[start:end]
+            for start, end in view.completion_spans
+            if end <= len(copied)
+        ) or len(copied) != len(expected)
+
+
+def test_phase1_corruption_is_deterministic() -> None:
+    """Seed, epoch, row identity, and profile fully determine one corruption."""
+    source = _row()
+    profile = load_phase1_structural_loss_profile("historical_structural_mask_v1")
+    kwargs = {
+        "profile": profile,
+        "mode": "train",
+        "run_seed": 97,
+        "epoch": 3,
+        "row_index": 2,
+    }
+
+    first = build_phase1_structural_loss_view(source, **kwargs)
+    second = build_phase1_structural_loss_view(copy.deepcopy(source), **kwargs)
+
+    assert first == second
+
+
+def test_phase1_each_corruption_has_exact_inverse_repair() -> None:
+    """Every historical family produces a complete, lossless input repair plan."""
+    source = _row()
+    profile = load_phase1_structural_loss_profile("historical_structural_mask_v1")
+
+    for epoch in range(len(EXPECTED_FAMILIES)):
+        view = build_phase1_structural_loss_view(
+            source,
+            profile=profile,
+            mode="train",
+            run_seed=31,
+            epoch=epoch,
+            row_index=0,
+        )
+        repairs = detect_phase1_repairs(view.row["x"], source["x"])
+
+        assert repairs
+        assert apply_phase1_repairs(view.row["x"], repairs) == source["x"]
+        assert view.row["x"] != source["x"]
+
+
+def test_phase1_structural_error_detection() -> None:
+    """Wrong types and unexpected members are explicit, exactly repairable errors."""
+    expected = _row()["x"]
+    observed = copy.deepcopy(expected)
+    observed["json"]["Boot"] = []
+    observed["json"]["UnexpectedTelemetryAlias"] = 73
+
+    repairs = detect_phase1_repairs(observed, expected)
+
+    assert {(repair.kind, repair.path) for repair in repairs} == {
+        ("set", ("json", "Boot")),
+        ("delete", ("json", "UnexpectedTelemetryAlias")),
+    }
+    assert apply_phase1_repairs(observed, repairs) == expected
+
+
+def test_phase1_missing_action_and_missing_api_cases() -> None:
+    """Missing action structure, API identity, and REST path remain distinguishable."""
+    expected = _row()["x"]
+    observed = copy.deepcopy(expected)
+    del observed["rest_api"]
+    del observed["json"]["@odata.id"]
+    del observed["json"]["Actions"]
+
+    repairs = detect_phase1_repairs(observed, expected)
+    repair_paths = {repair.path for repair in repairs}
+
+    assert ("rest_api",) in repair_paths
+    assert ("json", "@odata.id") in repair_paths
+    assert ("json", "Actions") in repair_paths
+    assert apply_phase1_repairs(observed, repairs) == expected
+
+
+def test_phase1_correct_document_emits_no_repair() -> None:
+    """An already-correct observation is a fixed point of repair detection."""
+    expected = _row()["x"]
+
+    repairs = detect_phase1_repairs(copy.deepcopy(expected), expected)
+
+    assert repairs == ()
+    assert apply_phase1_repairs(expected, repairs) == expected
+
+
+def test_phase1_telemetry_object_receives_bounded_structural_loss() -> None:
+    """Telemetry remains learnable without ever selecting the whole root object."""
+    body = {
+        "@odata.id": "/redfish/v1/Chassis/1/Sensors/CPU0Temp",
+        "Reading": 71.25,
+        "ReadingUnits": "Cel",
+        "Status": {"Health": "OK", "State": "Enabled"},
+    }
+    source = build_phase1_row(
+        rest_api=body["@odata.id"],
+        allowed_methods=["GET"],
+        input_json=body,
+        target_json=body,
+    )
+    view = build_phase1_structural_loss_view(
+        source,
+        profile=load_phase1_structural_loss_profile(
+            "historical_structural_mask_v1"
+        ),
+        mode="train",
+        run_seed=31,
+        epoch=3,
+        row_index=0,
+    )
+    rendered = phase1_json_dumps(body)
+
+    assert view.family == "json_objects"
+    assert view.operations != ("mask:json_objects:/",)
+    assert all(end - start < len(rendered) for start, end in view.completion_spans)
+    assert apply_phase1_repairs(
+        view.row["x"],
+        detect_phase1_repairs(view.row["x"], source["x"]),
+    ) == source["x"]

--- a/tests/gates/test_phase1_heldout_manifest.py
+++ b/tests/gates/test_phase1_heldout_manifest.py
@@ -116,7 +116,12 @@ def test_phase1_contract_yaml_matches_render_constants_and_invariants() -> None:
     assert set(row["y_true"]) == set(spec["row"]["target"]) - {"required"}
     assert set(row["metadata"]) == set(spec["metadata"]["fields"])
     assert spec["objective"]["prompt_tokens_ignored"] is True
-    assert spec["objective"]["completion_tokens_supervised"] is True
+    assert spec["objective"]["completion_tokens_supervised"] == (
+        "training_profile.phase1_structural_loss_profile"
+    )
+    assert spec["objective"]["canonical_target_immutable"] is True
+    structural = spec["objective"]["historical_structural_mask_v1"]
+    assert structural["selected_span_hidden_from_input"] is True
     assert spec["objective"]["overflow_policy"] == "reject"
 
 

--- a/tests/modules/train/test_phase1_promotion.py
+++ b/tests/modules/train/test_phase1_promotion.py
@@ -43,6 +43,7 @@ def _thresholds(**overrides: object) -> dict[str, object]:
     thresholds: dict[str, object] = {
         "require_complete_heldout_manifest": True,
         "min_model_json_parse_rate": 0.995,
+        "min_model_json_exact_match_rate": 0.8,
         "min_model_resource_identity_match_rate": 0.995,
         "min_exact_match_delta_vs_foundation": 0.02,
         "max_instruction_judge_accept_rate_drop": 0.03,
@@ -59,12 +60,14 @@ def _thresholds(**overrides: object) -> dict[str, object]:
 def _metrics(*, min_generation_budget: int = 160) -> dict[str, object]:
     baseline_metrics = {
         PARSE_KEY: 1.0,
+        EXACT_KEY: 0.90,
         IDENTITY_KEY: 1.0,
         TARGET_P95_KEY: 96.0,
         BUDGET_KEY: min_generation_budget,
     }
     model_metrics = {
         PARSE_KEY: 1.0,
+        EXACT_KEY: 0.95,
         IDENTITY_KEY: 1.0,
         TARGET_P95_KEY: 96.0,
         BUDGET_KEY: min_generation_budget,
@@ -592,6 +595,40 @@ def test_phase1_promotion_rejects_negative_generation_margin() -> None:
         _evaluate(thresholds=_thresholds(generation_target_token_margin=-1))
 
 
+def test_phase1_instruction_retention_is_merge_blocking() -> None:
+    """A judge-acceptance regression beyond the configured drop blocks promotion."""
+    retention = {
+        "comparison": {"delta": {"judge_acceptance_rate": -0.031}},
+    }
+
+    result = _evaluate(retention_evidence=retention)
+
+    assert result["status"] == "fail"
+    assert any(
+        failure["name"] == "max_instruction_judge_accept_rate_drop"
+        for failure in result["failures"]
+    )
+
+
+def test_phase1_absolute_completion_quality_floor() -> None:
+    """A strong baseline delta cannot hide unusable absolute completion quality."""
+    full_metrics = _metrics()
+    full_metrics["metrics"]["model_x"][EXACT_KEY] = 0.79
+    full_evidence = _evidence()
+    full_evidence["model_x"]["metrics"][EXACT_KEY] = 0.79
+
+    result = _evaluate(
+        full_metrics=full_metrics,
+        full_evidence=full_evidence,
+    )
+
+    assert result["status"] == "fail"
+    assert any(
+        failure["name"] == "min_model_json_exact_match_rate"
+        for failure in result["failures"]
+    )
+
+
 def test_phase1_golden_acceptance_config_declares_new_run_report_hard_checks() -> None:
     """The checked-in golden acceptance spec names the new run-report gates."""
     spec = yaml.safe_load(
@@ -605,3 +642,4 @@ def test_phase1_golden_acceptance_config_declares_new_run_report_hard_checks() -
         "optimizer_steps_positive",
         "finite_run_metrics",
     } <= set(spec["hard_checks"])
+    assert spec["thresholds"]["min_model_json_exact_match_rate"] == 0.8

--- a/tests/scripts/test_phase1_inference_gate.py
+++ b/tests/scripts/test_phase1_inference_gate.py
@@ -205,6 +205,7 @@ def test_build_outputs_preserves_full_evidence_by_corpus_for_promotion(
     promotion = evaluate_phase1_promotion(
         thresholds={
             "min_model_json_parse_rate": 1.0,
+            "min_model_json_exact_match_rate": 1.0,
             "min_model_resource_identity_match_rate": 1.0,
             "min_exact_match_delta_vs_foundation": 0.0,
             "max_instruction_judge_accept_rate_drop": 0.0,


### PR DESCRIPTION
## Summary
- prevent whole-root Phase 1 masking and add deterministic inverse repair checks
- cover copy leakage, missing API/action structure, telemetry, and corruption edge cases
- make instruction retention and absolute JSON exact-match quality promotion blockers

## Validation
- GitHub Actions (automatic)
- local project tests intentionally not run; project validation is CI-only